### PR TITLE
prevent build from failing if descriptions are missing in front matter

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -125,6 +125,26 @@ const GITHUB_API = {
       html: 'https://github.com/bcgov/range-web/blob/master/public/manifest.json',
     },
   },
+  BAD_MD_FILE: { // no description front matter (which is required)
+    name: 'badfile.md',
+    path: 'public/badfile.md',
+    sha: 'ef19ec243e739479802a5553d0b38a18ed845307',
+    size: 317,
+    url: 'https://api.github.com/repos/bcgov/range-web/contents/public/badfile.md?ref=master',
+    html_url: 'https://github.com/bcgov/range-web/blob/master/public/badfile.md',
+    git_url:
+      'https://api.github.com/repos/bcgov/range-web/git/blobs/ef19ec243e739479802a5553d0b38a18ed845307',
+    download_url: 'https://raw.githubusercontent.com/bcgov/range-web/master/public/badfile.md',
+    type: 'file',
+    content: '---\ntitle: yoyoyo\n---\n# markdown',
+    encoding: 'base64',
+    _links: {
+      self: 'https://api.github.com/repos/bcgov/range-web/contents/public/badfile.md?ref=master',
+      git:
+        'https://api.github.com/repos/bcgov/range-web/git/blobs/ef19ec243e739479802a5553d0b38a18ed845307',
+      html: 'https://github.com/bcgov/range-web/blob/master/public/badfile.md',
+    },
+  },
   FAIL: {
     message: 'Not Found',
     documentation_url: 'https://developer.github.com/v3',

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
@@ -6,7 +6,7 @@ const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch');
 // mock console logs so that any error logs are not outputed during suite
 global.console = {
-  log: jest.fn(),
+  log: console.log,
   warn: jest.fn(),
   error: jest.fn(),
 };
@@ -61,5 +61,19 @@ describe('Integration github api module', () => {
     } catch (e) {
       expect(e.message).toBe('Fetch Failed');
     }
+  });
+
+  it('returns files if configurations are bad', async () => {
+    fetch
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.TREE)))) // first for getting tree
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.BAD_MD_FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.BAD_MD_FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))));
+
+    const files = await getFilesFromRepo(GITHUB_SOURCE);
+    // console.log(files);
+    expect(files).toBeInstanceOf(Array);
+    expect(files.length).toBe(1);
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -280,15 +280,22 @@ const getFilesFromRepo = async ({sourceType, resourceType, name, sourcePropertie
       )
       .map(async f => {
         const ft = fileTransformer(f.metadata.extension, f);
-        return await ft
-          .use(markdownFrontmatterPlugin)
-          .use(pagePathPlugin)
-          .use(markdownUnfurlPlugin)
-          .use(markdownResourceTypePlugin)
-          .resolve();
+        try {
+          return await ft
+            .use(markdownFrontmatterPlugin)
+            .use(pagePathPlugin)
+            .use(markdownUnfurlPlugin)
+            .use(markdownResourceTypePlugin)
+            .resolve();
+        } catch (e) {
+          // return undefined and skip file
+          // at this point we could apply a hook to post a gh issue if needed
+          return undefined;
+        }
       });
-
-    return await Promise.all(processedFiles);
+    const postProcessedFiles = await Promise.all(processedFiles);
+    // any promises that return undefined are filtered out
+    return postProcessedFiles.filter(f => f !== undefined);
   } catch (e) {
     console.error(e);
     // eslint-disable-next-line


### PR DESCRIPTION
# About
Before this PR, if a markdown file had a `required` front matter property that was not being included