### PR TITLE
On click of the card filter button, it scrolls to card container

### DIFF
--- a/app-web/__tests__/components/__snapshots__/CardFilterButton.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/CardFilterButton.test.js.snap
@@ -9,6 +9,7 @@ ShallowWrapper {
     filterNodes={[MockFunction]}
     filterSiphonNodes={[MockFunction]}
     resetfilter={[MockFunction]}
+    scrollToTarget=""
   >
     
   </CardFilterButton>,

--- a/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
+++ b/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
@@ -162,12 +162,14 @@ ShallowWrapper {
               <Connect(CardFilterButton)
                 className="btn btn-outline-primary PersonaButton"
                 filterKey="2"
+                scrollToTarget="CARDS_CONTAINER"
               >
                 I'm a Developer
               </Connect(CardFilterButton)>
               <Connect(CardFilterButton)
                 className="btn btn-outline-success PersonaButton"
                 filterKey="1"
+                scrollToTarget="CARDS_CONTAINER"
               >
                 I'm a Designer
               </Connect(CardFilterButton)>
@@ -198,153 +200,157 @@ ShallowWrapper {
                repository.
             </p>
           </section>
-          <div
-            className="ListContainer"
+          <Element
+            name="CARDS_CONTAINER"
           >
-            <SecondaryFilter
-              filterGroups={
-                Array [
-                  Object {
-                    "data": Array [
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "foo",
-                        "text": "Designers",
-                        "title": "For",
-                        "value": "Designer",
-                      },
-                      Object {
-                        "active": true,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "bar",
-                        "text": "Developers",
-                        "title": "For",
-                        "value": "Developer",
-                      },
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "baz",
-                        "text": "Product Owners",
-                        "title": "For",
-                        "value": "Product Owner",
-                      },
-                    ],
-                    "filters": Array [
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "foo",
-                        "text": "Designers",
-                        "title": "For",
-                        "value": "Designer",
-                      },
-                      Object {
-                        "active": true,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "bar",
-                        "text": "Developers",
-                        "title": "For",
-                        "value": "Developer",
-                      },
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "baz",
-                        "text": "Product Owners",
-                        "title": "For",
-                        "value": "Product Owner",
-                      },
-                    ],
-                    "title": "For",
-                  },
-                ]
-              }
-              mobile={false}
-            />
-            <SecondaryFilter
-              filterGroups={
-                Array [
-                  Object {
-                    "data": Array [
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "foo",
-                        "text": "Designers",
-                        "title": "For",
-                        "value": "Designer",
-                      },
-                      Object {
-                        "active": true,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "bar",
-                        "text": "Developers",
-                        "title": "For",
-                        "value": "Developer",
-                      },
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "baz",
-                        "text": "Product Owners",
-                        "title": "For",
-                        "value": "Product Owner",
-                      },
-                    ],
-                    "filters": Array [
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "foo",
-                        "text": "Designers",
-                        "title": "For",
-                        "value": "Designer",
-                      },
-                      Object {
-                        "active": true,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "bar",
-                        "text": "Developers",
-                        "title": "For",
-                        "value": "Developer",
-                      },
-                      Object {
-                        "active": false,
-                        "availableResources": null,
-                        "filterBy": "attributes.persona",
-                        "key": "baz",
-                        "text": "Product Owners",
-                        "title": "For",
-                        "value": "Product Owner",
-                      },
-                    ],
-                    "title": "For",
-                  },
-                ]
-              }
-              mobile={true}
-            />
             <div
-              className="CardContainer"
+              className="ListContainer"
             >
-              <Flag
-                name="features.githubResourceCards"
+              <SecondaryFilter
+                filterGroups={
+                  Array [
+                    Object {
+                      "data": Array [
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "foo",
+                          "text": "Designers",
+                          "title": "For",
+                          "value": "Designer",
+                        },
+                        Object {
+                          "active": true,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "bar",
+                          "text": "Developers",
+                          "title": "For",
+                          "value": "Developer",
+                        },
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "baz",
+                          "text": "Product Owners",
+                          "title": "For",
+                          "value": "Product Owner",
+                        },
+                      ],
+                      "filters": Array [
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "foo",
+                          "text": "Designers",
+                          "title": "For",
+                          "value": "Designer",
+                        },
+                        Object {
+                          "active": true,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "bar",
+                          "text": "Developers",
+                          "title": "For",
+                          "value": "Developer",
+                        },
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "baz",
+                          "text": "Product Owners",
+                          "title": "For",
+                          "value": "Product Owner",
+                        },
+                      ],
+                      "title": "For",
+                    },
+                  ]
+                }
+                mobile={false}
               />
+              <SecondaryFilter
+                filterGroups={
+                  Array [
+                    Object {
+                      "data": Array [
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "foo",
+                          "text": "Designers",
+                          "title": "For",
+                          "value": "Designer",
+                        },
+                        Object {
+                          "active": true,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "bar",
+                          "text": "Developers",
+                          "title": "For",
+                          "value": "Developer",
+                        },
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "baz",
+                          "text": "Product Owners",
+                          "title": "For",
+                          "value": "Product Owner",
+                        },
+                      ],
+                      "filters": Array [
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "foo",
+                          "text": "Designers",
+                          "title": "For",
+                          "value": "Designer",
+                        },
+                        Object {
+                          "active": true,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "bar",
+                          "text": "Developers",
+                          "title": "For",
+                          "value": "Developer",
+                        },
+                        Object {
+                          "active": false,
+                          "availableResources": null,
+                          "filterBy": "attributes.persona",
+                          "key": "baz",
+                          "text": "Product Owners",
+                          "title": "For",
+                          "value": "Product Owner",
+                        },
+                      ],
+                      "title": "For",
+                    },
+                  ]
+                }
+                mobile={true}
+              />
+              <div
+                className="CardContainer"
+              >
+                <Flag
+                  name="features.githubResourceCards"
+                />
+              </div>
             </div>
-          </div>
+          </Element>
         </main>,
       ],
       "hamburgerClicked": undefined,
@@ -409,12 +415,14 @@ ShallowWrapper {
                 <Connect(CardFilterButton)
                   className="btn btn-outline-primary PersonaButton"
                   filterKey="2"
+                  scrollToTarget="CARDS_CONTAINER"
                 >
                   I'm a Developer
                 </Connect(CardFilterButton)>
                 <Connect(CardFilterButton)
                   className="btn btn-outline-success PersonaButton"
                   filterKey="1"
+                  scrollToTarget="CARDS_CONTAINER"
                 >
                   I'm a Designer
                 </Connect(CardFilterButton)>
@@ -445,1071 +453,9 @@ ShallowWrapper {
                  repository.
               </p>
             </section>,
-            <div
-              className="ListContainer"
+            <Element
+              name="CARDS_CONTAINER"
             >
-              <SecondaryFilter
-                filterGroups={
-                  Array [
-                    Object {
-                      "data": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "filters": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "title": "For",
-                    },
-                  ]
-                }
-                mobile={false}
-              />
-              <SecondaryFilter
-                filterGroups={
-                  Array [
-                    Object {
-                      "data": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "filters": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "title": "For",
-                    },
-                  ]
-                }
-                mobile={true}
-              />
-              <div
-                className="CardContainer"
-              >
-                <Flag
-                  name="features.githubResourceCards"
-                />
-              </div>
-            </div>,
-          ],
-          "className": "Main container",
-          "role": "main",
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <h1
-                  className="jumbotron-heading"
-                >
-                  Welcome.
-                </h1>,
-                <h3>
-                   We are here to help.
-                </h3>,
-                <p
-                  className="lead"
-                >
-                  This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
-                </p>,
-                <p>
-                  In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
-                </p>,
-                <div
-                  className="d-flex justify-content-center align-items-center"
-                >
-                  <Connect(CardFilterButton)
-                    className="btn btn-outline-primary PersonaButton"
-                    filterKey="2"
-                  >
-                    I'm a Developer
-                  </Connect(CardFilterButton)>
-                  <Connect(CardFilterButton)
-                    className="btn btn-outline-success PersonaButton"
-                    filterKey="1"
-                  >
-                    I'm a Designer
-                  </Connect(CardFilterButton)>
-                </div>,
-                <blockquote
-                  className="blockquote"
-                >
-                  <p
-                    className="mb-0"
-                  >
-                    Thanks for visiting!
-                  </p>
-                  <footer
-                    className="blockquote-footer"
-                  >
-                    The DevHub Team.
-                  </footer>
-                </blockquote>,
-                <p
-                  className="text-muted"
-                >
-                  PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
-                  <a
-                    href="https://github.com/bcgov/devhub-app-web/issues"
-                  >
-                    GitHub
-                  </a>
-                   repository.
-                </p>,
-              ],
-              "className": "jumbotron text-center",
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "Welcome.",
-                  "className": "jumbotron-heading",
-                },
-                "ref": null,
-                "rendered": "Welcome.",
-                "type": "h1",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": " We are here to help.",
-                },
-                "ref": null,
-                "rendered": " We are here to help.",
-                "type": "h3",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
-                  "className": "lead",
-                },
-                "ref": null,
-                "rendered": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
-                "type": "p",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
-                },
-                "ref": null,
-                "rendered": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
-                "type": "p",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <Connect(CardFilterButton)
-                      className="btn btn-outline-primary PersonaButton"
-                      filterKey="2"
-                    >
-                      I'm a Developer
-                    </Connect(CardFilterButton)>,
-                    <Connect(CardFilterButton)
-                      className="btn btn-outline-success PersonaButton"
-                      filterKey="1"
-                    >
-                      I'm a Designer
-                    </Connect(CardFilterButton)>,
-                  ],
-                  "className": "d-flex justify-content-center align-items-center",
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "class",
-                    "props": Object {
-                      "children": "I'm a Developer",
-                      "className": "btn btn-outline-primary PersonaButton",
-                      "filterKey": "2",
-                    },
-                    "ref": null,
-                    "rendered": "I'm a Developer",
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "class",
-                    "props": Object {
-                      "children": "I'm a Designer",
-                      "className": "btn btn-outline-success PersonaButton",
-                      "filterKey": "1",
-                    },
-                    "ref": null,
-                    "rendered": "I'm a Designer",
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <p
-                      className="mb-0"
-                    >
-                      Thanks for visiting!
-                    </p>,
-                    <footer
-                      className="blockquote-footer"
-                    >
-                      The DevHub Team.
-                    </footer>,
-                  ],
-                  "className": "blockquote",
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Thanks for visiting!",
-                      "className": "mb-0",
-                    },
-                    "ref": null,
-                    "rendered": "Thanks for visiting!",
-                    "type": "p",
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "The DevHub Team.",
-                      "className": "blockquote-footer",
-                    },
-                    "ref": null,
-                    "rendered": "The DevHub Team.",
-                    "type": "footer",
-                  },
-                ],
-                "type": "blockquote",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
-                    <a
-                      href="https://github.com/bcgov/devhub-app-web/issues"
-                    >
-                      GitHub
-                    </a>,
-                    " repository.",
-                  ],
-                  "className": "text-muted",
-                },
-                "ref": null,
-                "rendered": Array [
-                  "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "GitHub",
-                      "href": "https://github.com/bcgov/devhub-app-web/issues",
-                    },
-                    "ref": null,
-                    "rendered": "GitHub",
-                    "type": "a",
-                  },
-                  " repository.",
-                ],
-                "type": "p",
-              },
-            ],
-            "type": "section",
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <SecondaryFilter
-                  filterGroups={
-                    Array [
-                      Object {
-                        "data": Array [
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "foo",
-                            "text": "Designers",
-                            "title": "For",
-                            "value": "Designer",
-                          },
-                          Object {
-                            "active": true,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "bar",
-                            "text": "Developers",
-                            "title": "For",
-                            "value": "Developer",
-                          },
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "baz",
-                            "text": "Product Owners",
-                            "title": "For",
-                            "value": "Product Owner",
-                          },
-                        ],
-                        "filters": Array [
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "foo",
-                            "text": "Designers",
-                            "title": "For",
-                            "value": "Designer",
-                          },
-                          Object {
-                            "active": true,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "bar",
-                            "text": "Developers",
-                            "title": "For",
-                            "value": "Developer",
-                          },
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "baz",
-                            "text": "Product Owners",
-                            "title": "For",
-                            "value": "Product Owner",
-                          },
-                        ],
-                        "title": "For",
-                      },
-                    ]
-                  }
-                  mobile={false}
-                />,
-                <SecondaryFilter
-                  filterGroups={
-                    Array [
-                      Object {
-                        "data": Array [
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "foo",
-                            "text": "Designers",
-                            "title": "For",
-                            "value": "Designer",
-                          },
-                          Object {
-                            "active": true,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "bar",
-                            "text": "Developers",
-                            "title": "For",
-                            "value": "Developer",
-                          },
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "baz",
-                            "text": "Product Owners",
-                            "title": "For",
-                            "value": "Product Owner",
-                          },
-                        ],
-                        "filters": Array [
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "foo",
-                            "text": "Designers",
-                            "title": "For",
-                            "value": "Designer",
-                          },
-                          Object {
-                            "active": true,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "bar",
-                            "text": "Developers",
-                            "title": "For",
-                            "value": "Developer",
-                          },
-                          Object {
-                            "active": false,
-                            "availableResources": null,
-                            "filterBy": "attributes.persona",
-                            "key": "baz",
-                            "text": "Product Owners",
-                            "title": "For",
-                            "value": "Product Owner",
-                          },
-                        ],
-                        "title": "For",
-                      },
-                    ]
-                  }
-                  mobile={true}
-                />,
-                <div
-                  className="CardContainer"
-                >
-                  <Flag
-                    name="features.githubResourceCards"
-                  />
-                </div>,
-              ],
-              "className": "ListContainer",
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "filterGroups": Array [
-                    Object {
-                      "data": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "filters": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "title": "For",
-                    },
-                  ],
-                  "mobile": false,
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "filterGroups": Array [
-                    Object {
-                      "data": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "filters": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "title": "For",
-                    },
-                  ],
-                  "mobile": true,
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <Flag
-                    name="features.githubResourceCards"
-                  />,
-                  "className": "CardContainer",
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "children": Array [],
-                    "name": "features.githubResourceCards",
-                  },
-                  "ref": null,
-                  "rendered": Array [],
-                  "type": [Function],
-                },
-                "type": "div",
-              },
-            ],
-            "type": "div",
-          },
-        ],
-        "type": "main",
-      },
-    ],
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "class",
-      "props": Object {
-        "children": Array [
-          <Flag
-            name="features.sourceFiltering"
-          >
-            <Connect(PrimaryFilter) />
-          </Flag>,
-          <main
-            className="Main container"
-            role="main"
-          >
-            <section
-              className="jumbotron text-center"
-            >
-              <h1
-                className="jumbotron-heading"
-              >
-                Welcome.
-              </h1>
-              <h3>
-                 We are here to help.
-              </h3>
-              <p
-                className="lead"
-              >
-                This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
-              </p>
-              <p>
-                In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
-              </p>
-              <div
-                className="d-flex justify-content-center align-items-center"
-              >
-                <Connect(CardFilterButton)
-                  className="btn btn-outline-primary PersonaButton"
-                  filterKey="2"
-                >
-                  I'm a Developer
-                </Connect(CardFilterButton)>
-                <Connect(CardFilterButton)
-                  className="btn btn-outline-success PersonaButton"
-                  filterKey="1"
-                >
-                  I'm a Designer
-                </Connect(CardFilterButton)>
-              </div>
-              <blockquote
-                className="blockquote"
-              >
-                <p
-                  className="mb-0"
-                >
-                  Thanks for visiting!
-                </p>
-                <footer
-                  className="blockquote-footer"
-                >
-                  The DevHub Team.
-                </footer>
-              </blockquote>
-              <p
-                className="text-muted"
-              >
-                PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
-                <a
-                  href="https://github.com/bcgov/devhub-app-web/issues"
-                >
-                  GitHub
-                </a>
-                 repository.
-              </p>
-            </section>
-            <div
-              className="ListContainer"
-            >
-              <SecondaryFilter
-                filterGroups={
-                  Array [
-                    Object {
-                      "data": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "filters": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "title": "For",
-                    },
-                  ]
-                }
-                mobile={false}
-              />
-              <SecondaryFilter
-                filterGroups={
-                  Array [
-                    Object {
-                      "data": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "filters": Array [
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "foo",
-                          "text": "Designers",
-                          "title": "For",
-                          "value": "Designer",
-                        },
-                        Object {
-                          "active": true,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "bar",
-                          "text": "Developers",
-                          "title": "For",
-                          "value": "Developer",
-                        },
-                        Object {
-                          "active": false,
-                          "availableResources": null,
-                          "filterBy": "attributes.persona",
-                          "key": "baz",
-                          "text": "Product Owners",
-                          "title": "For",
-                          "value": "Product Owner",
-                        },
-                      ],
-                      "title": "For",
-                    },
-                  ]
-                }
-                mobile={true}
-              />
-              <div
-                className="CardContainer"
-              >
-                <Flag
-                  name="features.githubResourceCards"
-                />
-              </div>
-            </div>
-          </main>,
-        ],
-        "hamburgerClicked": undefined,
-        "showHamburger": true,
-      },
-      "ref": null,
-      "rendered": Array [
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "children": Array [
-              <Connect(PrimaryFilter) />,
-              null,
-            ],
-            "name": "features.sourceFiltering",
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {},
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            null,
-          ],
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": Array [
-              <section
-                className="jumbotron text-center"
-              >
-                <h1
-                  className="jumbotron-heading"
-                >
-                  Welcome.
-                </h1>
-                <h3>
-                   We are here to help.
-                </h3>
-                <p
-                  className="lead"
-                >
-                  This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
-                </p>
-                <p>
-                  In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
-                </p>
-                <div
-                  className="d-flex justify-content-center align-items-center"
-                >
-                  <Connect(CardFilterButton)
-                    className="btn btn-outline-primary PersonaButton"
-                    filterKey="2"
-                  >
-                    I'm a Developer
-                  </Connect(CardFilterButton)>
-                  <Connect(CardFilterButton)
-                    className="btn btn-outline-success PersonaButton"
-                    filterKey="1"
-                  >
-                    I'm a Designer
-                  </Connect(CardFilterButton)>
-                </div>
-                <blockquote
-                  className="blockquote"
-                >
-                  <p
-                    className="mb-0"
-                  >
-                    Thanks for visiting!
-                  </p>
-                  <footer
-                    className="blockquote-footer"
-                  >
-                    The DevHub Team.
-                  </footer>
-                </blockquote>
-                <p
-                  className="text-muted"
-                >
-                  PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
-                  <a
-                    href="https://github.com/bcgov/devhub-app-web/issues"
-                  >
-                    GitHub
-                  </a>
-                   repository.
-                </p>
-              </section>,
               <div
                 className="ListContainer"
               >
@@ -1656,266 +602,428 @@ ShallowWrapper {
                     name="features.githubResourceCards"
                   />
                 </div>
-              </div>,
-            ],
-            "className": "Main container",
-            "role": "main",
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <h1
-                    className="jumbotron-heading"
+              </div>
+            </Element>,
+          ],
+          "className": "Main container",
+          "role": "main",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <h1
+                  className="jumbotron-heading"
+                >
+                  Welcome.
+                </h1>,
+                <h3>
+                   We are here to help.
+                </h3>,
+                <p
+                  className="lead"
+                >
+                  This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
+                </p>,
+                <p>
+                  In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
+                </p>,
+                <div
+                  className="d-flex justify-content-center align-items-center"
+                >
+                  <Connect(CardFilterButton)
+                    className="btn btn-outline-primary PersonaButton"
+                    filterKey="2"
+                    scrollToTarget="CARDS_CONTAINER"
                   >
-                    Welcome.
-                  </h1>,
-                  <h3>
-                     We are here to help.
-                  </h3>,
+                    I'm a Developer
+                  </Connect(CardFilterButton)>
+                  <Connect(CardFilterButton)
+                    className="btn btn-outline-success PersonaButton"
+                    filterKey="1"
+                    scrollToTarget="CARDS_CONTAINER"
+                  >
+                    I'm a Designer
+                  </Connect(CardFilterButton)>
+                </div>,
+                <blockquote
+                  className="blockquote"
+                >
                   <p
-                    className="lead"
+                    className="mb-0"
                   >
-                    This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
-                  </p>,
-                  <p>
-                    In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
-                  </p>,
-                  <div
-                    className="d-flex justify-content-center align-items-center"
+                    Thanks for visiting!
+                  </p>
+                  <footer
+                    className="blockquote-footer"
                   >
+                    The DevHub Team.
+                  </footer>
+                </blockquote>,
+                <p
+                  className="text-muted"
+                >
+                  PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
+                  <a
+                    href="https://github.com/bcgov/devhub-app-web/issues"
+                  >
+                    GitHub
+                  </a>
+                   repository.
+                </p>,
+              ],
+              "className": "jumbotron text-center",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Welcome.",
+                  "className": "jumbotron-heading",
+                },
+                "ref": null,
+                "rendered": "Welcome.",
+                "type": "h1",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": " We are here to help.",
+                },
+                "ref": null,
+                "rendered": " We are here to help.",
+                "type": "h3",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
+                  "className": "lead",
+                },
+                "ref": null,
+                "rendered": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
+                "type": "p",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
+                },
+                "ref": null,
+                "rendered": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
+                "type": "p",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
                     <Connect(CardFilterButton)
                       className="btn btn-outline-primary PersonaButton"
                       filterKey="2"
+                      scrollToTarget="CARDS_CONTAINER"
                     >
                       I'm a Developer
-                    </Connect(CardFilterButton)>
+                    </Connect(CardFilterButton)>,
                     <Connect(CardFilterButton)
                       className="btn btn-outline-success PersonaButton"
                       filterKey="1"
+                      scrollToTarget="CARDS_CONTAINER"
                     >
                       I'm a Designer
-                    </Connect(CardFilterButton)>
-                  </div>,
-                  <blockquote
-                    className="blockquote"
-                  >
+                    </Connect(CardFilterButton)>,
+                  ],
+                  "className": "d-flex justify-content-center align-items-center",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": "I'm a Developer",
+                      "className": "btn btn-outline-primary PersonaButton",
+                      "filterKey": "2",
+                      "scrollToTarget": "CARDS_CONTAINER",
+                    },
+                    "ref": null,
+                    "rendered": "I'm a Developer",
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": "I'm a Designer",
+                      "className": "btn btn-outline-success PersonaButton",
+                      "filterKey": "1",
+                      "scrollToTarget": "CARDS_CONTAINER",
+                    },
+                    "ref": null,
+                    "rendered": "I'm a Designer",
+                    "type": [Function],
+                  },
+                ],
+                "type": "div",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
                     <p
                       className="mb-0"
                     >
                       Thanks for visiting!
-                    </p>
+                    </p>,
                     <footer
                       className="blockquote-footer"
                     >
                       The DevHub Team.
-                    </footer>
-                  </blockquote>,
-                  <p
-                    className="text-muted"
-                  >
-                    PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
+                    </footer>,
+                  ],
+                  "className": "blockquote",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Thanks for visiting!",
+                      "className": "mb-0",
+                    },
+                    "ref": null,
+                    "rendered": "Thanks for visiting!",
+                    "type": "p",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "The DevHub Team.",
+                      "className": "blockquote-footer",
+                    },
+                    "ref": null,
+                    "rendered": "The DevHub Team.",
+                    "type": "footer",
+                  },
+                ],
+                "type": "blockquote",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
                     <a
                       href="https://github.com/bcgov/devhub-app-web/issues"
                     >
                       GitHub
-                    </a>
-                     repository.
-                  </p>,
-                ],
-                "className": "jumbotron text-center",
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "Welcome.",
-                    "className": "jumbotron-heading",
-                  },
-                  "ref": null,
-                  "rendered": "Welcome.",
-                  "type": "h1",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": " We are here to help.",
-                  },
-                  "ref": null,
-                  "rendered": " We are here to help.",
-                  "type": "h3",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
-                    "className": "lead",
-                  },
-                  "ref": null,
-                  "rendered": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
-                  "type": "p",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
-                  },
-                  "ref": null,
-                  "rendered": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
-                  "type": "p",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <Connect(CardFilterButton)
-                        className="btn btn-outline-primary PersonaButton"
-                        filterKey="2"
-                      >
-                        I'm a Developer
-                      </Connect(CardFilterButton)>,
-                      <Connect(CardFilterButton)
-                        className="btn btn-outline-success PersonaButton"
-                        filterKey="1"
-                      >
-                        I'm a Designer
-                      </Connect(CardFilterButton)>,
-                    ],
-                    "className": "d-flex justify-content-center align-items-center",
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "class",
-                      "props": Object {
-                        "children": "I'm a Developer",
-                        "className": "btn btn-outline-primary PersonaButton",
-                        "filterKey": "2",
-                      },
-                      "ref": null,
-                      "rendered": "I'm a Developer",
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "class",
-                      "props": Object {
-                        "children": "I'm a Designer",
-                        "className": "btn btn-outline-success PersonaButton",
-                        "filterKey": "1",
-                      },
-                      "ref": null,
-                      "rendered": "I'm a Designer",
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <p
-                        className="mb-0"
-                      >
-                        Thanks for visiting!
-                      </p>,
-                      <footer
-                        className="blockquote-footer"
-                      >
-                        The DevHub Team.
-                      </footer>,
-                    ],
-                    "className": "blockquote",
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Thanks for visiting!",
-                        "className": "mb-0",
-                      },
-                      "ref": null,
-                      "rendered": "Thanks for visiting!",
-                      "type": "p",
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "The DevHub Team.",
-                        "className": "blockquote-footer",
-                      },
-                      "ref": null,
-                      "rendered": "The DevHub Team.",
-                      "type": "footer",
-                    },
-                  ],
-                  "type": "blockquote",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
-                      <a
-                        href="https://github.com/bcgov/devhub-app-web/issues"
-                      >
-                        GitHub
-                      </a>,
-                      " repository.",
-                    ],
-                    "className": "text-muted",
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "GitHub",
-                        "href": "https://github.com/bcgov/devhub-app-web/issues",
-                      },
-                      "ref": null,
-                      "rendered": "GitHub",
-                      "type": "a",
-                    },
+                    </a>,
                     " repository.",
                   ],
-                  "type": "p",
+                  "className": "text-muted",
                 },
-              ],
-              "type": "section",
+                "ref": null,
+                "rendered": Array [
+                  "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "GitHub",
+                      "href": "https://github.com/bcgov/devhub-app-web/issues",
+                    },
+                    "ref": null,
+                    "rendered": "GitHub",
+                    "type": "a",
+                  },
+                  " repository.",
+                ],
+                "type": "p",
+              },
+            ],
+            "type": "section",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": <div
+                className="ListContainer"
+              >
+                <SecondaryFilter
+                  filterGroups={
+                    Array [
+                      Object {
+                        "data": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "filters": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "title": "For",
+                      },
+                    ]
+                  }
+                  mobile={false}
+                />
+                <SecondaryFilter
+                  filterGroups={
+                    Array [
+                      Object {
+                        "data": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "filters": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "title": "For",
+                      },
+                    ]
+                  }
+                  mobile={true}
+                />
+                <div
+                  className="CardContainer"
+                >
+                  <Flag
+                    name="features.githubResourceCards"
+                  />
+                </div>
+              </div>,
+              "name": "CARDS_CONTAINER",
             },
-            Object {
+            "ref": null,
+            "rendered": Object {
               "instance": null,
               "key": undefined,
               "nodeType": "host",
@@ -2244,6 +1352,1248 @@ ShallowWrapper {
                 },
               ],
               "type": "div",
+            },
+            "type": [Function],
+          },
+        ],
+        "type": "main",
+      },
+    ],
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": Array [
+          <Flag
+            name="features.sourceFiltering"
+          >
+            <Connect(PrimaryFilter) />
+          </Flag>,
+          <main
+            className="Main container"
+            role="main"
+          >
+            <section
+              className="jumbotron text-center"
+            >
+              <h1
+                className="jumbotron-heading"
+              >
+                Welcome.
+              </h1>
+              <h3>
+                 We are here to help.
+              </h3>
+              <p
+                className="lead"
+              >
+                This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
+              </p>
+              <p>
+                In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
+              </p>
+              <div
+                className="d-flex justify-content-center align-items-center"
+              >
+                <Connect(CardFilterButton)
+                  className="btn btn-outline-primary PersonaButton"
+                  filterKey="2"
+                  scrollToTarget="CARDS_CONTAINER"
+                >
+                  I'm a Developer
+                </Connect(CardFilterButton)>
+                <Connect(CardFilterButton)
+                  className="btn btn-outline-success PersonaButton"
+                  filterKey="1"
+                  scrollToTarget="CARDS_CONTAINER"
+                >
+                  I'm a Designer
+                </Connect(CardFilterButton)>
+              </div>
+              <blockquote
+                className="blockquote"
+              >
+                <p
+                  className="mb-0"
+                >
+                  Thanks for visiting!
+                </p>
+                <footer
+                  className="blockquote-footer"
+                >
+                  The DevHub Team.
+                </footer>
+              </blockquote>
+              <p
+                className="text-muted"
+              >
+                PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
+                <a
+                  href="https://github.com/bcgov/devhub-app-web/issues"
+                >
+                  GitHub
+                </a>
+                 repository.
+              </p>
+            </section>
+            <Element
+              name="CARDS_CONTAINER"
+            >
+              <div
+                className="ListContainer"
+              >
+                <SecondaryFilter
+                  filterGroups={
+                    Array [
+                      Object {
+                        "data": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "filters": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "title": "For",
+                      },
+                    ]
+                  }
+                  mobile={false}
+                />
+                <SecondaryFilter
+                  filterGroups={
+                    Array [
+                      Object {
+                        "data": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "filters": Array [
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "foo",
+                            "text": "Designers",
+                            "title": "For",
+                            "value": "Designer",
+                          },
+                          Object {
+                            "active": true,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "bar",
+                            "text": "Developers",
+                            "title": "For",
+                            "value": "Developer",
+                          },
+                          Object {
+                            "active": false,
+                            "availableResources": null,
+                            "filterBy": "attributes.persona",
+                            "key": "baz",
+                            "text": "Product Owners",
+                            "title": "For",
+                            "value": "Product Owner",
+                          },
+                        ],
+                        "title": "For",
+                      },
+                    ]
+                  }
+                  mobile={true}
+                />
+                <div
+                  className="CardContainer"
+                >
+                  <Flag
+                    name="features.githubResourceCards"
+                  />
+                </div>
+              </div>
+            </Element>
+          </main>,
+        ],
+        "hamburgerClicked": undefined,
+        "showHamburger": true,
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": Array [
+              <Connect(PrimaryFilter) />,
+              null,
+            ],
+            "name": "features.sourceFiltering",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {},
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            null,
+          ],
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <section
+                className="jumbotron text-center"
+              >
+                <h1
+                  className="jumbotron-heading"
+                >
+                  Welcome.
+                </h1>
+                <h3>
+                   We are here to help.
+                </h3>
+                <p
+                  className="lead"
+                >
+                  This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
+                </p>
+                <p>
+                  In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
+                </p>
+                <div
+                  className="d-flex justify-content-center align-items-center"
+                >
+                  <Connect(CardFilterButton)
+                    className="btn btn-outline-primary PersonaButton"
+                    filterKey="2"
+                    scrollToTarget="CARDS_CONTAINER"
+                  >
+                    I'm a Developer
+                  </Connect(CardFilterButton)>
+                  <Connect(CardFilterButton)
+                    className="btn btn-outline-success PersonaButton"
+                    filterKey="1"
+                    scrollToTarget="CARDS_CONTAINER"
+                  >
+                    I'm a Designer
+                  </Connect(CardFilterButton)>
+                </div>
+                <blockquote
+                  className="blockquote"
+                >
+                  <p
+                    className="mb-0"
+                  >
+                    Thanks for visiting!
+                  </p>
+                  <footer
+                    className="blockquote-footer"
+                  >
+                    The DevHub Team.
+                  </footer>
+                </blockquote>
+                <p
+                  className="text-muted"
+                >
+                  PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
+                  <a
+                    href="https://github.com/bcgov/devhub-app-web/issues"
+                  >
+                    GitHub
+                  </a>
+                   repository.
+                </p>
+              </section>,
+              <Element
+                name="CARDS_CONTAINER"
+              >
+                <div
+                  className="ListContainer"
+                >
+                  <SecondaryFilter
+                    filterGroups={
+                      Array [
+                        Object {
+                          "data": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "filters": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "title": "For",
+                        },
+                      ]
+                    }
+                    mobile={false}
+                  />
+                  <SecondaryFilter
+                    filterGroups={
+                      Array [
+                        Object {
+                          "data": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "filters": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "title": "For",
+                        },
+                      ]
+                    }
+                    mobile={true}
+                  />
+                  <div
+                    className="CardContainer"
+                  >
+                    <Flag
+                      name="features.githubResourceCards"
+                    />
+                  </div>
+                </div>
+              </Element>,
+            ],
+            "className": "Main container",
+            "role": "main",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <h1
+                    className="jumbotron-heading"
+                  >
+                    Welcome.
+                  </h1>,
+                  <h3>
+                     We are here to help.
+                  </h3>,
+                  <p
+                    className="lead"
+                  >
+                    This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.
+                  </p>,
+                  <p>
+                    In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.
+                  </p>,
+                  <div
+                    className="d-flex justify-content-center align-items-center"
+                  >
+                    <Connect(CardFilterButton)
+                      className="btn btn-outline-primary PersonaButton"
+                      filterKey="2"
+                      scrollToTarget="CARDS_CONTAINER"
+                    >
+                      I'm a Developer
+                    </Connect(CardFilterButton)>
+                    <Connect(CardFilterButton)
+                      className="btn btn-outline-success PersonaButton"
+                      filterKey="1"
+                      scrollToTarget="CARDS_CONTAINER"
+                    >
+                      I'm a Designer
+                    </Connect(CardFilterButton)>
+                  </div>,
+                  <blockquote
+                    className="blockquote"
+                  >
+                    <p
+                      className="mb-0"
+                    >
+                      Thanks for visiting!
+                    </p>
+                    <footer
+                      className="blockquote-footer"
+                    >
+                      The DevHub Team.
+                    </footer>
+                  </blockquote>,
+                  <p
+                    className="text-muted"
+                  >
+                    PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our 
+                    <a
+                      href="https://github.com/bcgov/devhub-app-web/issues"
+                    >
+                      GitHub
+                    </a>
+                     repository.
+                  </p>,
+                ],
+                "className": "jumbotron text-center",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "Welcome.",
+                    "className": "jumbotron-heading",
+                  },
+                  "ref": null,
+                  "rendered": "Welcome.",
+                  "type": "h1",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": " We are here to help.",
+                  },
+                  "ref": null,
+                  "rendered": " We are here to help.",
+                  "type": "h3",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
+                    "className": "lead",
+                  },
+                  "ref": null,
+                  "rendered": "This is the front door to the developer community of the BC Government. The aim of the DevHub is to help developers and digital product teams learn new skills and discover resources to use on their journeys of creating amazing applications for government.",
+                  "type": "p",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
+                  },
+                  "ref": null,
+                  "rendered": "In the future, we plan to offer a variety of cool and useful ways to organize and navigate DevHub resources. For now, you can tell us who you are below and we'll tailor the set of resources shown just for you.",
+                  "type": "p",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <Connect(CardFilterButton)
+                        className="btn btn-outline-primary PersonaButton"
+                        filterKey="2"
+                        scrollToTarget="CARDS_CONTAINER"
+                      >
+                        I'm a Developer
+                      </Connect(CardFilterButton)>,
+                      <Connect(CardFilterButton)
+                        className="btn btn-outline-success PersonaButton"
+                        filterKey="1"
+                        scrollToTarget="CARDS_CONTAINER"
+                      >
+                        I'm a Designer
+                      </Connect(CardFilterButton)>,
+                    ],
+                    "className": "d-flex justify-content-center align-items-center",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": "I'm a Developer",
+                        "className": "btn btn-outline-primary PersonaButton",
+                        "filterKey": "2",
+                        "scrollToTarget": "CARDS_CONTAINER",
+                      },
+                      "ref": null,
+                      "rendered": "I'm a Developer",
+                      "type": [Function],
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": "I'm a Designer",
+                        "className": "btn btn-outline-success PersonaButton",
+                        "filterKey": "1",
+                        "scrollToTarget": "CARDS_CONTAINER",
+                      },
+                      "ref": null,
+                      "rendered": "I'm a Designer",
+                      "type": [Function],
+                    },
+                  ],
+                  "type": "div",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <p
+                        className="mb-0"
+                      >
+                        Thanks for visiting!
+                      </p>,
+                      <footer
+                        className="blockquote-footer"
+                      >
+                        The DevHub Team.
+                      </footer>,
+                    ],
+                    "className": "blockquote",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Thanks for visiting!",
+                        "className": "mb-0",
+                      },
+                      "ref": null,
+                      "rendered": "Thanks for visiting!",
+                      "type": "p",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "The DevHub Team.",
+                        "className": "blockquote-footer",
+                      },
+                      "ref": null,
+                      "rendered": "The DevHub Team.",
+                      "type": "footer",
+                    },
+                  ],
+                  "type": "blockquote",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
+                      <a
+                        href="https://github.com/bcgov/devhub-app-web/issues"
+                      >
+                        GitHub
+                      </a>,
+                      " repository.",
+                    ],
+                    "className": "text-muted",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "PS. If you’d like to comment, offer a suggestion or ask a question you can find us by opening an issue in our ",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "GitHub",
+                        "href": "https://github.com/bcgov/devhub-app-web/issues",
+                      },
+                      "ref": null,
+                      "rendered": "GitHub",
+                      "type": "a",
+                    },
+                    " repository.",
+                  ],
+                  "type": "p",
+                },
+              ],
+              "type": "section",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": <div
+                  className="ListContainer"
+                >
+                  <SecondaryFilter
+                    filterGroups={
+                      Array [
+                        Object {
+                          "data": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "filters": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "title": "For",
+                        },
+                      ]
+                    }
+                    mobile={false}
+                  />
+                  <SecondaryFilter
+                    filterGroups={
+                      Array [
+                        Object {
+                          "data": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "filters": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "title": "For",
+                        },
+                      ]
+                    }
+                    mobile={true}
+                  />
+                  <div
+                    className="CardContainer"
+                  >
+                    <Flag
+                      name="features.githubResourceCards"
+                    />
+                  </div>
+                </div>,
+                "name": "CARDS_CONTAINER",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <SecondaryFilter
+                      filterGroups={
+                        Array [
+                          Object {
+                            "data": Array [
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "foo",
+                                "text": "Designers",
+                                "title": "For",
+                                "value": "Designer",
+                              },
+                              Object {
+                                "active": true,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "bar",
+                                "text": "Developers",
+                                "title": "For",
+                                "value": "Developer",
+                              },
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "baz",
+                                "text": "Product Owners",
+                                "title": "For",
+                                "value": "Product Owner",
+                              },
+                            ],
+                            "filters": Array [
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "foo",
+                                "text": "Designers",
+                                "title": "For",
+                                "value": "Designer",
+                              },
+                              Object {
+                                "active": true,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "bar",
+                                "text": "Developers",
+                                "title": "For",
+                                "value": "Developer",
+                              },
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "baz",
+                                "text": "Product Owners",
+                                "title": "For",
+                                "value": "Product Owner",
+                              },
+                            ],
+                            "title": "For",
+                          },
+                        ]
+                      }
+                      mobile={false}
+                    />,
+                    <SecondaryFilter
+                      filterGroups={
+                        Array [
+                          Object {
+                            "data": Array [
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "foo",
+                                "text": "Designers",
+                                "title": "For",
+                                "value": "Designer",
+                              },
+                              Object {
+                                "active": true,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "bar",
+                                "text": "Developers",
+                                "title": "For",
+                                "value": "Developer",
+                              },
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "baz",
+                                "text": "Product Owners",
+                                "title": "For",
+                                "value": "Product Owner",
+                              },
+                            ],
+                            "filters": Array [
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "foo",
+                                "text": "Designers",
+                                "title": "For",
+                                "value": "Designer",
+                              },
+                              Object {
+                                "active": true,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "bar",
+                                "text": "Developers",
+                                "title": "For",
+                                "value": "Developer",
+                              },
+                              Object {
+                                "active": false,
+                                "availableResources": null,
+                                "filterBy": "attributes.persona",
+                                "key": "baz",
+                                "text": "Product Owners",
+                                "title": "For",
+                                "value": "Product Owner",
+                              },
+                            ],
+                            "title": "For",
+                          },
+                        ]
+                      }
+                      mobile={true}
+                    />,
+                    <div
+                      className="CardContainer"
+                    >
+                      <Flag
+                        name="features.githubResourceCards"
+                      />
+                    </div>,
+                  ],
+                  "className": "ListContainer",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "function",
+                    "props": Object {
+                      "filterGroups": Array [
+                        Object {
+                          "data": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "filters": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "title": "For",
+                        },
+                      ],
+                      "mobile": false,
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "function",
+                    "props": Object {
+                      "filterGroups": Array [
+                        Object {
+                          "data": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "filters": Array [
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "foo",
+                              "text": "Designers",
+                              "title": "For",
+                              "value": "Designer",
+                            },
+                            Object {
+                              "active": true,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "bar",
+                              "text": "Developers",
+                              "title": "For",
+                              "value": "Developer",
+                            },
+                            Object {
+                              "active": false,
+                              "availableResources": null,
+                              "filterBy": "attributes.persona",
+                              "key": "baz",
+                              "text": "Product Owners",
+                              "title": "For",
+                              "value": "Product Owner",
+                            },
+                          ],
+                          "title": "For",
+                        },
+                      ],
+                      "mobile": true,
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Flag
+                        name="features.githubResourceCards"
+                      />,
+                      "className": "CardContainer",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": Array [],
+                        "name": "features.githubResourceCards",
+                      },
+                      "ref": null,
+                      "rendered": Array [],
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": [Function],
             },
           ],
           "type": "main",

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -13732,6 +13732,11 @@
         "lodash._reinterpolate": "~3.0.0"
       }
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -20317,6 +20322,15 @@
             "loose-envify": "^1.0.0"
           }
         }
+      }
+    },
+    "react-scroll": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.10.tgz",
+      "integrity": "sha512-7K1caXF19PQ/jck+QRCdRMytqWei1ktv7jtcsgMap2s55pGOUc/a5phr4loajZRFRx3qKj9Tz12KDtELp91xMg==",
+      "requires": {
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.5.8"
       }
     },
     "react-select": {

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -78,6 +78,7 @@
     "react-image": "^1.5.1",
     "react-redux": "^5.0.0",
     "react-router-dom": "^4.3.1",
+    "react-scroll": "^1.7.10",
     "react-select": "^2.1.2",
     "react-toggled": "^1.2.7",
     "redux": "^3.0.0",

--- a/app-web/src/components/CardFilterButton/CardFilterButton.js
+++ b/app-web/src/components/CardFilterButton/CardFilterButton.js
@@ -1,13 +1,44 @@
+/*
+Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
 import React from 'react';
 import PropTypes from 'prop-types';
+import { scroller } from 'react-scroll';
 import Button from '../../components/UI/Button/Button';
 import { connect } from 'react-redux';
 import * as actions from '../../store/actions/actions';
-
-export const CardFilterButton = ({ addFilter, filterKey, unsetFilters, children, ...rest }) => {
+import { REACT_SCROLL } from '../../constants/ui';
+export const CardFilterButton = ({
+  scrollToTarget,
+  addFilter,
+  filterKey,
+  unsetFilters,
+  children,
+  ...rest
+}) => {
+  // resets all filters, adds the selected filter and scrolls down to the target container
   const clicked = function() {
     unsetFilters();
     addFilter(filterKey);
+    // scroll to the cards container
+    scroller.scrollTo(scrollToTarget, {
+      ...REACT_SCROLL.CONFIG,
+      offset: -120,
+    });
   };
 
   return (
@@ -21,10 +52,12 @@ CardFilterButton.propTypes = {
   addFilter: PropTypes.func.isRequired,
   unsetFilters: PropTypes.func.isRequired,
   children: PropTypes.string,
+  scrollToTarget: PropTypes.string,
 };
 
 CardFilterButton.defaultProps = {
   children: '',
+  scrollToTarget: '',
 };
 
 const mapDispatchToProps = dispatch => {

--- a/app-web/src/constants/ui.js
+++ b/app-web/src/constants/ui.js
@@ -152,3 +152,15 @@ export const FOOTER_NAVIGATION = [
     text: 'home',
   },
 ];
+
+// react-scroll requires identifiers to scroll to individual elements
+export const REACT_SCROLL = {
+  CONFIG: {
+    duration: 750,
+    delay: 100,
+    smooth: true,
+  },
+  ELEMENTS: {
+    CARDS_CONTAINER: 'CARDS_CONTAINER',
+  },
+};

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -1,19 +1,21 @@
 import React, { Component } from 'react';
 import { graphql } from 'gatsby';
-// import YAML from 'js-yaml';
 import shortid from 'shortid';
 import { connect } from 'react-redux';
-import * as actions from '../store/actions/actions';
 import { Flag } from 'flag';
+
+import * as actions from '../store/actions/actions';
 import { groupBy } from '../utils/dataMassager';
 import { GITHUB_ISSUES_ROUTE } from '../constants/routes';
+import { REACT_SCROLL } from '../constants/ui';
 import { DEFAULT_FILTERS } from '../constants/filterGroups';
-// local components
+import styles from './index.module.css';
+// components
+import { Element } from 'react-scroll';
 import Layout from '../hoc/Layout';
 import PrimaryFilter from '../components/PrimaryFilter/PrimaryFilter';
 import SecondaryFilter from '../components/SecondaryFilter/SecondaryFilter';
 import Cards from '../components/Cards/Cards';
-import styles from './index.module.css';
 import CardFilterButton from '../components/CardFilterButton/CardFilterButton';
 
 export class Index extends Component {
@@ -76,12 +78,14 @@ export class Index extends Component {
 
             <div className={'d-flex justify-content-center align-items-center'}>
               <CardFilterButton
+                scrollToTarget={REACT_SCROLL.ELEMENTS.CARDS_CONTAINER}
                 filterKey={DEFAULT_FILTERS.PERSONA_DEVELOPER.key}
                 className={['btn btn-outline-primary', styles.PersonaButton].join(' ')}
               >
                 I'm a Developer
               </CardFilterButton>
               <CardFilterButton
+                scrollToTarget={REACT_SCROLL.ELEMENTS.CARDS_CONTAINER}
                 filterKey={DEFAULT_FILTERS.PERSONA_DESIGNER.key}
                 className={['btn btn-outline-success', styles.PersonaButton].join(' ')}
               >
@@ -99,13 +103,15 @@ export class Index extends Component {
               opening an issue in our <a href={GITHUB_ISSUES_ROUTE}>GitHub</a> repository.
             </p>
           </section>
-          <div className={styles.ListContainer}>
-            <SecondaryFilter filterGroups={groupedFilters} />
-            <SecondaryFilter filterGroups={groupedFilters} mobile />
-            <div className={styles.CardContainer}>
-              <Flag name="features.githubResourceCards">{SiphonResources}</Flag>
+          <Element name={REACT_SCROLL.ELEMENTS.CARDS_CONTAINER}>
+            <div className={styles.ListContainer}>
+              <SecondaryFilter filterGroups={groupedFilters} />
+              <SecondaryFilter filterGroups={groupedFilters} mobile />
+              <div className={styles.CardContainer}>
+                <Flag name="features.githubResourceCards">{SiphonResources}</Flag>
+              </div>
             </div>
-          </div>
+          </Element>
         </main>
       </Layout>
     );


### PR DESCRIPTION
## Summary
Peter pointed out an issue that on smaller screens, when you click the card filter persona buttons, although it does actually trigger a filter, there is no visible change on the screen. This is because the bootstrap jumbotron takes up the entire view port and therefor leaves no space for a visual cue that the cards have changed. I added `react-scroll` to the party so that on click of those buttons, it scrolls to the container. 

Fixes #206 