### PR TITLE
add secrets template for github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 #Build and Deployment Tools
 
+## Setting up
+Please ensure to run through the templates and setup your github token secret prior to build

--- a/jenkins/templates/gh-secret.yaml
+++ b/jenkins/templates/gh-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: "true"
+objects:
+- apiVersion: v1
+  data:
+    GITHUB_TOKEN: ${GITHUB_TOKEN}
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: devhub-gh-token
+  type: Opaque
+parameters:
+- description: The github API token
+  displayName: GITHUB_TOKEN
+  required: true
+  
+


### PR DESCRIPTION
devhub now uses a github access token, i'm adding a template to the tools for awareness that the secret is required before building