### PR TITLE
Siphon Collections as a First class object ( pr 2 of n)

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -542,7 +542,17 @@ const PROCESSED_WEB_SOURCE = {
   path: 'https://example.com',
 };
 
+// different from the registry with the collection,
+// when the collection is processed through the fetch queue
+// the type property is bound to it based on conditions
+const COLLECTION_OBJ_FROM_FETCH_QUEUE = {
+  type: 'curated',
+  name: 'foo',
+  sources: [],
+};
+
 module.exports = {
+  COLLECTION_OBJ_FROM_FETCH_QUEUE,
   GITHUB_API,
   PROCESSED_FILE_MD,
   PROCESSED_FILE_TXT,

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -26,13 +26,14 @@ import {
   getFetchQueue,
   normalizePersonas,
 } from '../sourceNodes';
-import { createSiphonNode } from '../utils/createNode';
+import { createSiphonNode, createCollectionNode } from '../utils/createNode';
 import { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } from '../utils/constants';
 import {
   GRAPHQL_NODES_WITH_REGISTRY,
   GRAPHQL_NODES_WITHOUT_REGISTRY,
   REGISTRY,
   REGISTRY_WITH_COLLECTION,
+  COLLECTION_OBJ_FROM_FETCH_QUEUE,
 } from '../__fixtures__/fixtures';
 import { validateSourceRegistry } from '../utils/fetchSource';
 
@@ -206,6 +207,23 @@ describe('gatsby source github all plugin', () => {
     };
 
     expect(createSiphonNode(file, '123')).toEqual(expected);
+  });
+
+  test('createCollectionNode returns an object', () => {
+    const result = createCollectionNode(COLLECTION_OBJ_FROM_FETCH_QUEUE, '123');
+    const expected = {
+      id: '123',
+      name: result.name,
+      type: result.type,
+      children: [],
+      parent: null,
+      internal: {
+        contentDigest: JSON.stringify(COLLECTION_OBJ_FROM_FETCH_QUEUE),
+        type: GRAPHQL_NODE_TYPE.COLLECTION,
+      },
+    };
+
+    expect(result).toEqual(expected);
   });
 
   test('sourcesAreValid handles collections of sources', () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -18,7 +18,6 @@
 // Created by Patrick Simonian on 2018-10-12.
 //
 import {
-  createSiphonNode,
   checkRegistry,
   getRegistry,
   filterIgnoredResources,
@@ -27,6 +26,7 @@ import {
   getFetchQueue,
   normalizePersonas,
 } from '../sourceNodes';
+import { createSiphonNode } from '../utils/createNode';
 import { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } from '../utils/constants';
 import {
   GRAPHQL_NODES_WITH_REGISTRY,

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -17,9 +17,9 @@
 //
 // Created by Patrick Simonian on 2018-10-12.
 //
-const crypto = require('crypto');
 const _ = require('lodash'); // eslint-disable-line
 const chalk = require('chalk'); // eslint-disable-line
+const { hashString } = require('./utils/helpers');
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
 const { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } = require('./utils/constants');
 const { TypeCheck } = require('@bcgov/common-web-utils');
@@ -61,10 +61,7 @@ const createSiphonNode = (data, id) => ({
     personas: data.metadata.personas, // persona from the source registry, see constants for valid personas
   },
   internal: {
-    contentDigest: crypto
-      .createHash('md5')
-      .update(JSON.stringify(data))
-      .digest('hex'),
+    contentDigest: hashString(JSON.stringify(data)),
     // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate
     // to transformer plugins this node has data they can further process.
     mediaType: data.metadata.mediaType,
@@ -276,11 +273,7 @@ const sourceNodes = async ({ getNodes, actions, createNodeId }, { tokens, source
         dataToNodify = filterIgnoredResources(dataToNodify);
         // create nodes
         return dataToNodify.map(file => {
-          const fileHash = crypto
-            .createHash('md5')
-            .update(JSON.stringify(file.metadata))
-            .digest('hex');
-
+          const fileHash = hashString(JSON.stringify(file.metadata));
           return createNode(createSiphonNode(file, createNodeId(fileHash)));
         });
       }),
@@ -293,6 +286,7 @@ const sourceNodes = async ({ getNodes, actions, createNodeId }, { tokens, source
     throw e;
   }
 };
+
 module.exports = {
   getRegistry,
   checkRegistry,

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -19,59 +19,11 @@
 //
 const _ = require('lodash'); // eslint-disable-line
 const chalk = require('chalk'); // eslint-disable-line
+const { TypeCheck } = require('@bcgov/common-web-utils');
 const { hashString } = require('./utils/helpers');
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
-const { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } = require('./utils/constants');
-const { TypeCheck } = require('@bcgov/common-web-utils');
-
-/**
- * creates a object that is passed to the gatsby create node function
- * many of these properties are assigned by convention
- * @param {Object} data
- * @param {String} id
- */
-const createSiphonNode = (data, id) => ({
-  id,
-  children: [],
-  fileName: data.metadata.fileName,
-  fileType: data.metadata.fileType,
-  name: data.metadata.name,
-  owner: data.metadata.owner,
-  parent: null,
-  path: data.path,
-  unfurl: data.metadata.unfurl, // normalized unfurled content from various sources https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254
-  collection: {
-    name: data.metadata.collection.name, // name of the collection
-    type: data.metadata.collection.type,
-  },
-  source: {
-    name: data.metadata.source, // the source-name
-    displayName: data.metadata.sourceName, // the pretty name of the 'source'
-    sourcePath: data.metadata.sourceURL, // the path to the source
-    type: data.metadata.sourceType, // the type of the source
-    _properties: data.metadata.sourceProperties, // the source properties mapped to the node from the registry
-  },
-  resource: {
-    path: data.metadata.resourcePath, // either path to a gastby created page based on this node
-    type: data.metadata.resourceType, // the base resource type for this see utils/constants.js
-    originalSource: data.metadata.originalResourceLocation, // the original location of the resource
-  },
-  attributes: {
-    labels: data.metadata.labels, // labels from source registry
-    personas: data.metadata.personas, // persona from the source registry, see constants for valid personas
-  },
-  internal: {
-    contentDigest: hashString(JSON.stringify(data)),
-    // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate
-    // to transformer plugins this node has data they can further process.
-    mediaType: data.metadata.mediaType,
-    // A globally unique node type chosen by the plugin owner.
-    type: GRAPHQL_NODE_TYPE.SIPHON,
-    // Optional field exposing the raw content for this node
-    // that transformer plugins can take and further process.
-    content: data.content,
-  },
-});
+const { COLLECTION_TYPES } = require('./utils/constants');
+const { createSiphonNode } = require('./utils/createNode');
 
 /**
  * returns true/false if source contains more sources

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+const { hashString } = require('./helpers');
+const { GRAPHQL_NODE_TYPE } = require('./constants');
+
+/**
+ * creates the object that is passed into the gatsby create node function
+ * to create a siphon collection node type
+ * @param {Object} collection the collection object
+ * @param {String} id the unique id
+ */
+const createCollectionNode = (collection, id) => {
+  const { name, type } = collection;
+  return {
+    id,
+    children: [],
+    parent: null,
+    name,
+    type,
+    internal: {
+      contentDigest: hashString(JSON.stringify(collection)),
+      type: GRAPHQL_NODE_TYPE.COLLECTION,
+    },
+  };
+};
+
+/**
+ * creates a object that is passed to the gatsby create node function
+ * many of these properties are assigned by convention
+ * @param {Object} data the siphon node data
+ * @param {String} id the unique id
+ */
+const createSiphonNode = (data, id) => ({
+  id,
+  children: [],
+  fileName: data.metadata.fileName,
+  fileType: data.metadata.fileType,
+  name: data.metadata.name,
+  owner: data.metadata.owner,
+  parent: null,
+  path: data.path,
+  unfurl: data.metadata.unfurl, // normalized unfurled content from various sources https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254
+  collection: {
+    name: data.metadata.collection.name, // name of the collection
+    type: data.metadata.collection.type,
+  },
+  source: {
+    name: data.metadata.source, // the source-name
+    displayName: data.metadata.sourceName, // the pretty name of the 'source'
+    sourcePath: data.metadata.sourceURL, // the path to the source
+    type: data.metadata.sourceType, // the type of the source
+    _properties: data.metadata.sourceProperties, // the source properties mapped to the node from the registry
+  },
+  resource: {
+    path: data.metadata.resourcePath, // either path to a gastby created page based on this node
+    type: data.metadata.resourceType, // the base resource type for this see utils/constants.js
+    originalSource: data.metadata.originalResourceLocation, // the original location of the resource
+  },
+  attributes: {
+    labels: data.metadata.labels, // labels from source registry
+    personas: data.metadata.personas, // persona from the source registry, see constants for valid personas
+  },
+  internal: {
+    contentDigest: hashString(JSON.stringify(data)),
+    // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate
+    // to transformer plugins this node has data they can further process.
+    mediaType: data.metadata.mediaType,
+    // A globally unique node type chosen by the plugin owner.
+    type: GRAPHQL_NODE_TYPE.SIPHON,
+    // Optional field exposing the raw content for this node
+    // that transformer plugins can take and further process.
+    content: data.content,
+  },
+});
+
+module.exports = {
+  createSiphonNode,
+  createCollectionNode,
+};

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -15,22 +15,23 @@ limitations under the License.
 
 Created by Patrick Simonian
 */
+const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
+const path = require('path');
+const crypto = require('crypto');
+const url = require('url');
+const chalk = require('chalk');
+const shorthash = require('shorthash');
+const stringSimilarity = require('string-similarity');
+const scrape = require('html-metadata');
+const validUrl = require('valid-url');
+const { RESOURCE_TYPES_LIST, UNFURL_TYPES } = require('./constants');
+
 /**
  * returns an idempotent path based on a base path plus a digestable string that is hashed
  * @param {String} base the base path (which is not changed)
  * @param  {...String} digestables comma seperated list of strings which are dsigested by shorthash
  * @returns {String} ie (/mypath, file.md) => /mypath/123dsfakjhdf
  */
-const { TypeCheck } = require('@bcgov/common-web-utils'); // eslint-disable-line
-const path = require('path');
-const url = require('url');
-const chalk = require('chalk');
-const shorthash = require('shorthash');
-const stringSimilarity = require('string-similarity');
-const { RESOURCE_TYPES_LIST, UNFURL_TYPES } = require('./constants');
-const scrape = require('html-metadata');
-const validUrl = require('valid-url');
-
 const createPathWithDigest = (base, ...digestables) => {
   if (!TypeCheck.isString(base)) {
     throw new Error('base must be a string');
@@ -175,7 +176,19 @@ const unfurlWebURI = async uri => {
   return createUnfurlObj(UNFURL_TYPES.EXTERNAL, combinedData);
 };
 
+/**
+ * returns a md5 hash
+ * @param {String} content the string to be hashed
+ * @returns {String} the hash
+ */
+const hashString = content =>
+  crypto
+    .createHash('md5')
+    .update(content)
+    .digest('hex');
+
 module.exports = {
+  hashString,
   createPathWithDigest,
   createUnfurlObj,
   getClosestResourceType,


### PR DESCRIPTION
## Summary
This is part two of many parts in a series of small pull requests working to refactor siphon to create collection objects.

#265 

### Notable Changes
- refactor a few functions and added the createCollection fn with unit tests (not implemented yet though)
