### PR TITLE
Update pipeline lib to v0.0.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ pipeline {
   }
 
   environment {
-    OCP_PIPELINE_CLI_URL = 'https://raw.githubusercontent.com/BCDevOps/ocp-cd-pipeline/v0.0.4/src/main/resources/pipeline-cli'
-    OCP_PIPELINE_VERSION = '0.0.4'
+    OCP_PIPELINE_CLI_URL = 'https://raw.githubusercontent.com/BCDevOps/ocp-cd-pipeline/v0.0.5/src/main/resources/pipeline-cli'
+    OCP_PIPELINE_VERSION = '0.0.5'
   }
   stages {
     stage('Build') {


### PR DESCRIPTION
- Tagging workaround
- Preserve highest number of replicas between new and current DC