### PR TITLE
Increase replica count to 2 for dev hub static web pod.

### DIFF
--- a/openshift/dc.yaml
+++ b/openshift/dc.yaml
@@ -20,7 +20,7 @@ objects:
     creationTimestamp: null
     name: ${NAME}-static${SUFFIX}
   spec:
-    replicas: 1
+    replicas: 2
     selector:
       deploymentconfig: ${NAME}-static${SUFFIX}
     strategy:


### PR DESCRIPTION
Just updating the number of replicas so we are sure to survive maintenance with no blips.