### PR TITLE
Refactored Gatsby CreatePages to choose template based on source type

### DIFF
--- a/app-web/__tests__/components/__snapshots__/PrimaryFooter.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/PrimaryFooter.test.js.snap
@@ -20,7 +20,7 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": <div
-        class="Container"
+        className="Container"
       >
         <NavigationItems
           items={
@@ -51,7 +51,7 @@ ShallowWrapper {
             ]
           }
         />,
-        "class": "Container",
+        "className": "Container",
       },
       "ref": null,
       "rendered": Object {
@@ -81,7 +81,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": <div
-          class="Container"
+          className="Container"
         >
           <NavigationItems
             items={
@@ -112,7 +112,7 @@ ShallowWrapper {
               ]
             }
           />,
-          "class": "Container",
+          "className": "Container",
         },
         "ref": null,
         "rendered": Object {

--- a/app-web/src/components/PrimaryFooter/PrimaryFooter.js
+++ b/app-web/src/components/PrimaryFooter/PrimaryFooter.js
@@ -23,7 +23,7 @@ import { FOOTER_NAVIGATION } from '../../constants/ui';
 
 const PrimaryFooter = props => (
   <footer className={classes.PrimaryFooter}>
-    <div class={classes.Container}>
+    <div className={classes.Container}>
       <NavigationItems items={FOOTER_NAVIGATION} />
     </div>
   </footer>

--- a/app-web/src/hoc/GithubTemplateLayout.js
+++ b/app-web/src/hoc/GithubTemplateLayout.js
@@ -9,16 +9,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/fontawesome-free-brands';
 import { faCodeBranch } from '@fortawesome/free-solid-svg-icons';
 
-const TemplateLayout = ({ siphonData, nav, pathname, children }) => {
+const GithubTemplateLayout = ({ siphonData, nav, pathname, children }) => {
   // SourceNavigation doesn't show up if there are no links
   const sourceNavigation =
     nav.edges.length > 0 ? <SourceNavigation components={nav.edges} activeLink={pathname} /> : null;
   return (
     <Layout>
-      <div className={styles.DesignSystem}>
-        <div className={styles.Panel}>
+      <div className={styles.TemplateContainer}>
+        <div className={styles.SidePanel}>
           <header className={styles.Header}>
-            <h1>{siphonData.sourceName}</h1>
+            <h1>{siphonData.source.displayName}</h1>
             <ul className={styles.SourceTags}>
               <li>
                 <a href={siphonData.resource.originalSource}>
@@ -46,12 +46,13 @@ const TemplateLayout = ({ siphonData, nav, pathname, children }) => {
   );
 };
 
-TemplateLayout.propTypes = {
+GithubTemplateLayout.propTypes = {
   children: PropTypes.node.isRequired,
   siphonData: PropTypes.shape({
     source: PropTypes.shape({
       sourcePath: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
+      displayName: PropTypes.string.isRequired,
     }),
     resource: PropTypes.shape({
       originalSource: PropTypes.string.isRequired,
@@ -61,4 +62,4 @@ TemplateLayout.propTypes = {
   pathname: PropTypes.object.isRequired,
 };
 
-export default TemplateLayout;
+export default GithubTemplateLayout;

--- a/app-web/src/hoc/TemplateLayout.module.css
+++ b/app-web/src/hoc/TemplateLayout.module.css
@@ -1,12 +1,13 @@
-.DesignSystem {
+.TemplateContainer {
     display: flex;
     flex-wrap: wrap;
     padding-bottom: 50px;
 }
 
-.Panel {
+.SidePanel {
     flex: 1 0 200px;
 }
+
 .Header {
     background-color: #fff;
     padding-top: 10px;
@@ -61,7 +62,7 @@
         background-color: inherit;
     }
 
-    .Panel {
+    .SidePanel {
         max-width: 200px;
     }
 }

--- a/app-web/src/templates/SourceGithubHTML.js
+++ b/app-web/src/templates/SourceGithubHTML.js
@@ -18,39 +18,35 @@
 // Created by Patrick Simonian on 2018-10-12.
 //
 import React from 'react';
-import TemplateLayout from '../hoc/TemplateLayout';
-import styles from './SourceMarkdown.module.css';
+import GithubTemplateLayout from '../hoc/GithubTemplateLayout';
+import styles from './SourceHTML.module.css';
 // eslint-disable-next-line
-const SourceMarkdown = ({ data: { devhubSiphon, nav }, location: pathname }) => (
-  <TemplateLayout siphonData={devhubSiphon} nav={nav} pathname={pathname}>
+const SourceHTML = ({ data: { devhubSiphon, nav }, location: pathname }) => (
+  <GithubTemplateLayout siphonData={devhubSiphon} nav={nav} pathname={pathname}>
     <div
-      className={styles.MarkdownBody}
+      className={styles.HTMLBody}
       dangerouslySetInnerHTML={{
-        __html: devhubSiphon.childMarkdownRemark.html,
+        __html: devhubSiphon.internal.content,
       }}
     />
-  </TemplateLayout>
+  </GithubTemplateLayout>
 );
 
-export const devhubSiphonMarkdown = graphql`
-  query devhubSiphonMarkdown($id: String!, $source: String!) {
+export const devhubSiphonHTML = graphql`
+  query devhubSiphonHTML($id: String!, $source: String!) {
     devhubSiphon(id: { eq: $id }) {
       name
       id
-      childMarkdownRemark {
-        frontmatter {
-          title
-        }
-        html
+      internal {
+        content
+      }
+      resource {
+        originalSource
       }
       source {
         name
         displayName
         sourcePath
-        type
-      }
-      resource {
-        originalSource
       }
       owner
       fileName
@@ -58,10 +54,7 @@ export const devhubSiphonMarkdown = graphql`
       path
     }
     nav: allDevhubSiphon(
-      filter: {
-        source: { name: { eq: $source } }
-        internal: { mediaType: { eq: "text/markdown" } }
-      }
+      filter: { source: { name: { eq: $source } }, internal: { mediaType: { eq: "text/html" } } }
     ) {
       edges {
         node {
@@ -72,4 +65,4 @@ export const devhubSiphonMarkdown = graphql`
   }
 `;
 
-export default SourceMarkdown;
+export default SourceHTML;

--- a/app-web/src/templates/SourceGithubMarkdown.js
+++ b/app-web/src/templates/SourceGithubMarkdown.js
@@ -18,35 +18,39 @@
 // Created by Patrick Simonian on 2018-10-12.
 //
 import React from 'react';
-import TemplateLayout from '../hoc/TemplateLayout';
-import styles from './SourceHTML.module.css';
+import GithubTemplateLayout from '../hoc/GithubTemplateLayout';
+import styles from './SourceMarkdown.module.css';
 // eslint-disable-next-line
-const SourceHTML = ({ data: { devhubSiphon, nav }, location: pathname }) => (
-  <TemplateLayout siphonData={devhubSiphon} nav={nav} pathname={pathname}>
+const SourceGithubMarkdown = ({ data: { devhubSiphon, nav }, location: pathname }) => (
+  <GithubTemplateLayout siphonData={devhubSiphon} nav={nav} pathname={pathname}>
     <div
-      className={styles.HTMLBody}
+      className={styles.MarkdownBody}
       dangerouslySetInnerHTML={{
-        __html: devhubSiphon.internal.content,
+        __html: devhubSiphon.childMarkdownRemark.html,
       }}
     />
-  </TemplateLayout>
+  </GithubTemplateLayout>
 );
 
-export const devhubSiphonHTML = graphql`
-  query devhubSiphonHTML($id: String!, $source: String!) {
+export const devhubSiphonMarkdown = graphql`
+  query devhubSiphonMarkdown($id: String!, $source: String!) {
     devhubSiphon(id: { eq: $id }) {
       name
       id
-      internal {
-        content
-      }
-      resource {
-        originalSource
+      childMarkdownRemark {
+        frontmatter {
+          title
+        }
+        html
       }
       source {
         name
         displayName
         sourcePath
+        type
+      }
+      resource {
+        originalSource
       }
       owner
       fileName
@@ -54,7 +58,10 @@ export const devhubSiphonHTML = graphql`
       path
     }
     nav: allDevhubSiphon(
-      filter: { source: { name: { eq: $source } }, internal: { mediaType: { eq: "text/html" } } }
+      filter: {
+        source: { name: { eq: $source } }
+        internal: { mediaType: { eq: "text/markdown" } }
+      }
     ) {
       edges {
         node {
@@ -65,4 +72,4 @@ export const devhubSiphonHTML = graphql`
   }
 `;
 
-export default SourceHTML;
+export default SourceGithubMarkdown;


### PR DESCRIPTION
# About

The page creation initially was only based on mediaType (ie page templates for markdowns vs html).
This led to templates that were strongly tied to github sources. Since Siphon can assign different source types as they are supported. The way templates are chosen to create a page from a siphon node has been refactored.

## Changes
- Updated createPages logic to choose templates based on source type
- Renamed Template files to be more related for github source types