### PR TITLE
Imp/siphon inline ignores

### DIFF
--- a/app-web/__mocks__/ignore.js
+++ b/app-web/__mocks__/ignore.js
@@ -20,8 +20,7 @@ jest.requireActual('ignore');
 
 module.exports = () => ({
   add: function() {
-    console.log('mocked version called???');
     return this;
   }, // eslint-disable-line
-  ignores: jest.fn(() => 'poops'),
+  ignores: jest.fn(() => false),
 });

--- a/app-web/__mocks__/ignore.js
+++ b/app-web/__mocks__/ignore.js
@@ -20,7 +20,8 @@ jest.requireActual('ignore');
 
 module.exports = () => ({
   add: function() {
+    console.log('mocked version called???');
     return this;
   }, // eslint-disable-line
-  ignores: jest.fn(() => false),
+  ignores: jest.fn(() => 'poops'),
 });

--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -18,6 +18,9 @@
 // Created by Patrick Simonian on 2018-10-12.
 //
 
+// sample files that may be received when calling github v3 tree api
+// seperating them out in this obj so that we can recycle some of these properties
+// in tests as well as other fixtures
 const TREE_FILES = {
   FILE1: {
     path: 'docs/readme1.md',
@@ -49,6 +52,7 @@ const TREE_FILES = {
 };
 
 const GITHUB_API = {
+  // the actual tree object returns from github tree api
   TREE: {
     sha: 'fd0a8ca2b638662d565a20ba2947678e4fd3acee',
     url:
@@ -111,6 +115,7 @@ const GITHUB_API = {
       },
     ],
   },
+  // sample return from github contents api
   FILE: {
     name: 'manifest.json',
     path: 'public/manifest.json',
@@ -132,8 +137,8 @@ const GITHUB_API = {
       html: 'https://github.com/bcgov/range-web/blob/master/public/manifest.json',
     },
   },
+  // sample file from github contents file missing description front matter
   BAD_MD_FILE: {
-    // no description front matter (which is required)
     name: 'badfile.md',
     path: 'public/badfile.md',
     sha: 'ef19ec243e739479802a5553d0b38a18ed845307',
@@ -153,15 +158,18 @@ const GITHUB_API = {
       html: 'https://github.com/bcgov/range-web/blob/master/public/badfile.md',
     },
   },
+  // sample return from a failed github contents api get request
   FAIL: {
     message: 'Not Found',
     documentation_url: 'https://developer.github.com/v3',
   },
+  // sameple .devhubignore file from github contents api
   IGNORE_FILE: {
     content: 'file1\nfile2\nfile3',
   },
 };
 
+// file after being processed through fetchsourcegithub
 const PROCESSED_FILE_HTML = {
   name: 'index.html',
   path: 'components/header/index.html',
@@ -200,7 +208,9 @@ const PROCESSED_FILE_HTML = {
   },
 };
 
-// with resource path frontmatter
+// with resource path frontmatter, this file is destined not to create a page but
+// rather have a hyperlink to an external resource. That external resource is actually
+// unfurled by one of the file transformer plugins
 const RAW_FILE_MD_WITH_RESOURCEPATH = {
   name: 'README.md',
   path: 'components/header/README.md',
@@ -353,6 +363,7 @@ const PROCESSED_FILE_TXT = {
   },
 };
 
+// a sample registry file that has been processed by the gatsby-source-filesystem/gatbsy-transformer-yaml plugins
 const REGISTRY = {
   id: '/registry.yml absPath of file >>> YAML',
   sources: [
@@ -376,6 +387,7 @@ const REGISTRY = {
   },
 };
 
+// same as above but this registry contains a 'collection' type config
 const REGISTRY_WITH_COLLECTION = {
   id: '/registry.yml absPath of file >>> YAML',
   sources: [
@@ -413,6 +425,8 @@ const REGISTRY_WITH_COLLECTION = {
   },
 };
 
+// the result of an allFile graphql query, it is filtered in sourceNodes.js to find only the registry file
+// that matches the option passed into this source plugin
 const GRAPHQL_NODES_WITH_REGISTRY = [
   {
     id: '/registry.yml absPath of file >>> YAML',
@@ -435,6 +449,7 @@ const GRAPHQL_NODES_WITH_REGISTRY = [
   },
 ];
 
+// for testing when registry doesn't exist/can't be found
 const GRAPHQL_NODES_WITHOUT_REGISTRY = [
   {
     internal: {
@@ -448,6 +463,7 @@ const GRAPHQL_NODES_WITHOUT_REGISTRY = [
   },
 ];
 
+//  a sample registry 'item'
 const GITHUB_SOURCE = {
   name: 'Design System',
   sourceType: 'github',
@@ -461,6 +477,7 @@ const GITHUB_SOURCE = {
   },
 };
 
+// another sample registry 'item'
 const GITHUB_SOURCE_WITHIN_INLINE_IGNORES = {
   name: 'Design System',
   sourceType: 'github',
@@ -475,6 +492,7 @@ const GITHUB_SOURCE_WITHIN_INLINE_IGNORES = {
   },
 };
 
+// sample config options passed into this source plugin from gatsby-config.js
 const CONFIG_OPTIONS = {
   tokens: {
     GITHUB_API_TOKEN: '123',

--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -17,6 +17,37 @@
 //
 // Created by Patrick Simonian on 2018-10-12.
 //
+
+const TREE_FILES = {
+  FILE1: {
+    path: 'docs/readme1.md',
+    mode: '100644',
+    type: 'blob',
+    sha: 'c18275f23c101c5bf62ab9a4a332b774db37dfd1',
+    size: 857,
+    url:
+      'https://api.github.com/repos/bcgov/range-web/git/blobs/c18275f23c101c5bf62ab9a4a332b774db37dfd1',
+  },
+  FILE2: {
+    path: 'docs/readme2.md',
+    mode: '100644',
+    type: 'blob',
+    sha: 'c18275f23c101c5bf62ab9a4a332b774db37dfd1',
+    size: 857,
+    url:
+      'https://api.github.com/repos/bcgov/range-web/git/blobs/c18275f23c101c5bf62ab9a4a332b774db37dfd1',
+  },
+  FILE3: {
+    path: 'docs/readme3.md',
+    mode: '100644',
+    type: 'blob',
+    sha: 'c18275f23c101c5bf62ab9a4a332b774db37dfd1',
+    size: 857,
+    url:
+      'https://api.github.com/repos/bcgov/range-web/git/blobs/c18275f23c101c5bf62ab9a4a332b774db37dfd1',
+  },
+};
+
 const GITHUB_API = {
   TREE: {
     sha: 'fd0a8ca2b638662d565a20ba2947678e4fd3acee',
@@ -32,33 +63,9 @@ const GITHUB_API = {
         url:
           'https://api.github.com/repos/bcgov/range-web/git/blobs/c18275f23c101c5bf62ab9a4a332b774db37dfd1',
       },
-      {
-        path: '/docs/readme1.md',
-        mode: '100644',
-        type: 'blob',
-        sha: 'c18275f23c101c5bf62ab9a4a332b774db37dfd1',
-        size: 857,
-        url:
-          'https://api.github.com/repos/bcgov/range-web/git/blobs/c18275f23c101c5bf62ab9a4a332b774db37dfd1',
-      },
-      {
-        path: '/docs/readme2.md',
-        mode: '100644',
-        type: 'blob',
-        sha: 'c18275f23c101c5bf62ab9a4a332b774db37dfd1',
-        size: 857,
-        url:
-          'https://api.github.com/repos/bcgov/range-web/git/blobs/c18275f23c101c5bf62ab9a4a332b774db37dfd1',
-      },
-      {
-        path: '/docs/readme3.md',
-        mode: '100644',
-        type: 'blob',
-        sha: 'c18275f23c101c5bf62ab9a4a332b774db37dfd1',
-        size: 857,
-        url:
-          'https://api.github.com/repos/bcgov/range-web/git/blobs/c18275f23c101c5bf62ab9a4a332b774db37dfd1',
-      },
+      TREE_FILES.FILE1,
+      TREE_FILES.FILE2,
+      TREE_FILES.FILE3,
       {
         path: '.gitignore',
         mode: '100644',
@@ -151,7 +158,7 @@ const GITHUB_API = {
     documentation_url: 'https://developer.github.com/v3',
   },
   IGNORE_FILE: {
-    content: 'file1 file2 file3',
+    content: 'file1\nfile2\nfile3',
   },
 };
 
@@ -454,6 +461,20 @@ const GITHUB_SOURCE = {
   },
 };
 
+const GITHUB_SOURCE_WITHIN_INLINE_IGNORES = {
+  name: 'Design System',
+  sourceType: 'github',
+  sourceProperties: {
+    owner: 'bcgov',
+    repo: 'design-system',
+    url: 'https://github.com/bcgov/design-system/',
+    ignores: ['docs/readme1.md'],
+  },
+  attributes: {
+    labels: ['components'],
+  },
+};
+
 const CONFIG_OPTIONS = {
   tokens: {
     GITHUB_API_TOKEN: '123',
@@ -473,5 +494,7 @@ module.exports = {
   REGISTRY,
   REGISTRY_WITH_COLLECTION,
   GITHUB_SOURCE,
+  GITHUB_SOURCE_WITHIN_INLINE_IGNORES,
   CONFIG_OPTIONS,
+  TREE_FILES,
 };

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
@@ -1,7 +1,12 @@
 import fetch from 'node-fetch'; // eslint-disable-line
-import { fetchSourceGithub } from '../utils/fetchSourceGithub';
-import { GITHUB_API, GITHUB_SOURCE } from '../__fixtures__/fixtures';
-
+import { fetchSourceGithub, createFetchFileRoute } from '../utils/fetchSourceGithub';
+import {
+  GITHUB_API,
+  GITHUB_SOURCE,
+  GITHUB_SOURCE_WITHIN_INLINE_IGNORES,
+  TREE_FILES,
+} from '../__fixtures__/fixtures';
+jest.unmock('ignore');
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch');
 // mock console logs so that any error logs are not outputed during suite
@@ -13,18 +18,111 @@ global.console = {
 // eslint-disable-next-line
 
 describe('Integration github api module', () => {
+  beforeEach(() => {
+    // reset calls to fetch for each test
+    fetch.mockReset();
+  });
+
   it('returns a list of files', async () => {
     // mock out concurrent requests to githup api
     fetch
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.TREE)))) // first for getting tree
-      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.IGNORE_FILE))))
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))));
 
-    const files = await fetchSourceGithub(GITHUB_SOURCE);
+    const files = await fetchSourceGithub(GITHUB_SOURCE, 'TOKEN');
     expect(files).toBeInstanceOf(Array);
     expect(files.length).toBe(3);
+  });
+
+  it('returns a list of files filtered by devhubignore', async () => {
+    fetch
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.TREE)))) // first for getting tree
+      .mockReturnValueOnce(
+        Promise.resolve(new Response(JSON.stringify({ content: TREE_FILES.FILE2.path }))),
+      )
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))));
+
+    const files = await fetchSourceGithub(GITHUB_SOURCE, 'TOKEN');
+    const { repo, owner } = GITHUB_SOURCE_WITHIN_INLINE_IGNORES.sourceProperties;
+    const fetchFile1Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE1.path);
+    const fetchFile2Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE2.path);
+    const fetchFile3Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE3.path);
+
+    expect(fetch).toHaveBeenCalledWith(fetchFile1Route, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer TOKEN`,
+        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+      },
+    });
+
+    // this one should not be called with fetchFile2 route
+    expect(fetch).not.toHaveBeenCalledWith(fetchFile2Route, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer TOKEN`,
+        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(fetchFile3Route, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer TOKEN`,
+        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+      },
+    });
+
+    expect(files.length).toBe(2);
+  });
+
+  it('returns a list of files filtered by inline ignores', async () => {
+    fetch
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.TREE)))) // first for getting tree
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.IGNORE_FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))));
+
+    const files = await fetchSourceGithub(GITHUB_SOURCE_WITHIN_INLINE_IGNORES, 'TOKEN');
+    const { repo, owner } = GITHUB_SOURCE_WITHIN_INLINE_IGNORES.sourceProperties;
+    const fetchFile1Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE1.path);
+    const fetchFile2Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE2.path);
+    const fetchFile3Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE3.path);
+
+    // github source with inline ignores, has an inline ignore for the file 1 path (see fixtures)
+    // we should expect fetch is not called with that file
+
+    expect(fetch).not.toHaveBeenCalledWith(fetchFile1Route, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer TOKEN`,
+        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(fetchFile2Route, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer TOKEN`,
+        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(fetchFile3Route, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer TOKEN`,
+        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+      },
+    });
+
+    expect(files.length).toBe(2);
   });
 
   it('returns a list of files even if some fail', async () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.itest.js
@@ -38,8 +38,13 @@ describe('Integration github api module', () => {
   });
 
   it('returns a list of files filtered by devhubignore', async () => {
+    // because fetch is called in multiple places we are mocking out each call to it with a different
+    // return from the github api
+    // first call: get the github tree
+    // second call: is a mock .devhubignore that is 'ignoring' path to file2
+    // third, fourth, fifth: are files from the contents api
     fetch
-      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.TREE)))) // first for getting tree
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.TREE))))
       .mockReturnValueOnce(
         Promise.resolve(new Response(JSON.stringify({ content: TREE_FILES.FILE2.path }))),
       )
@@ -48,6 +53,10 @@ describe('Integration github api module', () => {
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))));
 
     const files = await fetchSourceGithub(GITHUB_SOURCE, 'TOKEN');
+
+    // build out fetch paths for each file that would have been returned from the GITHUB_API.TREE
+    // because of the devhubignore file that was returned, we'd expect FILE2 path to not be passed into
+    // fetch
     const { repo, owner } = GITHUB_SOURCE_WITHIN_INLINE_IGNORES.sourceProperties;
     const fetchFile1Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE1.path);
     const fetchFile2Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE2.path);
@@ -90,6 +99,7 @@ describe('Integration github api module', () => {
       .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(GITHUB_API.FILE))));
 
     const files = await fetchSourceGithub(GITHUB_SOURCE_WITHIN_INLINE_IGNORES, 'TOKEN');
+
     const { repo, owner } = GITHUB_SOURCE_WITHIN_INLINE_IGNORES.sourceProperties;
     const fetchFile1Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE1.path);
     const fetchFile2Route = createFetchFileRoute(repo, owner, TREE_FILES.FILE2.path);

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
@@ -415,10 +415,4 @@ describe('Github API', () => {
       `${GITHUB_API_ENDPOINT}/repos/bar/foo/contents/doc.md?ref=develop`,
     );
   });
-
-  test('processIgnores removes leading forward slashes', () => {
-    const expected = ['docs'];
-    expect(processIgnores(['/docs'])).toEqual(expected);
-    expect(processIgnores(['//docs'])).toEqual(expected);
-  });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
@@ -34,6 +34,7 @@ import {
   isConfigForFetchingRepo,
   isConfigForFetchingFiles,
   createFetchFileRoute,
+  processIgnores,
 } from '../utils/fetchSourceGithub';
 // eslint-disable-next-line
 import { GITHUB_API_ENDPOINT } from '../utils/constants';
@@ -413,5 +414,11 @@ describe('Github API', () => {
     expect(createFetchFileRoute('foo', 'bar', 'doc.md', 'develop')).toBe(
       `${GITHUB_API_ENDPOINT}/repos/bar/foo/contents/doc.md?ref=develop`,
     );
+  });
+
+  test('processIgnores removes leading forward slashes', () => {
+    const expected = ['docs'];
+    expect(processIgnores(['/docs'])).toEqual(expected);
+    expect(processIgnores(['//docs'])).toEqual(expected);
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/utils/constants.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants.js
@@ -61,6 +61,7 @@ const DEFUALT_IGNORES = [
   'CODE OF CONDUCT.md',
   '/openshift',
   '/.github',
+  '.github',
 ];
 // github rest api v3
 const GITHUB_API_ENDPOINT = 'https://api.github.com';

--- a/app-web/plugins/gatsby-source-github-all/utils/constants.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants.js
@@ -163,6 +163,16 @@ const GITHUB_SOURCE_SCHEMA = {
     type: Array,
     required: false,
   },
+  // branch to base fetch off of
+  branch: {
+    type: String,
+    required: false,
+  },
+  // inline devhubignores
+  ignores: {
+    type: Array,
+    required: false,
+  },
 };
 
 module.exports = {

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSourceGithub.js
@@ -310,14 +310,6 @@ const filterFiles = (files, ignoreObj, contextDir) => {
 };
 
 /**
- * removes leading '/' from paths in ignores
- * @param {Array} ignores
- */
-const processIgnores = ignores => {
-  // ignores have to be relative paths
-  return ignores.map(i => i.replace(/^\/+/, ''));
-};
-/**
  * returns the list of files to be fetched
  * @param {Object} repo the repo data (comes from the registry)
  * is deconstructed into its components
@@ -340,10 +332,10 @@ const getFilesFromRepo = async ({ repo, owner, branch, context, ignores }, token
     let files = filterFilesFromDirectories(data.tree);
     // fetch ignore file if exists
     const repoIgnores = await fetchIgnoreFile(repo, owner, token, branch);
-    ig.add(processIgnores(repoIgnores));
+    ig.add(repoIgnores);
     // if ignores was passed into source params add them into the ignores list
     if (ignores) {
-      ig.add(processIgnores(ignores));
+      ig.add(ignores);
     }
     // pass files to filter routine with ignore object and specified context paths
     const filesToFetch = filterFiles(files, ig, context);
@@ -493,5 +485,4 @@ module.exports = {
   isConfigForFetchingFiles,
   applyBaseMetadata,
   validateSourceGithub,
-  processIgnores,
 };


### PR DESCRIPTION
## Summary
Add Support for siphon to ignore files from a repo by configuration instead of having to create/use a `.devhubignore` files

## Notable Changes <!-- if any -->
- I noticed many of the integration tests were actually **broken** because some of the 3rd party libraries were still being mocked out. This has been rectified. 
- Additional integration tests for testing the 'ignore' configurations were added
- Inside the registry `yaml` file, a registration can now be config'd like so
```yaml
- name: Patricks Design Systen
    sourceType: 'github'
    sourceProperties:
      url: https://github.com/bcgov/devhub-app-web/
      owner: patricksimonian
      repo: 'design-system'
      ignores:
        - components/
        - /README.md
    resourceType: 'Components'
    attributes:
      labels:
        - Repository
      persona: 'Developer'
```

