### PR TITLE
Github Link in markdown template pages not working fix

### DIFF
--- a/app-web/src/hoc/TemplateLayout.js
+++ b/app-web/src/hoc/TemplateLayout.js
@@ -21,7 +21,7 @@ const TemplateLayout = ({ siphonData, nav, pathname, children }) => {
             <h1>{siphonData.sourceName}</h1>
             <ul className={styles.SourceTags}>
               <li>
-                <a href={siphonData.originalSource}>
+                <a href={siphonData.resource.originalSource}>
                   <FontAwesomeIcon
                     icon={faGithub}
                     aria-label={`View the original source ${siphonData.fileName} on github`}

--- a/app-web/src/hoc/TemplateLayout.js
+++ b/app-web/src/hoc/TemplateLayout.js
@@ -32,7 +32,7 @@ const TemplateLayout = ({ siphonData, nav, pathname, children }) => {
                 <a href={`${siphonData.source.sourcePath}fork`}>
                   <FontAwesomeIcon
                     icon={faCodeBranch}
-                    aria-label={`Fork ${siphonData.sourceName} on github`}
+                    aria-label={`Fork ${siphonData.source.name} on github`}
                   />
                 </a>
               </li>
@@ -48,7 +48,15 @@ const TemplateLayout = ({ siphonData, nav, pathname, children }) => {
 
 TemplateLayout.propTypes = {
   children: PropTypes.node.isRequired,
-  siphonData: PropTypes.object.isRequired,
+  siphonData: PropTypes.shape({
+    source: PropTypes.shape({
+      sourcePath: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+    resource: PropTypes.shape({
+      originalSource: PropTypes.string.isRequired,
+    }),
+  }),
   nav: PropTypes.object.isRequired,
   pathname: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
Caused by a change to the graphql siphon schema.
Updated propTypes to prevent this issue from happening again.