### PR TITLE
Bug/path to resource

### DIFF
--- a/app-web/__mocks__/shorthash.js
+++ b/app-web/__mocks__/shorthash.js
@@ -1,0 +1,5 @@
+jest.requireActual('shorthash');
+
+module.exports = {
+  unique: string => string,
+};

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -23484,6 +23484,11 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "shorthash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/shorthash/-/shorthash-0.0.2.tgz",
+      "integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs="
+    },
     "shortid": {
       "version": "2.2.13",
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.13.tgz",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -57,6 +57,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "remark": "^10.0.0",
+    "shorthash": "0.0.2",
     "shortid": "^2.2.13",
     "styled-components": "^3.4.10",
     "styled-system": "^1.0.8",

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.itest.js
@@ -1,0 +1,14 @@
+import { createPathWithDigest } from '../utils/helpers';
+jest.unmock('@bcgov/common-web-utils');
+jest.unmock('shorthash');
+const shorthash = require('shorthash');
+describe('createPathWithDigest Integration Tests', () => {
+  it('return path is idempotent', () => {
+    const digestable = 'readme.md';
+    const hash = shorthash.unique(digestable);
+    expect(createPathWithDigest('/path/', digestable)).toBe(`/path/${hash}`);
+    expect(createPathWithDigest('path/', digestable)).toBe(
+      createPathWithDigest('path/', digestable)
+    );
+  });
+});

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.itest.js
@@ -1,12 +1,16 @@
 import { createPathWithDigest } from '../utils/helpers';
 jest.unmock('@bcgov/common-web-utils');
 jest.unmock('shorthash');
+
 const shorthash = require('shorthash');
+
 describe('createPathWithDigest Integration Tests', () => {
   it('return path is idempotent', () => {
     const digestable = 'readme.md';
     const hash = shorthash.unique(digestable);
+
     expect(createPathWithDigest('/path/', digestable)).toBe(`/path/${hash}`);
+
     expect(createPathWithDigest('path/', digestable)).toBe(
       createPathWithDigest('path/', digestable)
     );

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -5,13 +5,17 @@ describe('createPathWithDigest', () => {
     expect(() => createPathWithDigest(9, '123')).toThrow('base must be a string');
   });
 
-  it('throws if digestable is not a string', () => {
+  it('throws if digestables is not a string', () => {
     expect(() => createPathWithDigest('path', 123)).toThrow('digestable must be a string');
+    expect(() => createPathWithDigest('path', '123', 123)).toThrow('digestable must be a string');
   });
 
   it('returns a normalized path', () => {
     expect(createPathWithDigest('/path/', 'readme.md')).toBe('/path/readme.md');
     expect(createPathWithDigest('path/', 'readme.md')).toBe('/path/readme.md');
     expect(createPathWithDigest('path', 'readme.md')).toBe('/path/readme.md');
+    expect(createPathWithDigest('/path/', 'source', 'readme.md')).toBe('/path/sourcereadme.md');
+    expect(createPathWithDigest('path/', 'source', 'readme.md')).toBe('/path/sourcereadme.md');
+    expect(createPathWithDigest('path', 'source', 'readme.md')).toBe('/path/sourcereadme.md');
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -1,5 +1,6 @@
 import { createPathWithDigest } from '../utils/helpers';
 describe('createPathWithDigest', () => {
+
   it('throws if base is not a string', () => {
     expect(() => createPathWithDigest(9, '123')).toThrow('base must be a string');
   });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -1,0 +1,16 @@
+import { createPathWithDigest } from '../utils/helpers';
+describe('createPathWithDigest', () => {
+  it('throws if base is not a string', () => {
+    expect(() => createPathWithDigest(9, '123')).toThrow('base must be a string');
+  });
+
+  it('throws if digestable is not a string', () => {
+    expect(() => createPathWithDigest('path', 123)).toThrow('digestable must be a string');
+  });
+
+  it('returns a normalized path', () => {
+    expect(createPathWithDigest('/path/', 'readme.md')).toBe('/path/readme.md');
+    expect(createPathWithDigest('path/', 'readme.md')).toBe('/path/readme.md');
+    expect(createPathWithDigest('path', 'readme.md')).toBe('/path/readme.md');
+  });
+});

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
@@ -53,6 +53,6 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
     const transformedFile = fileTransformer(PROCESSED_FILE_MD.metadata.extension, PROCESSED_FILE_MD)
       .use(markdownPagePathPlugin)
       .resolve();
-    expect(transformedFile.metadata.resourcePath).toBe(`/${source}/${name}_0`);
+    expect(transformedFile.metadata.resourcePath).toBe(`/${source}/${source}${name}`);
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
@@ -53,6 +53,8 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
     const transformedFile = fileTransformer(PROCESSED_FILE_MD.metadata.extension, PROCESSED_FILE_MD)
       .use(markdownPagePathPlugin)
       .resolve();
-    expect(transformedFile.metadata.resourcePath).toBe(`/${source}/${source}${name}`);
+    expect(transformedFile.metadata.resourcePath).toBe(
+      `/${source}/${source}${name}https:/github.com/bcgov/design-system/blob/master/components/header/README.md`
+    );
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -21,11 +21,11 @@ Created by Patrick Simonian
  * @param  {Array} digestable 
  * @returns {String} ie (/mypath, file.md) => /mypath/123dsfakjhdf
  */
-import { TypeCheck } from '@bcgov/common-web-utils';
-import path from 'path';
-import shorthash from 'shorthash';
+const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
+const path = require('path');
+const shorthash = require('shorthash');
 
-export const createPathWithDigest = (base, digestable) => {
+const createPathWithDigest = (base, digestable) => {
   if (!TypeCheck.isString(base)) {
     throw new Error('base must be a string');
   }
@@ -35,4 +35,8 @@ export const createPathWithDigest = (base, digestable) => {
   const normalizedBase = base.replace(/^\//, '').replace(/\/$/, '');
   const digested = shorthash.unique(digestable);
   return path.join('/', normalizedBase, digested);
+};
+
+module.exports = {
+  createPathWithDigest,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -17,8 +17,8 @@ Created by Patrick Simonian
 */
 /**
  * returns an idempotent path based on a base path plus a digestable string that is hashed
- * @param {String} source the string name of the original source
- * @param  {Array} digestable 
+ * @param {String} base the base path (which is not changed)
+ * @param  {...String} digestables comma seperated list of strings which are dsigested by shorthash 
  * @returns {String} ie (/mypath, file.md) => /mypath/123dsfakjhdf
  */
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -29,11 +29,14 @@ const createPathWithDigest = (base, digestable) => {
   if (!TypeCheck.isString(base)) {
     throw new Error('base must be a string');
   }
+
   if (!TypeCheck.isString(digestable)) {
     throw new Error('digestable must be a string');
   }
+
   const normalizedBase = base.replace(/^\//, '').replace(/\/$/, '');
   const digested = shorthash.unique(digestable);
+
   return path.join('/', normalizedBase, digested);
 };
 

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+/**
+ * returns an idempotent path based on a base path plus a digestable string that is hashed
+ * @param {String} source the string name of the original source
+ * @param  {Array} digestable 
+ * @returns {String} ie (/mypath, file.md) => /mypath/123dsfakjhdf
+ */
+import { TypeCheck } from '@bcgov/common-web-utils';
+import path from 'path';
+import shorthash from 'shorthash';
+
+export const createPathWithDigest = (base, digestable) => {
+  if (!TypeCheck.isString(base)) {
+    throw new Error('base must be a string');
+  }
+  if (!TypeCheck.isString(digestable)) {
+    throw new Error('digestable must be a string');
+  }
+  const normalizedBase = base.replace(/^\//, '').replace(/\/$/, '');
+  const digested = shorthash.unique(digestable);
+  return path.join('/', normalizedBase, digested);
+};

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -25,17 +25,16 @@ const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
 const path = require('path');
 const shorthash = require('shorthash');
 
-const createPathWithDigest = (base, digestable) => {
+const createPathWithDigest = (base, ...digestables) => {
   if (!TypeCheck.isString(base)) {
     throw new Error('base must be a string');
   }
-
-  if (!TypeCheck.isString(digestable)) {
+  if (!digestables.every(TypeCheck.isString)) {
     throw new Error('digestable must be a string');
   }
 
   const normalizedBase = base.replace(/^\//, '').replace(/\/$/, '');
-  const digested = shorthash.unique(digestable);
+  const digested = shorthash.unique(digestables.join(''));
 
   return path.join('/', normalizedBase, digested);
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -19,6 +19,7 @@ const shortid = require('shortid'); // eslint-disable-line
 const matter = require('gray-matter'); // eslint-disable-line
 const visit = require('unist-util-visit'); // eslint-disable-line
 const remark = require('remark'); // eslint-disable-line
+const crypto = require('crypto'); // eslint-disable-line
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
 const { MARKDOWN_FRONTMATTER_SCHEMA } = require('./constants');
 /**

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -98,7 +98,8 @@ const markdownPagePathPlugin = (extension, file) => {
     // the page page is composed of the source name, the title of the file plus an id
     file.metadata.resourcePath = createPathWithDigest(
       file.metadata.source,
-      file.metadata.source + file.metadata.name
+      file.metadata.source,
+      file.metadata.name
     );
   }
 

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -99,7 +99,8 @@ const markdownPagePathPlugin = (extension, file) => {
     file.metadata.resourcePath = createPathWithDigest(
       file.metadata.source,
       file.metadata.source,
-      file.metadata.name
+      file.metadata.name,
+      file.html_url
     );
   }
 

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -19,8 +19,8 @@ const shortid = require('shortid'); // eslint-disable-line
 const matter = require('gray-matter'); // eslint-disable-line
 const visit = require('unist-util-visit'); // eslint-disable-line
 const remark = require('remark'); // eslint-disable-line
-const crypto = require('crypto'); // eslint-disable-line
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
+const { createPathWithDigest } = require('./helpers'); // eslint-disable-line
 const { MARKDOWN_FRONTMATTER_SCHEMA } = require('./constants');
 /**
  * applys default front matter properties
@@ -96,8 +96,10 @@ const markdownPagePathPlugin = (extension, file) => {
   } else {
     // no resource path, this file is destined to be turned into a page,
     // the page page is composed of the source name, the title of the file plus an id
-    file.metadata.resourcePath = `/${file.metadata.source}/${file.metadata
-      .name}_${shortid.generate()}`;
+    file.metadata.resourcePath = createPathWithDigest(
+      file.metadata.source,
+      file.metadata.source + file.metadata.name
+    );
   }
 
   return file;


### PR DESCRIPTION
## Issue
Resource Paths were unstable and changed values between builds. 
## Affects
For users, bookmarks to resources would break after a new build.

## Solution
paths to resources are now stable. They do not change values between builds.
For example:
Siphon sources `footer.md` from the repo `design-system`

Originally the resource path would `/design-system/footer_[random string]`

**Now** a hash is generated from `source + filename // ie 'design-system' + 'footer.md'` so the resource path becomes
`/design-system/[stable-unchanging-hash]`

## 
