### PR TITLE
Move client side filtering to allow for fiiltering by a 1 to many relationship

### DIFF
--- a/app-web/__fixtures__/redux-fixtures.js
+++ b/app-web/__fixtures__/redux-fixtures.js
@@ -18,7 +18,7 @@ export const NODES = [
       type: 'Components',
     },
     attributes: {
-      persona: 'Designer',
+      persona: ['Designer'],
     },
   },
   {
@@ -26,7 +26,7 @@ export const NODES = [
       type: 'Documentation',
     },
     attributes: {
-      persona: 'Developer',
+      persona: ['Developer'],
     },
   },
   {
@@ -34,7 +34,7 @@ export const NODES = [
       type: 'Components',
     },
     attributes: {
-      persona: 'Product Owner',
+      persona: ['Product Owner'],
     },
   },
 ];

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -166,7 +166,7 @@ describe('gatsby source github all plugin', () => {
       },
       attributes: {
         labels: 'component',
-        persona: undefined,
+        persona: [undefined],
       },
       source: {
         name: 'something/something',

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -57,7 +57,7 @@ const createSiphonNode = (data, id) => ({
   },
   attributes: {
     labels: data.metadata.labels, // labels from source registry
-    persona: data.metadata.persona, // persona from the source registry, see constants for valid personas
+    persona: [data.metadata.persona], // persona from the source registry, see constants for valid personas
   },
   internal: {
     contentDigest: crypto

--- a/app-web/src/store/reducers/siphon.js
+++ b/app-web/src/store/reducers/siphon.js
@@ -14,6 +14,7 @@ Created by Patrick Simonian
 import * as actionTypes from '../actions/actionTypes';
 import dotProp from 'dot-prop-immutable';
 import defaultFilterGroups from '../../constants/filterGroups';
+import { TypeCheck } from '@bcgov/common-web-utils';
 
 const initialState = {
   nodes: [],
@@ -35,7 +36,14 @@ const initialState = {
  * https://github.com/sindresorhus/dot-prop
  * @param {String} value the value to match against nodes value found by the dot prop
  */
-const dotPropMatchesValue = (node, filterBy, value) => dotProp.get(node, filterBy) === value;
+const dotPropMatchesValue = (node, filterBy, value) => {
+  const prop = dotProp.get(node, filterBy);
+  if (TypeCheck.isArray(prop)) {
+    return prop.some(p => p === value);
+  } else {
+    return prop === value;
+  }
+};
 
 /**
  * Check the number of resources that match a filter


### PR DESCRIPTION
## Summary
> This is the front end implementation, the next PR will be the backend implementation for siphon which allows for registering multiple personas

Cards may have properties that are inside of an array eg
```yaml
name: foo
attributes:
 personas: 
    - bar
    - baz
```
Prior to this PR, we could only filter by properties that were a single value. The `dotPropMatchesValue` fn has been modified to check for an array and match based on that if exists

#239 