### PR TITLE
Fix hamburger visible on large screen issue

### DIFF
--- a/app-web/src/components/PrimaryHeader/PrimaryHeader.module.css
+++ b/app-web/src/components/PrimaryHeader/PrimaryHeader.module.css
@@ -19,7 +19,7 @@
     display: flex;
 }
 
-.Hamburger {
+.PrimaryHeader .Hamburger {
     cursor: pointer;
 }
 
@@ -29,7 +29,7 @@
     }
 }
 @media screen and (min-width: 750px) {
-    .Hamburger {
+    .PrimaryHeader .Hamburger {
         display: none;
     }
 }


### PR DESCRIPTION
## Summary
The Hamburger Icon was showing on large screen sizes because the CSS specificity that set `display: none;` was not specific enough.