### PR TITLE
Bug/remark paths

### DIFF
--- a/app-web/__fixtures__/plugin-fixtures.js
+++ b/app-web/__fixtures__/plugin-fixtures.js
@@ -19,12 +19,15 @@ export const SOURCE_DEVHUB_GITHUB_QL_NODE = {
   id: 'd90c1b12-9055-580b-adb3-b29354871657',
   source: 'design-system',
   sourceName: 'Design System',
+  sourcePath: 'https://github.com/bcgov/design-system/',
+  resourcePath: '/design-system/README_123o8123',
   path: 'components/footer/README.md',
   owner: 'bcgov',
+  labels: ['Design System', 'Components'],
   fileName: 'about.md',
   fileType: 'Markdown',
   pagePath: '/design-system/about_G0Z6oO3_3',
-  htmlURL:
+  originalSource:
     'https://github.com/bcgov/design-system/blob/master/components/footer/something/README.md',
   internal: {
     mediaType: 'text/markdown',

--- a/app-web/__tests__/utils/utils.test.js
+++ b/app-web/__tests__/utils/utils.test.js
@@ -1,5 +1,25 @@
 import { groupBy } from '../../src/utils/dataMassager';
+import { SOURCE_DEVHUB_GITHUB_QL_NODE } from '../../__fixtures__/plugin-fixtures';
 import converter from '../../src/utils/gatsby-remark-transform-path';
+
+describe('Gatsby Remark Transformer Path Converter', () => {
+  test('it only transforms sourceDevHubGithub nodes', () => {
+    const path = './something.png';
+    const astType = 'image';
+    const node = {
+      internal: {
+        type: 'notsourceDevhubGithub',
+      },
+    };
+    expect(converter(astType, path, node)).toBe(path);
+  });
+
+  test('it returns path on sourceDevhubGithub nodes', () => {
+    const path = './somthing.png';
+    const astType = 'image';
+    expect(converter(astType, path, SOURCE_DEVHUB_GITHUB_QL_NODE)).not.toBe(path);
+  });
+});
 
 describe('Data Massagers', () => {
   test('it groups data correctly when passed in the right arguments', () => {

--- a/app-web/__tests__/utils/utils.test.js
+++ b/app-web/__tests__/utils/utils.test.js
@@ -1,4 +1,5 @@
 import { groupBy } from '../../src/utils/dataMassager';
+import converter from '../../src/utils/gatsby-remark-transform-path';
 
 describe('Data Massagers', () => {
   test('it groups data correctly when passed in the right arguments', () => {

--- a/app-web/__tests__/utils/utils.test.js
+++ b/app-web/__tests__/utils/utils.test.js
@@ -17,7 +17,9 @@ describe('Gatsby Remark Transformer Path Converter', () => {
   test('it returns path on sourceDevhubGithub nodes', () => {
     const path = './somthing.png';
     const astType = 'image';
-    expect(converter(astType, path, SOURCE_DEVHUB_GITHUB_QL_NODE)).not.toBe(path);
+    const newPath = converter(astType, path, SOURCE_DEVHUB_GITHUB_QL_NODE);
+    expect(typeof newPath).toBe('string');
+    expect(newPath).not.toBe(path);
   });
 });
 

--- a/app-web/src/utils/gatsby-remark-transform-path.js
+++ b/app-web/src/utils/gatsby-remark-transform-path.js
@@ -29,8 +29,8 @@ const { URL } = url;
 const converter = (astType, relativePath, parentQLnode) => {
   // only convert source devhub nodes
   if (parentQLnode.internal.type === 'SourceDevhubGithub') {
-    // parse the htmlURL node of the sourceDevhubGithub
-    const urlObj = new URL(parentQLnode.htmlURL);
+    // parse the originalSource node of the sourceDevhubGithub
+    const urlObj = new URL(parentQLnode.originalSource);
     // check if it has a protocol
     // join the relative path with the directory of the absolute source
     let absolutePath = url.resolve(urlObj.href, relativePath);


### PR DESCRIPTION
remark paths converter callback was failing because of changes to the graphql schema. I fixed it and added unit tests to catch this issue incase of future changes