### PR TITLE
add auto link headers

### DIFF
--- a/app-web/gatsby-config.js
+++ b/app-web/gatsby-config.js
@@ -77,6 +77,7 @@ module.exports = {
       resolve: 'gatsby-transformer-remark',
       options: {
         plugins: [
+          'gatsby-remark-autolink-headers',
           {
             resolve: 'gatsby-remark-prismjs',
             options: {

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -8675,6 +8675,17 @@
         "warning": "^3.0.0"
       }
     },
+    "gatsby-remark-autolink-headers": {
+      "version": "1.4.19",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-1.4.19.tgz",
+      "integrity": "sha1-hEF94vxvvpkUIZmZrg4mFvyceaI=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "github-slugger": "^1.1.1",
+        "mdast-util-to-string": "^1.0.2",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "gatsby-remark-images": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-2.0.5.tgz",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -32,6 +32,7 @@
     "gatsby-plugin-react-next": "^1.0.4",
     "gatsby-plugin-sharp": "^1.6.9",
     "gatsby-plugin-styled-components": "^3.0.0",
+    "gatsby-remark-autolink-headers": "^1.4.19",
     "gatsby-remark-images": "^2.0.5",
     "gatsby-remark-prismjs": "^3.0.2",
     "gatsby-source-filesystem": "^1.5.5",


### PR DESCRIPTION
# About
Internal Navigation for a md document wasn't working in devhub

## Changes
- this has been fixed by adding the auto link headers transformer plugin

*** IMPORTANT ***
The version of the npm auto link headers package has been purposely set to `1.4.19` as that is the last stable version that is compatible with Gatsby V1, in reality this plugin is already in 2.x.x and so we will need to upgrade this when we upgrade our app the Gatsby V2
