### PR TITLE
Siphon Collections as First Class Object (pr 3 of n)

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -548,7 +548,7 @@ const PROCESSED_WEB_SOURCE = {
 const COLLECTION_OBJ_FROM_FETCH_QUEUE = {
   type: 'curated',
   name: 'foo',
-  sources: [],
+  sources: [WEB_SOURCE],
 };
 
 module.exports = {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -20,13 +20,15 @@ describe('Integration Tests Source Nodes', () => {
     shortid.generate = jest.fn(() => 1);
   });
 
-  test.skip('sourceNodes creates nodes of type DevhubSyphon', async () => {
+  test('sourceNodes runs without crashing', async () => {
     const actions = {
-      createNode: node => node,
+      createNode: jest.fn(node => node),
+      createParentChildLink: jest.fn(obj => obj),
     };
+
     const createNodeId = jest.fn(() => 1);
     const getNodes = jest.fn(() => GRAPHQL_NODES_WITH_REGISTRY);
-    const nodes = await sourceNodes({ actions, createNodeId, getNodes }, CONFIG_OPTIONS);
-    expect(nodes.every(node => node.internal.type === GRAPHQL_NODE_TYPE.SIPHON)).toBe(true);
+    const collections = await sourceNodes({ actions, createNodeId, getNodes }, CONFIG_OPTIONS);
+    expect(collections).toBeDefined();
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -20,7 +20,7 @@ describe('Integration Tests Source Nodes', () => {
     shortid.generate = jest.fn(() => 1);
   });
 
-  test('sourceNodes creates nodes of type DevhubSyphon', async () => {
+  test.skip('sourceNodes creates nodes of type DevhubSyphon', async () => {
     const actions = {
       createNode: node => node,
     };

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -25,6 +25,7 @@ import {
   mapInheritedSourceAttributes,
   getFetchQueue,
   normalizePersonas,
+  processSource,
 } from '../sourceNodes';
 import { createSiphonNode, createCollectionNode } from '../utils/createNode';
 import { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } from '../utils/constants';
@@ -34,8 +35,10 @@ import {
   REGISTRY,
   REGISTRY_WITH_COLLECTION,
   COLLECTION_OBJ_FROM_FETCH_QUEUE,
+  WEB_SOURCE,
+  PROCESSED_WEB_SOURCE,
 } from '../__fixtures__/fixtures';
-import { validateSourceRegistry } from '../utils/fetchSource';
+import { validateSourceRegistry, fetchFromSource } from '../utils/fetchSource';
 
 jest.mock('crypto');
 
@@ -335,5 +338,22 @@ describe('gatsby source github all plugin', () => {
     };
 
     expect(normalizePersonas(attributes)).toEqual(expected);
+  });
+
+  test('returns a list of source node objects', async () => {
+    fetchFromSource.mockReturnValue(Promise.resolve([PROCESSED_WEB_SOURCE]));
+    const createNodeId = jest.fn(() => 1);
+    const createNode = jest.fn(node => node);
+
+    const result = await processSource(WEB_SOURCE, createNodeId, createNode, {});
+
+    expect(result instanceof Array).toBe(true);
+    expect(result.length).toBe(1);
+
+    const node = result[0];
+
+    expect(typeof node).toBe('object');
+    // validate the 'node' has properties that would only exist if the createNode fn was called to create the object
+    expect(node.id).toBeDefined();
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -20,19 +20,10 @@
 const _ = require('lodash'); // eslint-disable-line
 const chalk = require('chalk'); // eslint-disable-line
 const { TypeCheck } = require('@bcgov/common-web-utils');
-const { hashString } = require('./utils/helpers');
+const { hashString, isSourceCollection } = require('./utils/helpers');
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
 const { COLLECTION_TYPES } = require('./utils/constants');
-const { createSiphonNode } = require('./utils/createNode');
-
-/**
- * returns true/false if source contains more sources
- * @param {Object} source
- * @returns {Boolean}
- */
-const isSourceCollection = source =>
-  Object.prototype.hasOwnProperty.call(source.sourceProperties, 'sources') &&
-  TypeCheck.isArray(source.sourceProperties.sources);
+const { createSiphonNode, createCollectionNode } = require('./utils/createNode');
 
 /**
  * maps root level attributes to a child 'source'
@@ -210,14 +201,54 @@ const processSource = async (source, createNodeId, createNode, tokens) => {
   const resources = await fetchFromSource(source.sourceType, source, tokens);
   // any resources that hvae the metadata ignore flag are filtered out to prevent a node being created
   const filteredResources = filterIgnoredResources(resources);
-
-  return filteredResources.map(resource => {
-    const hash = hashString(JSON.stringify(resource));
-    const id = createNodeId(hash);
-    const node = createNode(createSiphonNode(resource, id));
-    return node;
-  });
+  return Promise.all(
+    filteredResources.map(async resource => {
+      const hash = hashString(JSON.stringify(resource));
+      const id = createNodeId(hash);
+      const siphonNode = createSiphonNode(resource, id);
+      await createNode(siphonNode);
+      return siphonNode;
+    }),
+  );
 };
+
+/**
+ * process the collection and fetches all sources for it
+ * creating a collection node and all source nodes for the collection,
+ * @param {Object} collection the collection
+ * @param {Function} createNodeId gatsby fn
+ * @param {Function} createNode gatsby fn
+ * @param {Function} createParentChildLink gatsby fn
+ * @param {Object} tokens tokens passed from options
+ * @returns {Object} the collection object
+ * {
+ *   ...collectionProperties
+ *   sources: [{...source}]
+ * }
+ */
+const processCollection = async (
+  collection,
+  createNodeId,
+  createNode,
+  createParentChildLink,
+  tokens,
+) => {
+  const hash = hashString(JSON.stringify(collection));
+  // id for collection node
+  const id = createNodeId(hash);
+  // fetch all sources
+  const sourceNodes = await Promise.all(
+    collection.sources.map(source => processSource(source, createNodeId, createNode, tokens)),
+  );
+  // flatten source nodes to get a list of all the resources
+  const resources = _.flatten(sourceNodes, true);
+  const collectionNode = createCollectionNode(collection, id);
+  await createNode(collectionNode);
+  resources.forEach(r => createParentChildLink({ parent: collectionNode, child: r }));
+  // establish a parent child link between all resources and the collection node
+  return collectionNode;
+};
+
 /**
  * event handler for the gatsby source plugin
  * more info https://www.gatsbyjs.org/docs/create-source-plugin/
@@ -228,7 +259,7 @@ const processSource = async (source, createNodeId, createNode, tokens) => {
 const sourceNodes = async ({ getNodes, actions, createNodeId }, { tokens, sourceRegistryType }) => {
   // get registry from current nodes
   const registry = getRegistry(getNodes, sourceRegistryType);
-  const { createNode } = actions;
+  const { createNode, createParentChildLink } = actions;
   try {
     // check registry prior to fetching data
     checkRegistry(registry);
@@ -236,22 +267,12 @@ const sourceNodes = async ({ getNodes, actions, createNodeId }, { tokens, source
     const fetchQueue = getFetchQueue(registry.sources);
 
     const collections = await Promise.all(
-      fetchQueue.map(async collection => {
-        const sources = await Promise.all(
-          collection.sources.map(source => fetchFromSource(source.sourceType, source, tokens)),
-        );
-        // sources is an array of arrays [[source data], [source data]] etc
-        // so we flatten it into a 1 dimensional array
-        let dataToNodify = _.flatten(sources, true);
-        dataToNodify = filterIgnoredResources(dataToNodify);
-        // create nodes
-        return dataToNodify.map(file => {
-          const fileHash = hashString(JSON.stringify(file.metadata));
-          return createNode(createSiphonNode(file, createNodeId(fileHash)));
-        });
-      }),
+      fetchQueue.map(async collection =>
+        processCollection(collection, createNodeId, createNode, createParentChildLink, tokens),
+      ),
     );
-    return _.flatten(collections, true);
+
+    return collections;
   } catch (e) {
     // failed to retrieve files or some other type of failure
     // eslint-disable-next-line
@@ -271,4 +292,5 @@ module.exports = {
   getFetchQueue,
   normalizePersonas,
   processSource,
+  processCollection,
 };

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -198,6 +198,27 @@ const getFetchQueue = sources => {
 };
 
 /**
+ * fetches source based on source type and source properties
+ * if source is found to be a collection it recurses over and return
+ * @param {Object} source the source object
+ * @param {Function} createNodeId gatsby fn
+ * @param {Function} createNode gatsby fn
+ * @param {Object} tokens the tokens passed from options
+ * @returns {Array} the list of resources retrieved from the source
+ */
+const processSource = async (source, createNodeId, createNode, tokens) => {
+  const resources = await fetchFromSource(source.sourceType, source, tokens);
+  // any resources that hvae the metadata ignore flag are filtered out to prevent a node being created
+  const filteredResources = filterIgnoredResources(resources);
+
+  return filteredResources.map(resource => {
+    const hash = hashString(JSON.stringify(resource));
+    const id = createNodeId(hash);
+    const node = createNode(createSiphonNode(resource, id));
+    return node;
+  });
+};
+/**
  * event handler for the gatsby source plugin
  * more info https://www.gatsbyjs.org/docs/create-source-plugin/
  * @param {Object} gatsbyEventObject
@@ -249,4 +270,5 @@ module.exports = {
   mapInheritedSourceAttributes,
   getFetchQueue,
   normalizePersonas,
+  processSource,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -187,6 +187,15 @@ const hashString = content =>
     .update(content)
     .digest('hex');
 
+/**
+ * returns true/false if source contains more sources
+ * @param {Object} source
+ * @returns {Boolean}
+ */
+const isSourceCollection = source =>
+  Object.prototype.hasOwnProperty.call(source.sourceProperties, 'sources') &&
+  TypeCheck.isArray(source.sourceProperties.sources);
+
 module.exports = {
   hashString,
   createPathWithDigest,
@@ -196,4 +205,5 @@ module.exports = {
   getAbsolutePathFromRelative,
   validateSourceAgainstSchema,
   unfurlWebURI,
+  isSourceCollection,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
@@ -186,6 +186,7 @@ const fetchSourceGithub = async (
   token,
 ) => {
   const { repo, owner, branch, url } = sourceProperties;
+
   let filesToFetch = [];
   // how are we sourcing this?
   if (isConfigForFetchingAFile(sourceProperties)) {
@@ -198,6 +199,7 @@ const fetchSourceGithub = async (
     // get files based on the github tree and other configs
     filesToFetch = await getFilesFromRepo(sourceProperties, token);
   }
+
   // actually fetch file contents and transform
   const filesWithContents = fetchFiles(filesToFetch, token);
   const filesResponse = await Promise.all(filesWithContents);


### PR DESCRIPTION
## Summary
This is the final integration piece for the siphon collections. Collection nodes are now created with a link to each child siphon node.

nodes can now be queried like so
```graphql
query {
  allDevhubSiphonCollection {
    edges {
      node {
        id
        name
        childrenDevhubSiphon {
          id
          name
          ...siphonNodeProps
        }
      }
    }
  }
}
```

#265 #266 

Fixes #260 