### PR TITLE
Allow siphon to take multiple files

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
@@ -32,6 +32,7 @@ import {
   applyBaseMetadata,
   isConfigForFetchingAFile,
   isConfigForFetchingRepo,
+  isConfigForFetchingFiles,
   createFetchFileRoute,
 } from '../utils/fetchSourceGithub';
 // eslint-disable-next-line
@@ -386,6 +387,23 @@ describe('Github API', () => {
       owner: 'bar',
     };
     expect(isConfigForFetchingAFile(sourceProperties)).toBe(false);
+  });
+
+  test('isConfigForFetchingFiles returns true if source properties is for a files', () => {
+    const sourceProperties = {
+      repo: 'foo',
+      owner: 'bar',
+      files: ['/something/test.md'],
+    };
+    expect(isConfigForFetchingFiles(sourceProperties)).toBe(true);
+  });
+
+  test('isConfigForFetchingFiles returns false if source properties is not for a file', () => {
+    const sourceProperties = {
+      repo: 'foo',
+      owner: 'bar',
+    };
+    expect(isConfigForFetchingFiles(sourceProperties)).toBe(false);
   });
 
   test('createFetchFileRoute creates route', () => {

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -62,6 +62,16 @@ const isConfigForFetchingAFile = sourceProperties =>
   isConfigForFetchingRepo(sourceProperties);
 
 /**
+ * checks if the sourceProperties that are passed in are for siphoning
+ * a list of files
+ * @param {Object} sourceProperties
+ * @returns {Boolean}
+ */
+const isConfigForFetchingFiles = sourceProperties =>
+  Object.prototype.hasOwnProperty.call(sourceProperties, 'files') &&
+  isConfigForFetchingRepo(sourceProperties);
+
+/**
  * creates the GITHUB v3 contents api endpoint for a file
  * @param {String} repo
  * @param {String} owner
@@ -401,8 +411,11 @@ const fetchSourceGithub = async (
   if (isConfigForFetchingAFile(sourceProperties)) {
     const { file } = sourceProperties;
     filesToFetch = [createFetchFileRoute(repo, owner, file, branch)];
-    // eslint-disable-line
+  } else if (isConfigForFetchingFiles(sourceProperties)) {
+    // map files list to get fetch file uris
+    filesToFetch = sourceProperties.files.map(f => createFetchFileRoute(repo, owner, f, branch));
   } else if (isConfigForFetchingRepo(sourceProperties)) {
+    // get files based on the github tree and other configs
     filesToFetch = await getFilesFromRepo(sourceProperties, token);
   }
   // actually fetch file contents and transform
@@ -467,6 +480,7 @@ module.exports = {
   filterFilesByContext,
   isConfigForFetchingAFile,
   isConfigForFetchingRepo,
+  isConfigForFetchingFiles,
   applyBaseMetadata,
   validateSourceGithub,
 };


### PR DESCRIPTION
## Summary
Addition to the collection milestone, this allows for `files` to be passed in as a sourceProperty to the registry file
