### PR TITLE
Add support for adding a 'persona' attribute to siphon

### DIFF
--- a/app-web/.prettierrc
+++ b/app-web/.prettierrc
@@ -1,5 +1,5 @@
 {
     "printWidth": 100,
     "singleQuote": true,
-    "trailingComma": "es5",
+    "trailingComma": "all",
 }

--- a/app-web/__fixtures__/plugin-fixtures.js
+++ b/app-web/__fixtures__/plugin-fixtures.js
@@ -22,7 +22,7 @@ export const SIPHON_QL_NODE = {
   sourcePath: 'https://github.com/bcgov/design-system/',
   resource: {
     originalSource:
-    'https://github.com/bcgov/design-system/blob/master/components/footer/something/README.md',
+      'https://github.com/bcgov/design-system/blob/master/components/footer/something/README.md',
   },
   resourcePath: '/design-system/README_123o8123',
   path: 'components/footer/README.md',

--- a/app-web/__tests__/components/Card.test.js
+++ b/app-web/__tests__/components/Card.test.js
@@ -11,7 +11,7 @@ describe('Card Component', () => {
         resourcePath="resourcePath"
         sourcePath="sourcePath"
         sourceName="sourceName"
-      />
+      />,
     );
     expect(wrapper).toMatchSnapshot();
   });

--- a/app-web/__tests__/pages/Index.test.js
+++ b/app-web/__tests__/pages/Index.test.js
@@ -47,7 +47,9 @@ describe('Index Container', () => {
       pathname: '/',
     };
 
-    const wrapper = shallow(<Index data={data} loadSiphonNodes={loadSiphonNodes} location={location}/>);
+    const wrapper = shallow(
+      <Index data={data} loadSiphonNodes={loadSiphonNodes} location={location} />,
+    );
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/app-web/__tests__/redux/uiActionCreators.test.js
+++ b/app-web/__tests__/redux/uiActionCreators.test.js
@@ -27,7 +27,7 @@ describe('ui action creators', () => {
   it('should create an action to set main navigiaton toggle', () => {
     const expected = ACTIONS.TOGGLE_MAIN_NAVIGATION_ON;
     expect(actions.toggleMainNavigation(ACTIONS.TOGGLE_MAIN_NAVIGATION_ON.payload.toggled)).toEqual(
-      expected
+      expected,
     );
   });
 });

--- a/app-web/gatsby/createPages.js
+++ b/app-web/gatsby/createPages.js
@@ -41,7 +41,7 @@ const getTemplate = (source, mediaType) => {
     return sourceTemplate[mediaType];
   } else {
     throw new Error(
-      `No Available Template for source type ${source}, this is most likely an issue with Siphon's code base creating nodes with the incorrect source type!`
+      `No Available Template for source type ${source}, this is most likely an issue with Siphon's code base creating nodes with the incorrect source type!`,
     );
   }
 };

--- a/app-web/gatsby/modifyWebpackConfig.js
+++ b/app-web/gatsby/modifyWebpackConfig.js
@@ -27,7 +27,7 @@ module.exports = ({ config, env }) => {
       });
       config.merge({
         postcss: [
-            require('postcss-flexbugs-fixes'), // eslint-disable-line
+          require('postcss-flexbugs-fixes'), // eslint-disable-line
           autoprefixer({
             browsers: [
               '>1%',

--- a/app-web/plugins/gatsby-remark-path-transform/__tests__/utils.test.js
+++ b/app-web/plugins/gatsby-remark-path-transform/__tests__/utils.test.js
@@ -39,12 +39,12 @@ describe('gatsby-remark-path-transform', () => {
       expect(() => {
         transformRelativePaths({}, { converter: null });
       }).toThrow(
-        "gatsby-remark-path-transform option: 'converter' must be passed in as a function!"
+        "gatsby-remark-path-transform option: 'converter' must be passed in as a function!",
       );
       expect(() => {
         transformRelativePaths({});
       }).toThrow(
-        "gatsby-remark-path-transform option: 'converter' must be passed in as a function!"
+        "gatsby-remark-path-transform option: 'converter' must be passed in as a function!",
       );
     });
 

--- a/app-web/plugins/gatsby-remark-path-transform/index.js
+++ b/app-web/plugins/gatsby-remark-path-transform/index.js
@@ -30,7 +30,7 @@ const { isRelativePath } = require('./utils/utils');
 const transformRelativePaths = ({ markdownAST, markdownNode, getNode }, { converter } = {}) => {
   if (!converter || !TypeCheck.isFunction(converter)) {
     throw new Error(
-      "gatsby-remark-path-transform option: 'converter' must be passed in as a function!"
+      "gatsby-remark-path-transform option: 'converter' must be passed in as a function!",
     );
   }
   const parentQLNode = getNode(markdownNode.parent);

--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -125,7 +125,8 @@ const GITHUB_API = {
       html: 'https://github.com/bcgov/range-web/blob/master/public/manifest.json',
     },
   },
-  BAD_MD_FILE: { // no description front matter (which is required)
+  BAD_MD_FILE: {
+    // no description front matter (which is required)
     name: 'badfile.md',
     path: 'public/badfile.md',
     sha: 'ef19ec243e739479802a5553d0b38a18ed845307',
@@ -291,6 +292,7 @@ const PROCESSED_FILE_MD = {
     fileName: 'README.md',
     mediaType: 'text/markdown',
     extension: 'md',
+    globalPersona: 'Designer',
   },
 };
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
@@ -34,7 +34,7 @@ describe('Integration github api module', () => {
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
       .mockReturnValueOnce(
-        Promise.resolve(new Response(JSON.stringify(GITHUB_API.FAIL), { status: 400 }))
+        Promise.resolve(new Response(JSON.stringify(GITHUB_API.FAIL), { status: 400 })),
       )
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))));
     const files = await getFilesFromRepo(GITHUB_SOURCE);
@@ -45,7 +45,7 @@ describe('Integration github api module', () => {
   it('returns a list of files even if some fail', async () => {
     // mock out concurrent requests to githup api
     fetch.mockReturnValueOnce(
-      Promise.resolve(new Response(JSON.stringify(GITHUB_API.FAIL), { status: 400 }))
+      Promise.resolve(new Response(JSON.stringify(GITHUB_API.FAIL), { status: 400 })),
     );
     const files = await getFilesFromRepo(GITHUB_SOURCE);
     expect(files).toBeInstanceOf(Array);

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
@@ -93,7 +93,7 @@ describe('Github API', () => {
           'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
         },
         method: 'GET',
-      })
+      }),
     );
   });
 
@@ -114,7 +114,7 @@ describe('Github API', () => {
     }
     // mock fetch file
     fetch.mockReturnValue(
-      Promise.resolve(new Response(JSON.stringify(GITHUB_API.FAIL), { status: 400 }))
+      Promise.resolve(new Response(JSON.stringify(GITHUB_API.FAIL), { status: 400 })),
     );
     const ignoreFile = await fetchIgnoreFile();
 
@@ -137,7 +137,7 @@ describe('Github API', () => {
           'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
         },
         method: 'GET',
-      })
+      }),
     );
   });
 
@@ -160,7 +160,7 @@ describe('Github API', () => {
       expect.objectContaining({
         headers: { Authorization: 'Bearer TOKEN' },
         method: 'GET',
-      })
+      }),
     );
   });
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.itest.js
@@ -13,7 +13,7 @@ describe('createPathWithDigest Integration Tests', () => {
     expect(createPathWithDigest('/path/', digestable)).toBe(`/path/${hash}`);
 
     expect(createPathWithDigest('path/', digestable)).toBe(
-      createPathWithDigest('path/', digestable)
+      createPathWithDigest('path/', digestable),
     );
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -28,7 +28,7 @@ describe('Integration Tests Source Nodes', () => {
     const getNodes = jest.fn(() => GRAPHQL_NODES_WITH_REGISTRY);
     const nodes = await sourceNodes(
       { boundActionCreators, createNodeId, getNodes },
-      CONFIG_OPTIONS
+      CONFIG_OPTIONS,
     );
     expect(nodes.every(node => node.internal.type === GRAPHQL_NODE_TYPE)).toBe(true);
   });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -89,11 +89,11 @@ describe('gatsby source github all plugin', () => {
   test("checkRegistry throws if sources don't exist or if sources are invalid", () => {
     const BAD_REGISTRY = { ...REGISTRY, sources: null };
     expect(() => checkRegistry(BAD_REGISTRY)).toThrow(
-      'Error in Gatsby Source Github All: registry is not valid. One or more repos may be missing required parameters'
+      'Error in Gatsby Source Github All: registry is not valid. One or more repos may be missing required parameters',
     );
     validateSourceRegistry.mockReturnValue(false);
     expect(() => checkRegistry(REGISTRY)).toThrow(
-      'Error in Gatsby Source Github All: registry is not valid. One or more repos may be missing required parameters'
+      'Error in Gatsby Source Github All: registry is not valid. One or more repos may be missing required parameters',
     );
   });
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -140,7 +140,10 @@ describe('gatsby source github all plugin', () => {
       owner: 'Billy Bob',
       parent: null,
       path: '/test.md',
-      labels: 'component',
+      attributes: {
+        labels: 'component',
+        persona: undefined,
+      },
       source: {
         name: 'something/something',
         displayName: 'something',

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
@@ -105,7 +105,7 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
   test('transformer leaves text files alone with markdown plugin', async () => {
     const transformedContent = await fileTransformer(
       PROCESSED_FILE_TXT.metadata.extension,
-      PROCESSED_FILE_TXT
+      PROCESSED_FILE_TXT,
     )
       .use(markdownFrontmatterPlugin)
       .resolve();
@@ -117,7 +117,7 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
     expect(data.data.resourcePath).toBeDefined();
     const transformedFile = await fileTransformer(
       RAW_FILE_MD_WITH_RESOURCEPATH.metadata.extension,
-      RAW_FILE_MD_WITH_RESOURCEPATH
+      RAW_FILE_MD_WITH_RESOURCEPATH,
     )
       .use(pagePathPlugin)
       .resolve();
@@ -134,7 +134,7 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
       .resolve();
 
     expect(transformedFile.metadata.resourcePath).toBe(
-      `/${source}/${source}${name}https:/github.com/bcgov/design-system/blob/master/components/header/README.md`
+      `/${source}/${source}${name}https:/github.com/bcgov/design-system/blob/master/components/header/README.md`,
     );
   });
 

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -44,7 +44,10 @@ const createSiphonNode = (data, id) => ({
     type: data.metadata.resourceType, // the base resource type for this see utils/constants.js
     originalSource: data.metadata.originalResourceLocation, // the original location of the resource
   },
-  labels: data.metadata.labels, // labels from source registry
+  attributes: {
+    labels: data.metadata.labels, // labels from source registry
+    persona: data.metadata.persona, // persona from the source registry, see constants for valid personas
+  },
   internal: {
     contentDigest: crypto
       .createHash('md5')

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -77,7 +77,7 @@ const sourcesAreValid = sources => sources.every(validateSourceRegistry);
 const checkRegistry = registry => {
   if (!registry.sources || !sourcesAreValid(registry.sources)) {
     throw new Error(
-      'Error in Gatsby Source Github All: registry is not valid. One or more repos may be missing required parameters'
+      'Error in Gatsby Source Github All: registry is not valid. One or more repos may be missing required parameters',
     );
   }
   return true;
@@ -104,7 +104,7 @@ const filterIgnoredResources = sources =>
     }
     console.log(
       chalk`\n The resource {green.bold ${s.metadata
-        .name}} has been flagged as {green.bold 'ignore'} and will not have a Siphon Node created for it`
+        .name}} has been flagged as {green.bold 'ignore'} and will not have a Siphon Node created for it`,
     );
     return false;
   });
@@ -119,7 +119,7 @@ const sourceNodes = async ({ getNodes, boundActionCreators, createNodeId }, { to
     checkRegistry(registry);
     // fetch all repos
     const sources = await Promise.all(
-      registry.sources.map(source => fetchFromSource(source.sourceType, source, tokens))
+      registry.sources.map(source => fetchFromSource(source.sourceType, source, tokens)),
     );
     // sources is an array of arrays [[source data], [source data]] etc
     // so we flatten it into a 1 dimensional array

--- a/app-web/plugins/gatsby-source-github-all/utils/constants.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants.js
@@ -130,6 +130,10 @@ const MARKDOWN_FRONTMATTER_SCHEMA = {
     type: String,
     required: false,
   },
+  persona: {
+    type: String,
+    required: false,
+  },
 };
 
 const GITHUB_SOURCE_SCHEMA = {

--- a/app-web/plugins/gatsby-source-github-all/utils/constants.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants.js
@@ -37,6 +37,14 @@ const RESOURCE_TYPES = [
   'Components',
 ];
 
+const PERSONAS = {
+  DESIGNER: 'Designer',
+  DEVELOPER: 'Developer',
+  PRODUCT_OWNER: 'Product Owner',
+};
+
+const PERSONAS_LIST = Object.keys(PERSONAS).map(p => PERSONAS[p]);
+
 const GRAPHQL_NODE_TYPE = 'DevhubSiphon';
 
 const DEFUALT_IGNORES = [
@@ -151,4 +159,6 @@ module.exports = {
   SOURCE_TYPES,
   RESOURCE_TYPES,
   UNFURL_TYPES,
+  PERSONAS,
+  PERSONAS_LIST,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -199,7 +199,7 @@ const applyBaseMetadata = (
   sourceType,
   globalResourceType,
   originalResourceLocation,
-  globalPersona
+  globalPersona,
 ) => {
   const extension = getExtensionFromName(file.name);
   return {

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -121,7 +121,7 @@ const fetchFile = async (repo, owner, path, token, branch = '') => {
           Authorization: `Bearer ${token}`,
           'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
         },
-      }
+      },
     );
     const data = await result.json();
     if (result.ok) return data;
@@ -271,7 +271,7 @@ const getFilesFromRepo = async ({sourceType, resourceType, name, sourcePropertie
     const filesToFetch = filterFiles(files, ig);
     // retrieve contents for each file
     const filesWithContents = filesToFetch.map(file =>
-      fetchFile(repo, owner, file.path, token, branch)
+      fetchFile(repo, owner, file.path, token, branch),
     );
     const filesResponse = await Promise.all(filesWithContents);
     // for some reason the accept header is not returning with raw content so we will decode
@@ -290,8 +290,8 @@ const getFilesFromRepo = async ({sourceType, resourceType, name, sourcePropertie
           sourceType,
           resourceType,
           f.html_url,
-          persona
-        )
+          persona,
+        ),
       )
       .map(async f => {
         const ft = fileTransformer(f.metadata.extension, f);

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -196,7 +196,8 @@ const applyBaseMetadata = (
   sourceURL,
   sourceType,
   globalResourceType,
-  originalResourceLocation
+  originalResourceLocation,
+  globalPersona
 ) => {
   const extension = getExtensionFromName(file.name);
   return {
@@ -216,6 +217,7 @@ const applyBaseMetadata = (
       sourceType,
       globalResourceType,
       originalResourceLocation,
+      globalPersona,
     },
   };
 };
@@ -250,7 +252,7 @@ const filterFiles = (files, ignoreObj) => {
  * @returns {Array} The array of files
  */
 // eslint-disable-next-line
-const getFilesFromRepo = async ({sourceType, resourceType, name, sourceProperties: { repo, url, owner, branch }, attributes: { labels }}, token) => {
+const getFilesFromRepo = async ({sourceType, resourceType, name, sourceProperties: { repo, url, owner, branch }, attributes: { labels, persona }}, token) => {
   try {
     // ignore filtering
     const ig = ignore().add(DEFUALT_IGNORES);
@@ -276,7 +278,18 @@ const getFilesFromRepo = async ({sourceType, resourceType, name, sourcePropertie
     const processedFiles = filesResponse
       .filter(f => f !== undefined) // filter out any files that weren't fetched
       .map(f =>
-        applyBaseMetadata(f, labels, owner, repo, name, url, sourceType, resourceType, f.html_url)
+        applyBaseMetadata(
+          f,
+          labels,
+          owner,
+          repo,
+          name,
+          url,
+          sourceType,
+          resourceType,
+          f.html_url,
+          persona
+        )
       )
       .map(async f => {
         const ft = fileTransformer(f.metadata.extension, f);

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -24,6 +24,7 @@ const {
   MEDIATYPES,
   DEFUALT_IGNORES,
   GITHUB_SOURCE_SCHEMA,
+  PERSONAS_LIST,
 } = require('./constants');
 const chalk = require('chalk'); // eslint-disable-line
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
@@ -37,6 +38,7 @@ const {
   markdownUnfurlPlugin,
   markdownResourceTypePlugin,
   externalLinkUnfurlPlugin,
+  markdownPersonaPlugin,
 } = require('./plugins');
 /**
  * returns extension of a file name
@@ -300,6 +302,7 @@ const getFilesFromRepo = async ({sourceType, resourceType, name, sourcePropertie
             .use(markdownUnfurlPlugin)
             .use(markdownResourceTypePlugin)
             .use(externalLinkUnfurlPlugin)
+            .use(markdownPersonaPlugin, { personas: PERSONAS_LIST })
             .resolve();
         } catch (e) {
           console.error(chalk.yellow(e.message));

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -254,7 +254,16 @@ const filterFiles = (files, ignoreObj) => {
  * @returns {Array} The array of files
  */
 // eslint-disable-next-line
-const getFilesFromRepo = async ({sourceType, resourceType, name, sourceProperties: { repo, url, owner, branch }, attributes: { labels, persona }}, token) => {
+const getFilesFromRepo = async (
+  {
+    sourceType,
+    resourceType,
+    name,
+    sourceProperties: { repo, url, owner, branch },
+    attributes: { labels, persona },
+  },
+  token,
+) => {
   try {
     // ignore filtering
     const ig = ignore().add(DEFUALT_IGNORES);

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -89,7 +89,7 @@ const getClosestResourceType = resourceType => {
 const getClosestPersona = (persona, personas) => {
   // if its blank don't bother checking closeness
   if (persona === '') return '';
-  const matches = stringSimilarity.findBestMatch(personas, personas);
+  const matches = stringSimilarity.findBestMatch(persona, personas);
   // only return the best match if its greater than .5 in similarity
   return matches.bestMatch.rating >= 0.5 ? matches.bestMatch.target : '';
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -48,7 +48,7 @@ const createPathWithDigest = (base, ...digestables) => {
  */
 const createUnfurlObj = (
   type,
-  { label1, data1, label2, data2, description, title, image, author }
+  { label1, data1, label2, data2, description, title, image, author },
 ) => {
   if (!TypeCheck.isString(type)) {
     throw new Error('type must be a string!');
@@ -87,7 +87,7 @@ const getClosestResourceType = resourceType => {
  * @param {Array} personas the valid personas list
  */
 const getClosestPersona = (persona, personas) => {
-  const RATING_THRESHOLD = 0.5; // rating is between 0 - 1, we only want a match if it's greater than half. 
+  const RATING_THRESHOLD = 0.5; // rating is between 0 - 1, we only want a match if it's greater than half.
   // if its blank don't bother checking closeness
   if (persona === '') return '';
   const matches = stringSimilarity.findBestMatch(persona, personas);

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -80,8 +80,23 @@ const getClosestResourceType = resourceType => {
   return matches.bestMatch.rating >= 0.5 ? matches.bestMatch.target : '';
 };
 
+/**
+ * returns the closest persona from the array of personas based on the
+ * uncontrolled persona (given to us by contributors)
+ * @param {String} persona the persona provided by a specific piece of content
+ * @param {Array} personas the valid personas list
+ */
+const getClosestPersona = (persona, personas) => {
+  // if its blank don't bother checking closeness
+  if (persona === '') return '';
+  const matches = stringSimilarity.findBestMatch(personas, personas);
+  // only return the best match if its greater than .5 in similarity
+  return matches.bestMatch.rating >= 0.5 ? matches.bestMatch.target : '';
+};
+
 module.exports = {
   createPathWithDigest,
   createUnfurlObj,
   getClosestResourceType,
+  getClosestPersona,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -87,11 +87,11 @@ const getClosestResourceType = resourceType => {
  * @param {Array} personas the valid personas list
  */
 const getClosestPersona = (persona, personas) => {
+  const RATING_THRESHOLD = 0.5; // rating is between 0 - 1, we only want a match if it's greater than half. 
   // if its blank don't bother checking closeness
   if (persona === '') return '';
   const matches = stringSimilarity.findBestMatch(persona, personas);
-  // only return the best match if its greater than .5 in similarity
-  return matches.bestMatch.rating >= 0.5 ? matches.bestMatch.target : '';
+  return matches.bestMatch.rating >= RATING_THRESHOLD ? matches.bestMatch.target : '';
 };
 
 module.exports = {

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -33,7 +33,12 @@ const metascraper = require('metascraper')([
 const validUrl = require('valid-url');
 const got = require('got');
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
-const { createPathWithDigest, createUnfurlObj, getClosestResourceType, getClosestPersona } = require('./helpers'); // eslint-disable-line
+const {
+  createPathWithDigest,
+  createUnfurlObj,
+  getClosestResourceType,
+  getClosestPersona,
+} = require('./helpers'); // eslint-disable-line
 const { MARKDOWN_FRONTMATTER_SCHEMA, UNFURL_TYPES } = require('./constants');
 /**
  * applys default front matter properties
@@ -88,7 +93,7 @@ const markdownFrontmatterPlugin = (extension, file) => {
       if (property.required && valueIsInvalid) {
         throw new Error(
           `\nFrontmatter key '${key}' is required but ${file.metadata.fileName} for source ${file
-            .metadata.source} is missing it`
+            .metadata.source} is missing it`,
         );
         // is there a defaultable value we can provide
       } else if (valueIsInvalid && DEFAULTS[key]) {
@@ -134,7 +139,7 @@ const pagePathPlugin = (extension, file) => {
     file.metadata.source,
     file.metadata.source,
     file.metadata.name,
-    file.html_url
+    file.html_url,
   );
   return file;
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -77,6 +77,7 @@ const markdownFrontmatterPlugin = (extension, file) => {
       pageOnly: () => false, // in the use case where we want this node to not be presented as a card in the home page
       // provide default resource type to be blank
       resourceType: () => '',
+      persona: () => '',
     };
     // check front matter against defaults
     Object.keys(MARKDOWN_FRONTMATTER_SCHEMA).forEach(key => {

--- a/app-web/src/components/NavigationItems/NavigationItems.js
+++ b/app-web/src/components/NavigationItems/NavigationItems.js
@@ -34,7 +34,7 @@ NavigationItems.propTypes = {
     PropTypes.shape({
       to: PropTypes.string.isRequired,
       text: PropTypes.string.isRequired,
-    })
+    }),
   ),
 };
 

--- a/app-web/src/components/SourceNavigation/SourceNavigation.js
+++ b/app-web/src/components/SourceNavigation/SourceNavigation.js
@@ -70,7 +70,7 @@ SourceNavigation.propTypes = {
         resourcePath: PropTypes.string,
         resourceTitle: PropTypes.string,
       }),
-    })
+    }),
   ).isRequired,
 };
 

--- a/app-web/src/hoc/Layout.js
+++ b/app-web/src/hoc/Layout.js
@@ -37,7 +37,7 @@ class Layout extends React.Component {
             type="image/x-icon"
           />
         </Helmet>
-        <PrimaryHeader path={path}/>
+        <PrimaryHeader path={path} />
         <div className="container">{children}</div>
         <PrimaryFooter />
       </div>

--- a/docs/registerRepo.md
+++ b/docs/registerRepo.md
@@ -128,7 +128,9 @@ Must come inconjuction with `label1`
 Last of the two key value pairs allowed in the preview of a card
 #### value2 (optional)
 Must come inconjuction with `label2`
-
+#### persona (options)
+this will overide and global personas configurations set in the registry, this is used to allow for
+filtering the markdown files in the devhub by persona (valid personas: 'Developer', 'Designer', 'Product Owner')
 #### HTML metadata
 Follow this document on how to add the appropriate metadata to your HTML document. 
 
@@ -154,6 +156,9 @@ This is accomplished by 'registering' into the devhub.
         - `branch` (optional) The branch you would like devhub to source content from
 - `resourceType` (optional) This is a global resource type, any singular chunk of data (such as a markdown file or a yaml file or a  link to a website) that Siphon grabs from your source can have it's individual resourceType defaulted to this value
     - valid resource types: see the main readme
+- `attributes`
+    `labels`: a yaml list of labels/tags for all of your sources to inherit
+    `persona`: a global persona that all sources may inherit, personas are validated against a master list, valid values are: 'Designer', 'Developer', 'Product Owner'
 This will involve making a [Fork of the Devhub](https://github.com/bcgov/devhub-app-web/fork) and Pull Request to the [Devhub Repository's contributor-repository-registry branch](https://github.com/bcgov/devhub-app-web/tree/contributor-repo-registry).
 
 ***PULL REQUESTS TO MASTER OR ANY OTHER BRANCH WILL BE IGNORED***

--- a/docs/siphon.md
+++ b/docs/siphon.md
@@ -220,7 +220,10 @@ the graphQL schema (more on that [here](https://v1.gatsbyjs.org/docs/source-plug
         // or internal, a link to a generated gatsby page
         path 
     }
-    labels
+    attributes { // extra information that may be beneficial for searching
+        labels
+        persona
+    }
     internal {
         contentDigest // a gatsby required property
         // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate


### PR DESCRIPTION
# About
Siphon now supports a persona attribute in the registry yaml. The **persona** is just another key/value pair that allows for filtering *by persona* in the front end. The persona attribute in the registry is 'inherited' by markdown github sources. Overriding individual markdown files is supported as well with a markdown `persona` property. 

## Changes
- added support for persona in registry
- added support for persona in markdown files
- updated docs
- updated siphon graphql schema a tiny bit