### PR TITLE
add platform services wiki to devhub

### DIFF
--- a/app-web/source-registry/registry.yml
+++ b/app-web/source-registry/registry.yml
@@ -39,6 +39,21 @@ sources:
         - Wiki
         - How To
       persona: 'Developer'
+  - name: Platform Services Wiki
+    sourceType: 'github'
+    sourceProperties:
+      url: https://github.com/BCDevOps/platform-services
+      owner: BCDevOps
+      repo: 'platform-services'
+      context: 'wiki'
+    resourceType: 'Documentation'
+    attributes:
+      labels:
+        - Guides
+        - Repository
+        - Wiki
+        - How To
+      persona: 'Developer'
   - name: OpenShift Components
     sourceType: 'github'
     sourceProperties:


### PR DESCRIPTION
## Summary
First try to add a platform-services wiki to the devhub. Might need adjusting :) 

## Notable Changes <!-- if any -->
- Adding the platform-services wiki folder as a documentation source
