### PR TITLE
Bug: Adding ignore to frontmatter still creates a card that goes to no where

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -17,7 +17,12 @@
 //
 // Created by Patrick Simonian on 2018-10-12.
 //
-import { createSiphonNode, checkRegistry, getRegistry } from '../sourceNodes';
+import {
+  createSiphonNode,
+  checkRegistry,
+  getRegistry,
+  filterIgnoredResources,
+} from '../sourceNodes';
 import { GRAPHQL_NODE_TYPE } from '../utils/constants';
 import {
   GRAPHQL_NODES_WITH_REGISTRY,
@@ -31,6 +36,41 @@ jest.mock('crypto');
 jest.mock('../utils/fetchSource.js');
 
 describe('gatsby source github all plugin', () => {
+  test('filterIgnoreResources returns a filtered set of sources', () => {
+    const sources = [
+      {
+        metadata: {
+          ignore: true,
+        },
+      },
+      {
+        metadata: {
+          ignore: false,
+        },
+      },
+      {
+        metadata: {
+          apple: true,
+        },
+      },
+    ];
+
+    const expected = [
+      {
+        metadata: {
+          ignore: false,
+        },
+      },
+      {
+        metadata: {
+          apple: true,
+        },
+      },
+    ];
+
+    expect(filterIgnoredResources(sources)).toEqual(expected);
+  });
+
   test('getRegistry returns the registry', () => {
     const getNodes = jest.fn(() => GRAPHQL_NODES_WITH_REGISTRY);
     expect(getRegistry(getNodes)).toEqual(REGISTRY);

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -19,6 +19,7 @@
 //
 const crypto = require('crypto');
 const _ = require('lodash'); // eslint-disable-line
+const chalk = require('chalk'); // eslint-disable-line
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
 const { GRAPHQL_NODE_TYPE } = require('./utils/constants');
 
@@ -94,9 +95,16 @@ const getRegistry = getNodes => {
  * @returns {Array} the filtered sources 
  */
 const filterIgnoredResources = sources =>
-  sources.filter(
-    s => !Object.prototype.hasOwnProperty.call(s.metadata, 'ignore') || !s.metadata.ignore
-  );
+  sources.filter(s => {
+    if (!Object.prototype.hasOwnProperty.call(s.metadata, 'ignore') || !s.metadata.ignore) {
+      return true;
+    }
+    console.log(
+      chalk`\n The resource {green.bold ${s.metadata
+        .name}} has been flagged as {green.bold 'ignore'} and will not have a Siphon Node created for it`
+    );
+    return false;
+  });
 
 // eslint-disable-next-line consistent-return
 const sourceNodes = async ({ getNodes, boundActionCreators, createNodeId }, { tokens }) => {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -88,6 +88,16 @@ const getRegistry = getNodes => {
   throw new Error('Registry not found');
 };
 
+/**
+ * Filteres out resources that have the ignore metadata property set to true
+ * @param {Array} sources
+ * @returns {Array} the filtered sources 
+ */
+const filterIgnoredResources = sources =>
+  sources.filter(
+    s => !Object.prototype.hasOwnProperty.call(s.metadata, 'ignore') || !s.metadata.ignore
+  );
+
 // eslint-disable-next-line consistent-return
 const sourceNodes = async ({ getNodes, boundActionCreators, createNodeId }, { tokens }) => {
   // get registry from current nodes
@@ -100,9 +110,10 @@ const sourceNodes = async ({ getNodes, boundActionCreators, createNodeId }, { to
     const sources = await Promise.all(
       registry.sources.map(source => fetchFromSource(source.sourceType, source, tokens))
     );
-    // sources is an array of arrays [repo files, repo files] etc
+    // sources is an array of arrays [[source data], [source data]] etc
     // so we flatten it into a 1 dimensional array
     let dataToNodify = _.flatten(sources, true);
+    dataToNodify = filterIgnoredResources(dataToNodify);
     // create nodes
     return dataToNodify.map(file => createNode(createSiphonNode(file, createNodeId(file.sha))));
   } catch (e) {
@@ -117,4 +128,5 @@ module.exports = {
   checkRegistry,
   createSiphonNode,
   sourceNodes,
+  filterIgnoredResources,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -85,7 +85,8 @@ const markdownFrontmatterPlugin = (extension, file) => {
       // if propery required and frontmatter doesn't have it
       if (property.required && valueIsInvalid) {
         throw new Error(
-          `Frontmatter key ${key} is required but ${file.metadata.fileName} is missing it`
+          `\nFrontmatter key '${key}' is required but ${file.metadata.fileName} for source ${file
+            .metadata.source} is missing it`
         );
         // is there a defaultable value we can provide
       } else if (valueIsInvalid && DEFAULTS[key]) {
@@ -97,6 +98,7 @@ const markdownFrontmatterPlugin = (extension, file) => {
       ...file.metadata,
       resourceTitle: frontmatter.title,
       resourceDescription: frontmatter.description,
+      ignore: frontmatter.ignore,
     };
     // create 'new' md string with updated front matter
     file.content = matter.stringify(data.content, frontmatter);


### PR DESCRIPTION
# About

We found an issue where markdown files may have an 'ignore' front matter property set to true, it would still create a card component which would link to a page that hadn't be created. 

This was found because there was some logic in the createPages to prevent pages from being created in the node but the card components graphql did not share a similar logic. To circumvent this issue all together, the approach i took was prevent graphql nodes from being created if they have an 'ignore: true' front matter property. 

## Changes
- metadata property now includes 'ignore'
- source nodes now filter out files that have a ignore: true metadata property
- added unit tests for said filtering function