### PR TITLE
Add source type 'web' so that siphon can suck up information from a website

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -476,6 +476,17 @@ const GITHUB_SOURCE = {
     labels: ['components'],
   },
 };
+// sample web source registry item
+const WEB_SOURCE = {
+  name: 'Foo',
+  sourceType: 'web',
+  sourceProperties: {
+    url: 'https://google.com',
+  },
+  attributes: {
+    persona: 'Developer',
+  },
+};
 
 // another sample registry 'item'
 const GITHUB_SOURCE_WITHIN_INLINE_IGNORES = {
@@ -500,11 +511,43 @@ const CONFIG_OPTIONS = {
   sourceRegistryType: 'SourceRegistryYaml',
 };
 
+const PROCESSED_WEB_SOURCE = {
+  metadata: {
+    unfurl: {
+      author: 'foo',
+      description: 'bar',
+      image: null,
+      label1: null,
+      value1: null,
+      label2: null,
+      value2: null,
+    },
+    resourceType: 'Documentation',
+    sourceType: 'web',
+    name: 'web source',
+    attributes: {
+      persona: 'Developer',
+    },
+    collection: {
+      name: 'web source',
+      type: 'source',
+    },
+    resourcePath: 'https://example.com',
+    originalResourceLocation: 'https://example.com',
+    fileName: null,
+    fileType: null,
+    owner: 'foo',
+    mediaType: 'text/html', // hmm not too sure what should be considered the best media type
+  },
+  path: 'https://example.com',
+};
+
 module.exports = {
   GITHUB_API,
   PROCESSED_FILE_MD,
   PROCESSED_FILE_TXT,
   PROCESSED_FILE_HTML,
+  PROCESSED_WEB_SOURCE,
   RAW_FILE_MD,
   RAW_FILE_MD_WITH_RESOURCEPATH,
   GRAPHQL_NODES_WITH_REGISTRY,
@@ -512,6 +555,7 @@ module.exports = {
   REGISTRY,
   REGISTRY_WITH_COLLECTION,
   GITHUB_SOURCE,
+  WEB_SOURCE,
   GITHUB_SOURCE_WITHIN_INLINE_IGNORES,
   CONFIG_OPTIONS,
   TREE_FILES,

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceWeb.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceWeb.test.js
@@ -1,0 +1,16 @@
+import { WEB_SOURCE } from '../__fixtures__/fixtures';
+import { validateSourceWeb } from '../utils/sources/web/';
+
+describe('sourceType Web', () => {
+  test('validateSourceGithub returns true when valid', () => {
+    expect(validateSourceWeb(WEB_SOURCE)).toBe(true);
+  });
+
+  test('validateSourceWeb returns false when source is invalid', () => {
+    const BAD_SOURCE = {
+      ...WEB_SOURCE,
+      sourceProperties: { url: null },
+    };
+    expect(validateSourceWeb(BAD_SOURCE)).toBe(false);
+  });
+});

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -1,4 +1,9 @@
-import { createPathWithDigest, createUnfurlObj, getClosestResourceType } from '../utils/helpers';
+import {
+  createPathWithDigest,
+  createUnfurlObj,
+  getClosestResourceType,
+  unfurlWebURI,
+} from '../utils/helpers';
 import { RESOURCE_TYPES } from '../utils/constants';
 
 describe('createPathWithDigest', () => {
@@ -40,5 +45,22 @@ describe('getClosestResourceType', () => {
 
   it('returns the closest resource type when matched', () => {
     expect(getClosestResourceType(RESOURCE_TYPES[0])).toBe(RESOURCE_TYPES[0]);
+  });
+});
+
+describe('unfurlWebURI', () => {
+  it('returns a unfurl object', () => {
+    const uri = 'https://example.com';
+    expect(unfurlWebURI(uri)).toBeDefined();
+  });
+
+  it('throws if uri is invalid', async () => {
+    try {
+      await expect(unfurlWebURI());
+    } catch (e) {
+      expect(e).toEqual({
+        error: 'The uri is not valid',
+      });
+    }
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
@@ -11,12 +11,18 @@ import {
 } from '../utils/plugins';
 import { PROCESSED_FILE_MD } from '../__fixtures__/fixtures';
 import { PERSONAS_LIST, RESOURCE_TYPES } from '../utils/constants';
-import { createUnfurlObj, getClosestResourceType, getClosestPersona } from '../utils/helpers';
+import {
+  createUnfurlObj,
+  getClosestResourceType,
+  getClosestPersona,
+  unfurlWebURI,
+} from '../utils/helpers';
 jest.mock('../utils/helpers.js');
 
 createUnfurlObj.mockReturnValue({});
 getClosestResourceType.mockReturnValue('');
 getClosestPersona.mockImplementation(persona => persona);
+unfurlWebURI.mockReturnValue({});
 
 describe('Transformer System', () => {
   let file = null;
@@ -120,7 +126,7 @@ describe('Transformer System', () => {
       expect(result).toBeDefined();
     });
 
-    it('returns files with unfurl', async () => {
+    it('returns files with unfurl property defined', async () => {
       file.metadata.resourcePath =
         'http://www.bloomberg.com/news/articles/2016-05-24/as-zenefits-stumbles-gusto-goes-head-on-by-selling-insurance';
       const result = await externalLinkUnfurlPlugin(file.metadata.extension, file);

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/siphonNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/siphonNode.js
@@ -25,6 +25,7 @@ const UNFURL_TYPES = {
 // source types that map to fetch routines
 const COLLECTION_TYPES = {
   [SOURCE_TYPES.GITHUB]: 'source',
+  [SOURCE_TYPES.WEB]: 'source',
   CURATED: 'curated',
 };
 

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/sourceTypes.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/sourceTypes.js
@@ -17,6 +17,7 @@ Created by Patrick Simonian
 */
 const SOURCE_TYPES = {
   GITHUB: 'github',
+  WEB: 'web',
 };
 
 const GITHUB_SOURCE_SCHEMA = {
@@ -52,7 +53,15 @@ const GITHUB_SOURCE_SCHEMA = {
   },
 };
 
+const WEB_SOURCE_SCHEMA = {
+  url: {
+    type: String,
+    required: true,
+  },
+};
+
 module.exports = {
   SOURCE_TYPES,
   GITHUB_SOURCE_SCHEMA,
+  WEB_SOURCE_SCHEMA,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSource.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSource.js
@@ -18,6 +18,7 @@ Created by Patrick Simonian
 
 const { SOURCE_TYPES } = require('./constants');
 const { fetchSourceGithub, validateSourceGithub } = require('./sources/github');
+const { fetchSourceWeb, validateSourceWeb } = require('./sources/web');
 /**
  * maps to a fetch function for that sourceType,
  * all fetch functions implement the same return object
@@ -29,6 +30,8 @@ const fetchFromSource = (sourceType, source, { GITHUB_API_TOKEN }) => {
   switch (sourceType) {
     case SOURCE_TYPES.GITHUB:
       return fetchSourceGithub(source, GITHUB_API_TOKEN);
+    case SOURCE_TYPES.WEB:
+      return fetchSourceWeb(source);
     default:
       return [];
   }
@@ -44,6 +47,8 @@ const validateSourceRegistry = source => {
   switch (source.sourceType) {
     case SOURCE_TYPES.GITHUB:
       return validateSourceGithub(source);
+    case SOURCE_TYPES.WEB:
+      return validateSourceWeb(source);
     default:
       return false;
   }

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -24,6 +24,7 @@ Created by Patrick Simonian
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
 const path = require('path');
 const url = require('url');
+const chalk = require('chalk');
 const shorthash = require('shorthash');
 const stringSimilarity = require('string-similarity');
 const { RESOURCE_TYPES_LIST } = require('./constants');
@@ -112,6 +113,38 @@ const getAbsolutePathFromRelative = (relativePath, absolutePath, queryParams) =>
   });
 
   return absPathObj.toString();
+}
+
+/* validates a registry item's source Properties against a valid schema
+* @param {Object} source the registry source item properties
+* @param {Object} schema has shape { type: String | Boolean | Date etc, required: true/false}
+* @returns {Boolean}
+*/
+const validateSourceAgainstSchema = (source, schema) => {
+  return Object.keys(schema).every(key => {
+    const schemaItem = schema[key];
+    let isValid = true;
+
+    if (schemaItem.required) {
+      isValid =
+        Object.prototype.hasOwnProperty.call(source.sourceProperties, key) &&
+        TypeCheck.isA(schemaItem.type, source.sourceProperties[key]);
+      // does this source property have it anyways?
+    } else if (Object.prototype.hasOwnProperty.call(source.sourceProperties, key)) {
+      isValid = TypeCheck.isA(schemaItem.type, source.sourceProperties[key]);
+    }
+
+    if (!isValid) {
+      console.error(
+        chalk`{red.bold \nError Validating Source type ${source.sourceType}} 
+
+       Source failed on validation on source property {yellow.bold ${key}}
+       received value {yellow.bold ${source.sourceProperties[key]}}`,
+      );
+    }
+
+    return isValid;
+  });
 };
 
 module.exports = {
@@ -120,4 +153,5 @@ module.exports = {
   getClosestResourceType,
   getClosestPersona,
   getAbsolutePathFromRelative,
+  validateSourceAgainstSchema,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
@@ -33,6 +33,7 @@ const {
   filterFilesFromDirectories,
   applyBaseMetadata,
 } = require('./helpers');
+const { validateSourceAgainstSchema } = require('../../helpers');
 
 /**
  * Using the recursion param, this
@@ -161,32 +162,7 @@ const getFilesFromRepo = async ({ repo, owner, branch, context, ignores }, token
  * @param {Object} source
  * @returns {Boolean}
  */
-const validateSourceGithub = source => {
-  return Object.keys(GITHUB_SOURCE_SCHEMA).every(key => {
-    const schemaItem = GITHUB_SOURCE_SCHEMA[key];
-    let isValid = true;
-
-    if (schemaItem.required) {
-      isValid =
-        Object.prototype.hasOwnProperty.call(source.sourceProperties, key) &&
-        TypeCheck.isA(schemaItem.type, source.sourceProperties[key]);
-      // does this source property have it anyways?
-    } else if (Object.prototype.hasOwnProperty.call(source.sourceProperties, key)) {
-      isValid = TypeCheck.isA(schemaItem.type, source.sourceProperties[key]);
-    }
-
-    if (!isValid) {
-      console.error(
-        chalk`{red.bold \nError Validating Source type github} 
-
-       Source failed on validation on source property {yellow.bold ${key}}
-       received value {yellow.bold ${source.sourceProperties[key]}}`,
-      );
-    }
-
-    return isValid;
-  });
-};
+const validateSourceGithub = source => validateSourceAgainstSchema(source, GITHUB_SOURCE_SCHEMA);
 
 /**
  * returns a flattened array of github files from a repository

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -62,7 +62,6 @@ const fetchSourceWeb = async ({
       path: url,
     };
 
-    console.log('returning data \n');
     return [siphonData];
   } catch (e) {
     console.error(e);

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -15,12 +15,60 @@ limitations under the License.
 
 Created by Patrick Simonian
 */
-const { WEB_SOURCE_SCHEMA } = require('../../constants');
-const { validateSourceAgainstSchema } = require('../../helpers');
+const { WEB_SOURCE_SCHEMA, MEDIATYPES } = require('../../constants');
+const { validateSourceAgainstSchema, unfurlWebURI } = require('../../helpers');
 
+/**
+ * validates the source properties against the web source schema
+ * @param {Object} source the registry source item
+ * @returns {Boolean}
+ */
 const validateSourceWeb = source => validateSourceAgainstSchema(source, WEB_SOURCE_SCHEMA);
 
-const fetchSourceWeb = () => [];
+/**
+ * fetches data from a web source
+ * based on the configuration passed into the routine
+ * @param {Object} source the source configuration (comes from the registry)
+ * is deconstructed into its components
+ * @returns {Object} the siphon object that is ready to be turned into a node
+ */
+const fetchSourceWeb = async ({
+  sourceType,
+  resourceType,
+  name,
+  sourceProperties,
+  attributes,
+  collection,
+}) => {
+  const { url } = sourceProperties;
+  // fetch information from the url
+  try {
+    const unfurl = await unfurlWebURI(url);
+    const siphonData = {
+      metadata: {
+        unfurl,
+        resourceType,
+        sourceType,
+        name,
+        ...attributes,
+        collection,
+        resourcePath: url,
+        originalResourceLocation: url,
+        fileName: null,
+        fileType: null,
+        owner: unfurl.author,
+        mediaType: MEDIATYPES.HTML, // hmm not too sure what should be considered the best media type
+      },
+      path: url,
+    };
+
+    console.log('returning data \n');
+    return [siphonData];
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+};
 
 module.exports = {
   validateSourceWeb,

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+const { WEB_SOURCE_SCHEMA } = require('../../constants');
+const { validateSourceAgainstSchema } = require('../../helpers');
+
+const validateSourceWeb = source => validateSourceAgainstSchema(source, WEB_SOURCE_SCHEMA);
+
+const fetchSourceWeb = () => [];
+
+module.exports = {
+  validateSourceWeb,
+  fetchSourceWeb,
+};


### PR DESCRIPTION
## Summary
Added another 'sourceType' to siphon called `web`

A web source type and takes a `url` property as its sole `sourceProperties`

The url is unfurled and then created into a graphql node

## Changes
- added source type `web `
- refactored source property validation routine https://github.com/bcgov/devhub-app-web/pull/214/files#diff-e9d28f0b4bea9f05787cd5359900ae47R125
- refactored unfurling an external url routine https://github.com/bcgov/devhub-app-web/pull/214/files#diff-e9d28f0b4bea9f05787cd5359900ae47R152