### PR TITLE
Siphon Collections as a first class object ( pr 1 of n)

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -27,6 +27,6 @@ describe('Integration Tests Source Nodes', () => {
     const createNodeId = jest.fn(() => 1);
     const getNodes = jest.fn(() => GRAPHQL_NODES_WITH_REGISTRY);
     const nodes = await sourceNodes({ actions, createNodeId, getNodes }, CONFIG_OPTIONS);
-    expect(nodes.every(node => node.internal.type === GRAPHQL_NODE_TYPE)).toBe(true);
+    expect(nodes.every(node => node.internal.type === GRAPHQL_NODE_TYPE.SIPHON)).toBe(true);
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -198,7 +198,7 @@ describe('gatsby source github all plugin', () => {
         // to transformer plugins this node has data they can further process.
         mediaType: 'application/test',
         // A globally unique node type chosen by the plugin owner.
-        type: GRAPHQL_NODE_TYPE,
+        type: GRAPHQL_NODE_TYPE.SIPHON,
         // Optional field exposing the raw content for this node
         // that transformer plugins can take and further process.
         content: 'content',
@@ -239,6 +239,7 @@ describe('gatsby source github all plugin', () => {
     });
   });
 
+  // get fetch queue should return a list of collections that contain a list of sources to fetch
   test('creates a fetch queue with collections', () => {
     const result = getFetchQueue(REGISTRY.sources);
     expect(result.length).toBe(REGISTRY.sources.length);
@@ -246,9 +247,23 @@ describe('gatsby source github all plugin', () => {
 
     const result2 = getFetchQueue(REGISTRY_WITH_COLLECTION.sources);
     expect(result2.length).toBe(REGISTRY_WITH_COLLECTION.sources.length);
-    expect(result2.sources.length).toBe(
+    expect(result2[0].sources.length).toBe(
       REGISTRY_WITH_COLLECTION.sources[0].sourceProperties.sources.length,
     );
+  });
+
+  test('collections within the list have the relevant collection properties', () => {
+    const result = getFetchQueue(REGISTRY.sources);
+    expect(result[0].name).toBeDefined();
+    expect(result[0].type).toBeDefined();
+  });
+
+  test('getFetchQueue passes the correct collection type', () => {
+    const result = getFetchQueue(REGISTRY.sources);
+    expect(result[0].type).toBe(COLLECTION_TYPES.github);
+
+    const result2 = getFetchQueue(REGISTRY_WITH_COLLECTION.sources);
+    expect(result2[0].type).toBe(COLLECTION_TYPES.CURATED);
   });
 
   test('normalize personas converts persona into personas when alone', () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -242,9 +242,11 @@ describe('gatsby source github all plugin', () => {
   test('creates a fetch queue with collections', () => {
     const result = getFetchQueue(REGISTRY.sources);
     expect(result.length).toBe(REGISTRY.sources.length);
+    expect(result[0].sources.length).toBe(1);
 
     const result2 = getFetchQueue(REGISTRY_WITH_COLLECTION.sources);
-    expect(result2.length).toBe(
+    expect(result2.length).toBe(REGISTRY_WITH_COLLECTION.sources.length);
+    expect(result2.sources.length).toBe(
       REGISTRY_WITH_COLLECTION.sources[0].sourceProperties.sources.length,
     );
   });

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/siphonNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/siphonNode.js
@@ -48,7 +48,10 @@ const PERSONAS = {
 
 const PERSONAS_LIST = Object.values(PERSONAS);
 
-const GRAPHQL_NODE_TYPE = 'DevhubSiphon';
+const GRAPHQL_NODE_TYPE = {
+  SIPHON: 'DevhubSiphon',
+  COLLECTION: 'DevhubSiphonCollection',
+};
 
 module.exports = {
   UNFURL_TYPES,

--- a/app-web/src/utils/gatsby-remark-transform-path.js
+++ b/app-web/src/utils/gatsby-remark-transform-path.js
@@ -64,7 +64,7 @@ const getGithubBasePath = (repo, owner, branch = 'master') => {
  */
 const converter = (astType, path, parentQLnode) => {
   // only convert source devhub nodes
-  if (parentQLnode.internal.type === GRAPHQL_NODE_TYPE) {
+  if (parentQLnode.internal.type === GRAPHQL_NODE_TYPE.SIPHON) {
     // normalize the path so that any paths that have no leading slash are assumed to be relative
     const normalizedPath = normalizeFilePath(path);
     let absolutePath;


### PR DESCRIPTION
## Summary
Update Siphon to create collection nodes that reference their child siphon nodes.
In this pr, the fetch queue fn was refactored to create a list of 'collections'. This list is used looped over and sources fetched in a similar fashion leading to a backwards compatible way of fetching sources. 

The over all work required to convert siphon collections to a first class object is not entirely extensive but is best broken into smaller PRs. Therefor, this is the first of n successive prs.

Issue: #260 