### PR TITLE
Imp/siphon node changes

### DIFF
--- a/app-web/__fixtures__/plugin-fixtures.js
+++ b/app-web/__fixtures__/plugin-fixtures.js
@@ -20,6 +20,10 @@ export const SIPHON_QL_NODE = {
   source: 'design-system',
   sourceName: 'Design System',
   sourcePath: 'https://github.com/bcgov/design-system/',
+  resource: {
+    originalSource:
+    'https://github.com/bcgov/design-system/blob/master/components/footer/something/README.md',
+  },
   resourcePath: '/design-system/README_123o8123',
   path: 'components/footer/README.md',
   owner: 'bcgov',
@@ -27,8 +31,6 @@ export const SIPHON_QL_NODE = {
   fileName: 'about.md',
   fileType: 'Markdown',
   pagePath: '/design-system/about_G0Z6oO3_3',
-  originalSource:
-    'https://github.com/bcgov/design-system/blob/master/components/footer/something/README.md',
   internal: {
     mediaType: 'text/markdown',
     type: 'DevhubSiphon',

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -69,6 +69,8 @@ describe('gatsby source github all plugin', () => {
         mediaType: 'application/test',
         extension: '.md',
         labels: 'component',
+        originalResourceLocation:
+          'https://github.com/awesomeOrg/awesomeRepo/blob/master/public/manifest.json',
       },
       name: 'test',
       path: '/test.md',
@@ -99,7 +101,6 @@ describe('gatsby source github all plugin', () => {
       parent: null,
       path: '/test.md',
       labels: 'component',
-      originalSource: 'https://github.com/awesomeOrg/awesomeRepo/blob/master/public/manifest.json',
       source: {
         name: 'something/something',
         displayName: 'something',
@@ -108,6 +109,8 @@ describe('gatsby source github all plugin', () => {
       },
       unfurl: undefined,
       resource: {
+        originalSource:
+          'https://github.com/awesomeOrg/awesomeRepo/blob/master/public/manifest.json',
         type: undefined,
         path: undefined,
       },

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -32,7 +32,6 @@ const createSiphonNode = (data, id) => ({
   parent: null,
   path: data.path,
   unfurl: data.metadata.unfurl, // normalized unfurled content from various sources https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254
-  originalSource: data.html_url, // original path to the data
   source: {
     name: data.metadata.source, // the source-name
     displayName: data.metadata.sourceName, // the pretty name of the 'source'
@@ -42,6 +41,7 @@ const createSiphonNode = (data, id) => ({
   resource: {
     path: data.metadata.resourcePath, // either path to a gastby created page based on this node
     type: data.metadata.resourceType, // the base resource type for this see utils/constants.js
+    originalSource: data.metadata.originalResourceLocation, // the original location of the resource
   },
   labels: data.metadata.labels, // labels from source registry
   internal: {

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -194,7 +194,8 @@ const applyBaseMetadata = (
   sourceName,
   sourceURL,
   sourceType,
-  globalResourceType
+  globalResourceType,
+  originalResourceLocation
 ) => {
   const extension = getExtensionFromName(file.name);
   return {
@@ -213,6 +214,7 @@ const applyBaseMetadata = (
       sourceURL,
       sourceType,
       globalResourceType,
+      originalResourceLocation,
     },
   };
 };
@@ -272,7 +274,9 @@ const getFilesFromRepo = async ({sourceType, resourceType, name, sourcePropertie
     // also adding some additional params
     const processedFiles = filesResponse
       .filter(f => f !== undefined) // filter out any files that weren't fetched
-      .map(f => applyBaseMetadata(f, labels, owner, repo, name, url, sourceType, resourceType))
+      .map(f =>
+        applyBaseMetadata(f, labels, owner, repo, name, url, sourceType, resourceType, f.html_url)
+      )
       .map(f => {
         const ft = fileTransformer(f.metadata.extension, f);
         return ft

--- a/app-web/src/templates/SourceHTML.js
+++ b/app-web/src/templates/SourceHTML.js
@@ -40,7 +40,9 @@ export const devhubSiphonHTML = graphql`
       internal {
         content
       }
-      originalSource
+      resource {
+        originalSource
+      }
       source {
         name
         displayName

--- a/app-web/src/templates/SourceMarkdown.js
+++ b/app-web/src/templates/SourceMarkdown.js
@@ -49,7 +49,9 @@ export const devhubSiphonMarkdown = graphql`
         sourcePath
         type
       }
-      originalSource
+      resource {
+        originalSource
+      }
       owner
       fileName
       fileType

--- a/app-web/src/utils/gatsby-remark-transform-path.js
+++ b/app-web/src/utils/gatsby-remark-transform-path.js
@@ -31,7 +31,7 @@ const converter = (astType, relativePath, parentQLnode) => {
   // only convert source devhub nodes
   if (parentQLnode.internal.type === GRAPHQL_NODE_TYPE) {
     // parse the originalSource node of the sourceDevhubGithub
-    const urlObj = new URL(parentQLnode.originalSource);
+    const urlObj = new URL(parentQLnode.resource.originalSource);
     // check if it has a protocol
     // join the relative path with the directory of the absolute source
     let absolutePath = url.resolve(urlObj.href, relativePath);


### PR DESCRIPTION
# About
there was still one property into the siphon graphql node that was strictly tied to the github api. 
Since the Github API and it's sourcing mechanism (fetchSourceGithub) had been abstracted away as a *type of* source, the property `originalSource` in the graphql schema should be abstracted away as well.

# Changes
- reference to html_url in the siphon graphql node's `originalSource` was abstracted away
- page queries that references original Source were changed to reflect the abstracttion 