### PR TITLE
Fix issue where external resource image may not unfurl

### DIFF
--- a/app-web/__mocks__/html-metadata.js
+++ b/app-web/__mocks__/html-metadata.js
@@ -1,0 +1,26 @@
+jest.requireActual('html-metadata');
+
+module.exports = async () => {
+  return {
+    twitter: {
+      author: 'Ellen Huet',
+      date: '2016-05-24T18:00:03.894Z',
+      description: 'The HR startups go to war.',
+      image: 'https://assets.bwbx.io/images/users/iqjWHBFdfxIU/ioh_yWEn8gHo/v1/-1x-1.jpg',
+      publisher: 'Bloomberg.com',
+      title: 'As Zenefits Stumbles, Gusto Goes Head-On by Selling Insurance',
+      url:
+        'http://www.bloomberg.com/news/articles/2016-05-24/as-zenefits-stumbles-gusto-goes-head-on-by-selling-insurance',
+    },
+    openGraph: {
+      author: 'Ellen Huet',
+      date: '2016-05-24T18:00:03.894Z',
+      description: 'The HR startups go to war.',
+      image: 'https://assets.bwbx.io/images/users/iqjWHBFdfxIU/ioh_yWEn8gHo/v1/-1x-1.jpg',
+      publisher: 'Bloomberg.com',
+      title: 'As Zenefits Stumbles, Gusto Goes Head-On by Selling Insurance',
+      url:
+        'http://www.bloomberg.com/news/articles/2016-05-24/as-zenefits-stumbles-gusto-goes-head-on-by-selling-insurance',
+    },
+  };
+};

--- a/app-web/__mocks__/valid-url.js
+++ b/app-web/__mocks__/valid-url.js
@@ -2,4 +2,5 @@ jest.requireActual('valid-url');
 
 module.exports = {
   isUri: url => url,
+  isWebUri: url => url,
 };

--- a/app-web/__mocks__/valid-url.js
+++ b/app-web/__mocks__/valid-url.js
@@ -1,5 +1,5 @@
 jest.requireActual('valid-url');
 
 module.exports = {
-  isUri: () => true,
+  isUri: url => url,
 };

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -5752,10 +5752,35 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
       "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
@@ -6154,6 +6179,15 @@
       "integrity": "sha1-n3EDKEwQWmbfQDCysycxZYNwE9o=",
       "requires": {
         "require-like": ">= 0.1.1"
+      }
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -10075,6 +10109,24 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
+    "html-metadata": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/html-metadata/-/html-metadata-1.7.0.tgz",
+      "integrity": "sha512-JyKSV659DyKM5ehkngEekXjQK0oSBQW4+UR9UZqDfJw9OVOuEHVmTQ+eS+1x7Ir25FfRbLEKYsN2yodEv2ehSg==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "cheerio": "1.0.0-rc.2",
+        "microdata-node": "0.2.1",
+        "preq": "0.5.4"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        }
+      }
+    },
     "html-react-parser": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-0.4.7.tgz",
@@ -13364,6 +13416,67 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "microdata-node": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/microdata-node/-/microdata-node-0.2.1.tgz",
+      "integrity": "sha1-xZ9Z0hMKMoBwoe2zFZCVDPfce40=",
+      "requires": {
+        "array-unique": "^0.1.1",
+        "domutils": "^1.5.1",
+        "es6-map": "^0.1.1",
+        "extend": "^2.0.0",
+        "htmlparser2": "^3.8.2",
+        "is-absolute-url": "^1.0.0"
+      },
+      "dependencies": {
+        "array-unique": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.1.1.tgz",
+          "integrity": "sha1-styOx2XTBlN9cpHg5iHoSdJXPPk="
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "extend": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
+          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
+        },
+        "htmlparser2": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.0.6"
+          }
+        },
+        "is-absolute-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-1.0.0.tgz",
+          "integrity": "sha1-LX7w/QuyqI2sfpIlPGgIoKziS/s="
+        },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -21787,6 +21900,16 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "preq": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/preq/-/preq-0.5.4.tgz",
+      "integrity": "sha1-GDEX1stB/iWF3E0D5geJ9E9l6oc=",
+      "requires": {
+        "bluebird": "^3.1.1",
+        "request": "^2.67.0",
+        "semver": "^5.3.0"
+      }
     },
     "preserve": {
       "version": "0.2.0",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -44,6 +44,7 @@
     "gatsby-transformer-yaml": "^1.5.11",
     "got": "^9.3.2",
     "hash.js": "^1.1.5",
+    "html-metadata": "^1.7.0",
     "i": "^0.3.6",
     "ignore": "^5.0.2",
     "js-yaml": "^3.12.0",

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
@@ -195,7 +195,7 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
   test('transformer unfurls an external resource path', async () => {
     const file = {
       metadata: {
-        resourcePath: 'www.example.com',
+        resourcePath: 'https://www.example.com',
       },
     };
 

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -19,6 +19,7 @@ const shortid = require('shortid'); // eslint-disable-line
 const matter = require('gray-matter'); // eslint-disable-line
 const visit = require('unist-util-visit'); // eslint-disable-line
 const remark = require('remark'); // eslint-disable-line
+const url = require('url');
 const metascraper = require('metascraper')([
   require('metascraper-author')(),
   require('metascraper-date')(),
@@ -197,7 +198,13 @@ const externalLinkUnfurlPlugin = async (extension, file) => {
   if (file.metadata.resourcePath && validUrl.isUri(file.metadata.resourcePath)) {
     const { body: html, url } = await got(file.metadata.resourcePath);
     const metadata = await metascraper({ html, url });
+    // update image to have resource path prepended to it if it is not https
+    metadata.image =
+      validUrl.isUri(metadata.image) !== undefined
+        ? metadata.image
+        : url.resolve(file.metadata.resourcePath, '/', metadata.image);
     file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, metadata);
+    console.log(metadata.image);
   }
   return file;
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -200,11 +200,13 @@ const externalLinkUnfurlPlugin = async (extension, file) => {
     const { body: html, url } = await got(file.metadata.resourcePath);
     const metadata = await metascraper({ html, url });
     // update image to have resource path prepended to it if it is not https
-    metadata.image =
-      validUrl.isUri(metadata.image) !== undefined
-        ? metadata.image
-        : resolve(file.metadata.resourcePath, '/', metadata.image);
-    file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, metadata);
+    if (metadata.image) {
+      metadata.image =
+        validUrl.isUri(metadata.image) !== undefined
+          ? metadata.image
+          : resolve(file.metadata.resourcePath, '/', metadata.image);
+      file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, metadata);
+    }
   }
   return file;
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -194,6 +194,7 @@ const markdownResourceTypePlugin = (extension, file) => {
  * @returns the modified file
  */
 const externalLinkUnfurlPlugin = async (extension, file) => {
+  const resolve = url.resolve;
   // does file have a resource path and is it a valid url?
   if (file.metadata.resourcePath && validUrl.isUri(file.metadata.resourcePath)) {
     const { body: html, url } = await got(file.metadata.resourcePath);
@@ -202,7 +203,7 @@ const externalLinkUnfurlPlugin = async (extension, file) => {
     metadata.image =
       validUrl.isUri(metadata.image) !== undefined
         ? metadata.image
-        : url.resolve(file.metadata.resourcePath, '/', metadata.image);
+        : resolve(file.metadata.resourcePath, '/', metadata.image);
     file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, metadata);
     console.log(metadata.image);
   }

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -205,7 +205,6 @@ const externalLinkUnfurlPlugin = async (extension, file) => {
         ? metadata.image
         : resolve(file.metadata.resourcePath, '/', metadata.image);
     file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, metadata);
-    console.log(metadata.image);
   }
   return file;
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -20,19 +20,8 @@ const matter = require('gray-matter'); // eslint-disable-line
 const visit = require('unist-util-visit'); // eslint-disable-line
 const remark = require('remark'); // eslint-disable-line
 const url = require('url');
-const metascraper = require('metascraper')([
-  require('metascraper-author')(),
-  require('metascraper-date')(),
-  require('metascraper-description')(),
-  require('metascraper-image')(),
-  require('metascraper-logo')(),
-  require('metascraper-clearbit-logo')(),
-  require('metascraper-publisher')(),
-  require('metascraper-title')(),
-  require('metascraper-url')(),
-]);
+const scrape = require('html-metadata');
 const validUrl = require('valid-url');
-const got = require('got');
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
 const {
   createPathWithDigest,
@@ -194,18 +183,25 @@ const markdownResourceTypePlugin = (extension, file) => {
  * @returns the modified file
  */
 const externalLinkUnfurlPlugin = async (extension, file) => {
-  const resolve = url.resolve;
   // does file have a resource path and is it a valid url?
   if (file.metadata.resourcePath && validUrl.isUri(file.metadata.resourcePath)) {
-    const { body: html, url } = await got(file.metadata.resourcePath);
-    const metadata = await metascraper({ html, url });
+    let metadata;
+    try {
+      metadata = await scrape(file.metadata.resourcePath);
+    } catch (e) {
+      console.log(e);
+      return file;
+    }
+    // metadata comes in with properties for each type of unfurl spec (twitter, openGraph etc)
+    const combinedMetadata = { ...metadata.twitter, ...metadata.openGraph };
+    // const metadata = await metascraper({ html, url });
     // update image to have resource path prepended to it if it is not https
-    if (metadata.image) {
-      metadata.image =
-        validUrl.isUri(metadata.image) !== undefined
-          ? metadata.image
-          : resolve(file.metadata.resourcePath, '/', metadata.image);
-      file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, metadata);
+    if (TypeCheck.isString(combinedMetadata.image)) {
+      if (validUrl.isWebUri(combinedMetadata.image) === undefined) {
+        combinedMetadata.image = url.resolve(file.metadata.resourcePath, combinedMetadata.image);
+      }
+
+      file.metadata.unfurl = createUnfurlObj(UNFURL_TYPES.EXTERNAL, combinedMetadata);
     }
   }
   return file;


### PR DESCRIPTION
# About
This is a composite issue.
### . Issue 1
twitter card images that were not absolute to the domain would not load in the devhub
### Issue 2
twitter card image properties were not being parsed correctly by the metascraper library

## Changes
- added some logic to the external unfurl plugin to preprend the domain if the image was !== /^https?/
- changed metascraping library for another one that seems to be more predictable