### PR TITLE
Add dynamic page create to gatsby configurations

### DIFF
--- a/app-web/gatsby-node.js
+++ b/app-web/gatsby-node.js
@@ -1,32 +1,23 @@
-const autoprefixer = require('autoprefixer');
+/*
+Copyright 2018 Province of British Columbia
 
-exports.modifyWebpackConfig = ({ config, env }) => {
-  // switch allows to change config based on environment
-  // eslint-disable-next-line
-  switch (env) {
-    case 'develop':
-      config.preLoader('eslint-loader', {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-      });
-      config.merge({
-        postcss: [
-          require('postcss-flexbugs-fixes'), // eslint-disable-line
-          autoprefixer({
-            browsers: [
-              '>1%',
-              'last 4 versions',
-              'Firefox ESR',
-              'not ie < 9', // React doesn't support IE8 anyway
-            ],
-            flexbox: 'no-2009',
-          }),
-        ],
-      });
-      break;
-  }
-  return config;
-};
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
 
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+
+// gatsby event hooks
+// https://www.gatsbyjs.org/docs/node-apis/
+exports.modifyWebpackConfig = require('./gatsby/modifyWebpackConfig');
 exports.onCreatePage = require('./gatsby/onCreatePage');
 exports.createPages = require('./gatsby/createPages');

--- a/app-web/gatsby-node.js
+++ b/app-web/gatsby-node.js
@@ -28,4 +28,5 @@ exports.modifyWebpackConfig = ({ config, env }) => {
   return config;
 };
 
+exports.onCreatePage = require('./gatsby/onCreatePage');
 exports.createPages = require('./gatsby/createPages');

--- a/app-web/gatsby/modifyWebpackConfig.js
+++ b/app-web/gatsby/modifyWebpackConfig.js
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+const autoprefixer = require('autoprefixer');
+
+module.exports = ({ config, env }) => {
+  // switch allows to change config based on environment
+  switch (env) {
+    case 'develop':
+      config.preLoader('eslint-loader', {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+      });
+      config.merge({
+        postcss: [
+            require('postcss-flexbugs-fixes'), // eslint-disable-line
+          autoprefixer({
+            browsers: [
+              '>1%',
+              'last 4 versions',
+              'Firefox ESR',
+              'not ie < 9', // React doesn't support IE8 anyway
+            ],
+            flexbox: 'no-2009',
+          }),
+        ],
+      });
+      break;
+    default:
+      return config;
+  }
+  return config;
+};

--- a/app-web/gatsby/onCreatePage.js
+++ b/app-web/gatsby/onCreatePage.js
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+
+// const { FILTER_BASE_ROUTE } = require('../src/constants/routes');
+// the above declaration is to identify the actual constants where FILTER_BASE_ROUTES
+// should be coming from. At this time, there is no babel transpilation of this file or gatsby-node
+// and so requiring from an es6+ file (such as src/constants/routes) will fail.
+// until the time this issue is resolved, are declaring the filter base route here in the interim.
+const FILTER_BASE_ROUTE = '/resources';
+
+module.exports = async ({ page, boundActionCreators }) => {
+  const { createPage } = boundActionCreators;
+  const re = new RegExp(`^${FILTER_BASE_ROUTE}`);
+  // check if page that's being created matches the filter base routes
+  // which is intended for client side loading only
+  // https://github.com/gatsbyjs/gatsby/blob/v1/docs/docs/building-apps-with-gatsby.md#client-only-routes--user-authentication
+  if (page.path.match(re)) {
+    page.matchPath = `${FILTER_BASE_ROUTE}/:resource`;
+    createPage(page);
+  }
+};

--- a/app-web/gatsby/onCreatePage.js
+++ b/app-web/gatsby/onCreatePage.js
@@ -17,10 +17,10 @@ Created by Patrick Simonian
 */
 
 // const { FILTER_BASE_ROUTE } = require('../src/constants/routes');
-// the above declaration is to identify the actual constants where FILTER_BASE_ROUTES
-// should be coming from. At this time, there is no babel transpilation of this file or gatsby-node
+// the above declaration is to identify the actual constants where FILTER_BASE_ROUTE
+// should be coming from. At this time, there is no babel transpilation of this file or gatsby-node.js
 // and so requiring from an es6+ file (such as src/constants/routes) will fail.
-// until the time this issue is resolved, are declaring the filter base route here in the interim.
+// until the time this issue is resolved, we are declaring the filter base route here in the interim.
 const FILTER_BASE_ROUTE = '/resources';
 
 module.exports = async ({ page, boundActionCreators }) => {

--- a/app-web/gatsby/onCreatePage.js
+++ b/app-web/gatsby/onCreatePage.js
@@ -30,7 +30,7 @@ module.exports = async ({ page, boundActionCreators }) => {
   // which is intended for client side loading only
   // https://github.com/gatsbyjs/gatsby/blob/v1/docs/docs/building-apps-with-gatsby.md#client-only-routes--user-authentication
   if (page.path.match(re)) {
-    page.matchPath = `${FILTER_BASE_ROUTE}/:resource`;
+    page.matchPath = `${FILTER_BASE_ROUTE}/:resource_type`;
     createPage(page);
   }
 };

--- a/app-web/src/constants/routes.js
+++ b/app-web/src/constants/routes.js
@@ -1,2 +1,10 @@
 export const HOME_ROUTE = '/';
 export const GITHUB_ISSUES_ROUTE = 'https://github.com/bcgov/devhub-app-web/issues';
+// used in createPages.js as well as for generating anchor tags based on the different resource
+// types
+export const FILTER_BASE_ROUTE = '/resources';
+export const DOCUMENTS_ROUTE = `${FILTER_BASE_ROUTE}/documents`;
+export const SELF_SERVICE_ROUTE = `${FILTER_BASE_ROUTE}/self-service`;
+export const COMPONENTS_ROUTE = `${FILTER_BASE_ROUTE}/components`;
+export const PROJECTS_ROUTE = `${FILTER_BASE_ROUTE}/projects`;
+export const PEOPLE_ROUTE = `${FILTER_BASE_ROUTE}/people`;


### PR DESCRIPTION
**Please note** these changes are very specific to gatsby v1 and ***will*** break on upgrade to gatsby v2
# About
Another step in the dynamic filtering feature. Filtering will be done via 'restful routes'. 
IE navigating to `/resources/components` will just re render the index page to show only cards that are `resourceType === 'components'`

During the navigation process, gatsby will actually look for a static site at the path `/resources/components`. The following changes tells gatsby to treat this route as dynamic and client side rendered only. 

# Changes
- added a hook for `onCreatePage` to treat any routes `/resources/*` as client side rendered
- did some code cleanup in the `gatsby-node.js`
