### PR TITLE
Update deploy config to take #replicas by configuration

### DIFF
--- a/openshift/config.groovy
+++ b/openshift/config.groovy
@@ -76,6 +76,7 @@ app {
         ssoURL = "${vars.deployment.ssoURL}"
         ssoClient = "${vars.deployment.ssoClient}"
         ssoRealm = "${vars.deployment.ssoRealm}"
+        replicas = "${vars.deployment.replicas}"
 
         timeoutInSeconds = 60*20 // 20 minutes
         templates = [
@@ -88,7 +89,8 @@ app {
                         'HOST': app.deployment.host,
                         'SSO_BASE_URL_VALUE': app.deployment.ssoURL,
                         'SSO_CLIENT_ID_VALUE': app.deployment.ssoClient,
-                        'SSO_REALM_NAME_VALUE': app.deployment.ssoRealm
+                        'SSO_REALM_NAME_VALUE': app.deployment.ssoRealm,
+                        'REPLICAS': app.deployment.replicas
                     ]
                 ]
         ]
@@ -111,6 +113,7 @@ environments {
                 ssoURL = "https://sso-dev.pathfinder.gov.bc.ca"
                 ssoClient = "devhub-web-${opt.'pr'}"
                 ssoRealm = "devhub"
+                replicas = 1
             }
         }
     }
@@ -129,6 +132,7 @@ environments {
                 ssoURL = "https://sso-test.pathfinder.gov.bc.ca"
                 ssoClient = "devhub-web"
                 ssoRealm = "devhub"
+                replicas = 1
             }
         }
     }
@@ -148,6 +152,7 @@ environments {
                 ssoURL = "https://sso.pathfinder.gov.bc.ca"
                 ssoClient = "devhub-web"
                 ssoRealm = "devhub"
+                replicas = 2
             }
         }
     }

--- a/openshift/dc.yaml
+++ b/openshift/dc.yaml
@@ -20,7 +20,7 @@ objects:
     creationTimestamp: null
     name: ${NAME}-static${SUFFIX}
   spec:
-    replicas: 2
+    replicas: ${REPLICAS}
     selector:
       deploymentconfig: ${NAME}-static${SUFFIX}
     strategy:
@@ -147,3 +147,8 @@ parameters:
   name: VOLUMN_NAME
   required: false
   value: web-caddy-config
+- description: Number of replicas to start by default
+  displayName: replicas
+  name: REPLICAS
+  required: false
+  value: 2


### PR DESCRIPTION
Deploy config had replicas hardcoded to 2. 

Because of our github flow, all of the dev deployments would run with 2 replicas by default. In the event the dev deployment isn't cleaned up (after successful merge of a pr), having 2 replicas eats up ram faster than 1 would. This causes issues later down the road when attempting to deploy/redeploy later pull requests because the dev namespace has exceeded its quota for ram. 
