### PR TITLE
Integrate external link unfurling

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -286,6 +286,7 @@ const getFilesFromRepo = async ({sourceType, resourceType, name, sourcePropertie
             .use(pagePathPlugin)
             .use(markdownUnfurlPlugin)
             .use(markdownResourceTypePlugin)
+            .use(externalLinkUnfurlPlugin)
             .resolve();
         } catch (e) {
           // return undefined and skip file

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -186,7 +186,7 @@ const markdownResourceTypePlugin = (extension, file) => {
 const externalLinkUnfurlPlugin = async (extension, file) => {
   // does file have a resource path and is it a valid url?
   if (file.metadata.resourcePath && validUrl.isUri(file.metadata.resourcePath)) {
-    const { body: html, url } = await got(file.resourcePath);
+    const { body: html, url } = await got(file.metadata.resourcePath);
     const metadata = await metascraper({ html, url });
     file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, metadata);
   }


### PR DESCRIPTION
# About
Any siphon nodes that have an external resourcePath are now unfurled

# Changes
- integrated externalUnfurlPlugin
- fixed an issue preventing unfurling