### PR TITLE
Add new plugin to address relative image path issue in front matter

### DIFF
--- a/app-web/__mocks__/gray-matter.js
+++ b/app-web/__mocks__/gray-matter.js
@@ -17,12 +17,12 @@ Created by Patrick Simonian
 */
 const matter = jest.requireActual('gray-matter');
 
-const matterMocked = function(content) {
+const matterMocked = jest.fn(content => {
   return {
     data: {},
     content,
   };
-};
+});
 
 matterMocked.prototype.stringify = function() {
   return 'content';

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -23,6 +23,7 @@ Created by Patrick Simonian
  */
 const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
 const path = require('path');
+const url = require('url');
 const shorthash = require('shorthash');
 const stringSimilarity = require('string-similarity');
 const { RESOURCE_TYPES_LIST } = require('./constants');
@@ -94,9 +95,29 @@ const getClosestPersona = (persona, personas) => {
   return matches.bestMatch.rating >= RATING_THRESHOLD ? matches.bestMatch.target : '';
 };
 
+/**
+ * returns a new absolute path based off of a relative position from the given absolute path
+ * @param {String} relativePath eg '../../something/something.txt'
+ * @param {String} absolutePath eg 'https://example.com/'
+ * @param {Object} queryParams a key value pair set of query parameters
+ */
+const getAbsolutePathFromRelative = (relativePath, absolutePath, queryParams) => {
+  const { URL } = url;
+  const absPath = url.resolve(absolutePath, relativePath);
+
+  const absPathObj = new URL(absPath);
+
+  Object.keys(queryParams).forEach(key => {
+    absPath.searchParams.set(key, queryParams[key]);
+  });
+
+  return absPathObj.toString();
+};
+
 module.exports = {
   createPathWithDigest,
   createUnfurlObj,
   getClosestResourceType,
   getClosestPersona,
+  getAbsolutePathFromRelative,
 };


### PR DESCRIPTION
## Summary
If you had front matter in a markdown file like 
```markdown
---
image: ./images/foo.png
---
```
This would not correctly render an image in the devhub because the path was relative to the github source. This has been corrected by adding another file transformer plugin.
Fixes #187 

** PLEASE NOTE ** this plugin has been authored and tested but not implemented. The reason for this is there are significant breaking changes within PR #213. The preferable thing to do is have that pr as well as this one merged and then a new pr created to implement this plugin.
