### PR TITLE
Bug/broken images in md v2

### DIFF
--- a/app-web/__mocks__/unist-util-visit.js
+++ b/app-web/__mocks__/unist-util-visit.js
@@ -1,4 +1,6 @@
 jest.requireActual('unist-util-visit');
 module.exports = (ast, node, cb) => {
-  cb(ast);
+  if (ast.type === node) {
+    cb(ast);
+  }
 };

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -3455,37 +3455,16 @@
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "cheerio": {
-<<<<<<< HEAD
-      "version": "0.22.0",
-      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
-=======
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
->>>>>>> update package-lock
       "requires": {
         "css-select": "~1.2.0",
         "dom-serializer": "~0.1.0",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
-<<<<<<< HEAD
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
-=======
         "lodash": "^4.15.0",
         "parse5": "^3.0.1"
->>>>>>> update package-lock
       },
       "dependencies": {
         "domhandler": {
@@ -3497,24 +3476,15 @@
           }
         },
         "htmlparser2": {
-<<<<<<< HEAD
-          "version": "3.9.2",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-=======
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
           "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
->>>>>>> update package-lock
           "requires": {
             "domelementtype": "^1.3.0",
             "domhandler": "^2.3.0",
             "domutils": "^1.5.1",
             "entities": "^1.1.1",
             "inherits": "^2.0.1",
-<<<<<<< HEAD
-            "readable-stream": "^2.0.2"
-=======
             "readable-stream": "^3.0.6"
           }
         },
@@ -3534,7 +3504,6 @@
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
->>>>>>> update package-lock
           }
         }
       }
@@ -8714,7 +8683,6 @@
         "warning": "^3.0.0"
       }
     },
-<<<<<<< HEAD
     "gatsby-remark-autolink-headers": {
       "version": "1.4.19",
       "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-1.4.19.tgz",
@@ -8726,8 +8694,6 @@
         "unist-util-visit": "^1.1.1"
       }
     },
-=======
->>>>>>> update package-lock
     "gatsby-remark-images": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-2.0.5.tgz",
@@ -22274,7 +22240,6 @@
         "react": "15"
       }
     },
-<<<<<<< HEAD
     "react-dotdotdot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/react-dotdotdot/-/react-dotdotdot-1.2.3.tgz",
@@ -22283,8 +22248,6 @@
         "object.pick": "^1.3.0"
       }
     },
-=======
->>>>>>> update package-lock
     "react-emotion": {
       "version": "8.0.12",
       "resolved": "https://registry.npmjs.org/react-emotion/-/react-emotion-8.0.12.tgz",
@@ -24779,8 +24742,6 @@
         "webpack-sources": "^0.2.0"
       },
       "dependencies": {
-<<<<<<< HEAD
-=======
         "cheerio": {
           "version": "0.22.0",
           "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
@@ -24835,7 +24796,6 @@
             "util-deprecate": "^1.0.1"
           }
         },
->>>>>>> update package-lock
         "source-list-map": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -3455,14 +3455,21 @@
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "cheerio": {
+<<<<<<< HEAD
       "version": "0.22.0",
       "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+=======
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+>>>>>>> update package-lock
       "requires": {
         "css-select": "~1.2.0",
         "dom-serializer": "~0.1.0",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
+<<<<<<< HEAD
         "lodash.assignin": "^4.0.9",
         "lodash.bind": "^4.1.4",
         "lodash.defaults": "^4.0.1",
@@ -3475,6 +3482,10 @@
         "lodash.reduce": "^4.4.0",
         "lodash.reject": "^4.4.0",
         "lodash.some": "^4.4.0"
+=======
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+>>>>>>> update package-lock
       },
       "dependencies": {
         "domhandler": {
@@ -3486,16 +3497,44 @@
           }
         },
         "htmlparser2": {
+<<<<<<< HEAD
           "version": "3.9.2",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+=======
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+>>>>>>> update package-lock
           "requires": {
             "domelementtype": "^1.3.0",
             "domhandler": "^2.3.0",
             "domutils": "^1.5.1",
             "entities": "^1.1.1",
             "inherits": "^2.0.1",
+<<<<<<< HEAD
             "readable-stream": "^2.0.2"
+=======
+            "readable-stream": "^3.0.6"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+>>>>>>> update package-lock
           }
         }
       }
@@ -8675,6 +8714,7 @@
         "warning": "^3.0.0"
       }
     },
+<<<<<<< HEAD
     "gatsby-remark-autolink-headers": {
       "version": "1.4.19",
       "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-1.4.19.tgz",
@@ -8686,6 +8726,8 @@
         "unist-util-visit": "^1.1.1"
       }
     },
+=======
+>>>>>>> update package-lock
     "gatsby-remark-images": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-2.0.5.tgz",
@@ -22232,6 +22274,7 @@
         "react": "15"
       }
     },
+<<<<<<< HEAD
     "react-dotdotdot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/react-dotdotdot/-/react-dotdotdot-1.2.3.tgz",
@@ -22240,6 +22283,8 @@
         "object.pick": "^1.3.0"
       }
     },
+=======
+>>>>>>> update package-lock
     "react-emotion": {
       "version": "8.0.12",
       "resolved": "https://registry.npmjs.org/react-emotion/-/react-emotion-8.0.12.tgz",
@@ -24734,6 +24779,63 @@
         "webpack-sources": "^0.2.0"
       },
       "dependencies": {
+<<<<<<< HEAD
+=======
+        "cheerio": {
+          "version": "0.22.0",
+          "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+          "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+          "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "^3.9.1",
+            "lodash.assignin": "^4.0.9",
+            "lodash.bind": "^4.1.4",
+            "lodash.defaults": "^4.0.1",
+            "lodash.filter": "^4.4.0",
+            "lodash.flatten": "^4.2.0",
+            "lodash.foreach": "^4.3.0",
+            "lodash.map": "^4.4.0",
+            "lodash.merge": "^4.4.0",
+            "lodash.pick": "^4.2.1",
+            "lodash.reduce": "^4.4.0",
+            "lodash.reject": "^4.4.0",
+            "lodash.some": "^4.4.0"
+          }
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+>>>>>>> update package-lock
         "source-list-map": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -12,6 +12,7 @@
     "autoprefixer": "^9.1.5",
     "babel-plugin-styled-components": "^1.8.0",
     "chalk": "^2.4.1",
+    "cheerio": "^1.0.0-rc.2",
     "clone": "^2.1.2",
     "dot-prop-immutable": "^1.5.0",
     "dotenv": "^6.0.0",

--- a/app-web/plugins/gatsby-remark-path-transform/__tests__/utils.test.js
+++ b/app-web/plugins/gatsby-remark-path-transform/__tests__/utils.test.js
@@ -59,8 +59,6 @@ describe('gatsby-remark-path-transform', () => {
       transformRelativePaths({ getNode, markdownAST, markdownNode }, { converter });
 
       expect(converter).toHaveBeenCalledWith('image', oldURL, GRAPH_QL_PARENT_NODE);
-      expect(converter).toHaveBeenLastCalledWith('link', markdownAST.url, GRAPH_QL_PARENT_NODE);
-      expect(converter).toHaveBeenCalledTimes(2);
       // expect url to hvae been changed
       expect(oldURL).not.toBe(markdownAST.url);
     });

--- a/app-web/plugins/gatsby-remark-path-transform/index.js
+++ b/app-web/plugins/gatsby-remark-path-transform/index.js
@@ -57,7 +57,7 @@ const transformRelativePaths = ({ markdownAST, markdownNode, getNode }, { conver
   const imageVisitedCB = visitCB(IMAGE, parentQLNode);
   const linkVisitedCB = visitCB(LINK, parentQLNode);
 
-  // visit any html nodes and ensure and check for stand alone img tags
+  // visit any html nodes and ensure and check for stand alone image tags
   visit(markdownAST, 'html', node => {
     const $ = cheerio.load(node.value);
     const images = $('img');

--- a/app-web/plugins/gatsby-remark-path-transform/index.js
+++ b/app-web/plugins/gatsby-remark-path-transform/index.js
@@ -20,6 +20,7 @@ const visit = require('unist-util-visit');
 const cheerio = require('cheerio');
 const { TypeCheck } = require('@bcgov/common-web-utils');
 const { isRelativePath } = require('./utils/utils');
+const { IMAGE, LINK } = require('./utils/constants');
 
 /**
  * sifts through ast (see https://www.huynguyen.io/2018-05-remark-gatsby-plugin-part-2/)
@@ -29,9 +30,6 @@ const { isRelativePath } = require('./utils/utils');
  * @param {Object} options 
  */
 const transformRelativePaths = ({ markdownAST, markdownNode, getNode }, { converter } = {}) => {
-  const IMAGE = 'image';
-  const LINK = 'link';
-
   if (!converter || !TypeCheck.isFunction(converter)) {
     throw new Error(
       "gatsby-remark-path-transform option: 'converter' must be passed in as a function!",
@@ -75,7 +73,7 @@ const transformRelativePaths = ({ markdownAST, markdownNode, getNode }, { conver
     node.url = imageVisitedCB(node.url);
   });
 
-  visit(markdownAST, 'link', node => {
+  visit(markdownAST, LINK, node => {
     node.url = linkVisitedCB(node.url);
   });
 };

--- a/app-web/plugins/gatsby-remark-path-transform/index.js
+++ b/app-web/plugins/gatsby-remark-path-transform/index.js
@@ -17,6 +17,7 @@ Created by Patrick Simonian
 */
 
 const visit = require('unist-util-visit');
+const cheerio = require('cheerio');
 const { TypeCheck } = require('@bcgov/common-web-utils');
 const { isRelativePath } = require('./utils/utils');
 
@@ -28,28 +29,51 @@ const { isRelativePath } = require('./utils/utils');
  * @param {Object} options 
  */
 const transformRelativePaths = ({ markdownAST, markdownNode, getNode }, { converter } = {}) => {
+  const IMAGE = 'image';
+  const LINK = 'link';
+
   if (!converter || !TypeCheck.isFunction(converter)) {
     throw new Error(
       "gatsby-remark-path-transform option: 'converter' must be passed in as a function!",
     );
   }
-  const parentQLNode = getNode(markdownNode.parent);
-  // visit anchor tags and images
-  visit(markdownAST, 'image', node => {
-    // is node url relative?
-    if (isRelativePath(node.url)) {
-      const absolutePath = converter('image', node.url, parentQLNode);
-      node.url = absolutePath; // eslint-disable-line
-    }
-  });
 
-  visit(markdownAST, 'link', node => {
+  /**
+   * Closured call back to call on visit of a node
+   * @param {String} nodeType 
+   * @param {Object} parentQLNode 
+   */
+  const visitCB = (nodeType, parentQLNode) => node => {
     // is node url relative?
     if (isRelativePath(node.url)) {
-      const absolutePath = converter('link', node.url, parentQLNode);
+      const absolutePath = converter(nodeType, node.url, parentQLNode);
       node.url = absolutePath; // eslint-disable-line
     }
+  };
+
+  const parentQLNode = getNode(markdownNode.parent);
+  const imageVisitedCB = visitCB(IMAGE, parentQLNode);
+  const linkVisitedCB = visitCB(LINK, parentQLNode);
+  // visit any html nodes and ensure and check for stand alone img tags
+  visit(markdownAST, 'html', node => {
+    const $ = cheerio.load(node.value);
+    const images = $('img');
+
+    images.each((ind, elm) => {
+      const src = $(elm).attr('src');
+
+      if (isRelativePath(src)) {
+        const absolutePath = converter(IMAGE, src, parentQLNode);
+        $(elm).attr('src', absolutePath);
+      }
+    });
+
+    node.value = $.html();
   });
+  // visit link and img ast nodes
+  visit(markdownAST, IMAGE, imageVisitedCB);
+
+  visit(markdownAST, 'link', linkVisitedCB);
 };
 
 module.exports = transformRelativePaths;

--- a/app-web/plugins/gatsby-remark-path-transform/utils/constants.js
+++ b/app-web/plugins/gatsby-remark-path-transform/utils/constants.js
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+const IMAGE = 'image';
+const LINK = 'link';
+
+module.exports = {
+  IMAGE,
+  LINK,
+};


### PR DESCRIPTION
# About
Markdown files support the use of some html within the content. Things like 
```md
![Source](../../source.png)
<img src="../../source.png" alt="Source" >
```
Should be equivalent. 

There was an issue where using the `img` tag in a markdown file would show up broken in the devhub if
the `src` attribute was a relative path. 

This was fixed by modifying the *transformer* plugin responsible for fixing relative path issues #58 to also 
look into html ast nodes within the markdown file and transform any image tags as needed.

## Changes
- refactored and updated the remark-transformer-path plugin to manipulate html ast nodes that have img tags within them
- updated unit tests