### PR TITLE
Siphon nodes now hold source properties information as a private attribute

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -131,6 +131,11 @@ describe('gatsby source github all plugin', () => {
         labels: 'component',
         originalResourceLocation:
           'https://github.com/awesomeOrg/awesomeRepo/blob/master/public/manifest.json',
+        sourceProperties: {
+          branch: 'master',
+          repo: 'foo',
+          owner: 'bar',
+        },
       },
       name: 'test',
       path: '/test.md',
@@ -174,6 +179,11 @@ describe('gatsby source github all plugin', () => {
         displayName: 'something',
         sourcePath: undefined,
         type: undefined,
+        _properties: {
+          branch: 'master',
+          repo: 'foo',
+          owner: 'bar',
+        },
       },
       unfurl: undefined,
       resource: {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -49,6 +49,7 @@ const createSiphonNode = (data, id) => ({
     displayName: data.metadata.sourceName, // the pretty name of the 'source'
     sourcePath: data.metadata.sourceURL, // the path to the source
     type: data.metadata.sourceType, // the type of the source
+    _properties: data.metadata.sourceProperties, // the source properties mapped to the node from the registry
   },
   resource: {
     path: data.metadata.resourcePath, // either path to a gastby created page based on this node

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/helpers.js
@@ -178,20 +178,21 @@ const filterFilesFromDirectories = entries => {
 };
 
 /**
- * applies base meta data to file
- * @param {Object} file
- * @param {Array} labels
- * @param {String} owner
- * @param {String} source
- * @param {String} sourceName
- * @param {String} sourceURL
- * @param {String} resourceType
+ * applies base meta data to file which is used to create a siphon node
+ * @param {Object} file // the github file object
+ * @param {Array} labels // any labels passed in from registry item.attributes.labels
+ * @param {String} owner // the repo owner
+ * @param {String} repo // the name of the repository
+ * @param {String} sourceName // the 'name' given to the source
+ * @param {String} sourceURL // the path to the source (ie github url)
+ * @param {String} globalResourceType // the global resource type assigned frmo the registry item.attributes.resourceType
+ * @param {String} originalResourceLocation // the original path to the resource (ie path to file in repository)
  */
 const applyBaseMetadata = (
   file,
   labels,
   owner,
-  source,
+  repo,
   sourceName,
   sourceURL,
   sourceType,
@@ -199,6 +200,7 @@ const applyBaseMetadata = (
   originalResourceLocation,
   globalPersonas,
   collection,
+  sourceProperties,
 ) => {
   const extension = getExtensionFromName(file.name);
   return {
@@ -207,7 +209,7 @@ const applyBaseMetadata = (
     metadata: {
       labels,
       sourceName,
-      source,
+      source: repo,
       owner,
       name: getNameWithoutExtension(file.name),
       fileType: getNameOfExtensionVerbose(file.name),

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/helpers.js
@@ -185,8 +185,12 @@ const filterFilesFromDirectories = entries => {
  * @param {String} repo // the name of the repository
  * @param {String} sourceName // the 'name' given to the source
  * @param {String} sourceURL // the path to the source (ie github url)
- * @param {String} globalResourceType // the global resource type assigned frmo the registry item.attributes.resourceType
+ * @param {String} globalResourceType // the global resource type assigned frmo the registry item.resourceType
  * @param {String} originalResourceLocation // the original path to the resource (ie path to file in repository)
+ * @param {Array} globalPersonas // the global personas assigned from the regsitry item.attributes.personas
+ * @param {Object} collection // the collection details including props like collection.type, collection.name etc
+ * @param {Object} sourceProperties // the source properties inherited by the file describing what arguments were used to
+ * obtain the file
  */
 const applyBaseMetadata = (
   file,
@@ -222,6 +226,7 @@ const applyBaseMetadata = (
       originalResourceLocation,
       globalPersonas,
       collection,
+      sourceProperties,
     },
   };
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
@@ -219,6 +219,7 @@ const fetchSourceGithub = async (
         f.html_url,
         personas,
         collection,
+        sourceProperties,
       ),
     )
     .map(async f => {

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -58,6 +58,7 @@ const fetchSourceWeb = async ({
         fileType: null,
         owner: unfurl.author,
         mediaType: MEDIATYPES.HTML, // hmm not too sure what should be considered the best media type
+        sourceProperties,
       },
       path: url,
     };


### PR DESCRIPTION
## Summary
Updated siphon to pass source attributes from registry into the siphon node. 

### Why?
I found that having this extra meta data may be helpful for functions later down in the pipeline. For instance knowing what 'branch' a file came from can be helpful for dynamically building hrefs that should reference files from the same branch in github.