### PR TITLE
Refactor Siphon validation Routine to ready for registration level validations

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -6,7 +6,7 @@ import {
   CONFIG_OPTIONS,
 } from '../__fixtures__/fixtures';
 import { GRAPHQL_NODE_TYPE } from '../utils/constants';
-import { sourceNodes } from '../sourceNodes';
+import { sourceNodes, validateRegistryItem } from '../sourceNodes';
 import { fetchSourceGithub, validateSourceGithub } from '../utils/sources/github';
 
 jest.mock('../utils/sources/github/index.js');
@@ -18,6 +18,14 @@ describe('Integration Tests Source Nodes', () => {
     validateSourceGithub.mockReturnValue(true);
     // mock out short id generate to consistly return the same id
     shortid.generate = jest.fn(() => 1);
+  });
+
+  test('validateRegistryItem returns true if name and sourceProperties exist', () => {
+    const registryItem = {
+      name: 'foo',
+      sourceProperties: {},
+    };
+    expect(validateRegistryItem(registryItem)).toBe(true);
   });
 
   test('sourceNodes runs without crashing', async () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -27,6 +27,7 @@ import {
   normalizePersonas,
   processSource,
   processCollection,
+  validateRegistryItem,
 } from '../sourceNodes';
 import { createSiphonNode, createCollectionNode } from '../utils/createNode';
 import { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } from '../utils/constants';
@@ -123,14 +124,6 @@ describe('gatsby source github all plugin', () => {
     expect(() => checkRegistry(REGISTRY)).toThrow(
       'Error in Gatsby Source Github All: registry is not valid. One or more repos may be missing required parameters',
     );
-  });
-
-  test('validateRegistryItem returns true if name and sourceProperties exist', () => {
-    const registryItem = {
-      name: 'foo',
-      sourceProperties: {},
-    };
-    expect(validateRegistryItem(registryItem)).toBe(true);
   });
 
   test('createSiphonNode returns data', () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -125,6 +125,14 @@ describe('gatsby source github all plugin', () => {
     );
   });
 
+  test('validateRegistryItem returns true if name and sourceProperties exist', () => {
+    const registryItem = {
+      name: 'foo',
+      sourceProperties: {},
+    };
+    expect(validateRegistryItem(registryItem)).toBe(true);
+  });
+
   test('createSiphonNode returns data', () => {
     const file = {
       metadata: {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -20,9 +20,9 @@
 const _ = require('lodash'); // eslint-disable-line
 const chalk = require('chalk'); // eslint-disable-line
 const { TypeCheck } = require('@bcgov/common-web-utils');
-const { hashString, isSourceCollection } = require('./utils/helpers');
+const { hashString, isSourceCollection, validateSourceAgainstSchema } = require('./utils/helpers');
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
-const { COLLECTION_TYPES } = require('./utils/constants');
+const { COLLECTION_TYPES, REGISTRY_ITEM_SCHEMA } = require('./utils/constants');
 const { createSiphonNode, createCollectionNode } = require('./utils/createNode');
 
 /**
@@ -64,6 +64,13 @@ const sourcesAreValid = sources => {
 
   return sourcesToCheck.every(validateSourceRegistry);
 };
+
+/**
+ * @param {Object} registryItem the registry item found within the registry file sources[index]
+ * @returns {Boolean} true if registry item is valid
+ */
+const validateRegistryItem = registryItem =>
+  validateSourceAgainstSchema(registryItem, REGISTRY_ITEM_SCHEMA);
 
 /**
  * validates source registry
@@ -293,4 +300,5 @@ module.exports = {
   normalizePersonas,
   processSource,
   processCollection,
+  validateRegistryItem,
 };

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -20,7 +20,11 @@
 const _ = require('lodash'); // eslint-disable-line
 const chalk = require('chalk'); // eslint-disable-line
 const { TypeCheck } = require('@bcgov/common-web-utils');
-const { hashString, isSourceCollection, validateSourceAgainstSchema } = require('./utils/helpers');
+const {
+  hashString,
+  isSourceCollection,
+  validateRegistryItemAgainstSchema,
+} = require('./utils/helpers');
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
 const { COLLECTION_TYPES, REGISTRY_ITEM_SCHEMA } = require('./utils/constants');
 const { createSiphonNode, createCollectionNode } = require('./utils/createNode');
@@ -70,7 +74,7 @@ const sourcesAreValid = sources => {
  * @returns {Boolean} true if registry item is valid
  */
 const validateRegistryItem = registryItem =>
-  validateSourceAgainstSchema(registryItem, REGISTRY_ITEM_SCHEMA);
+  validateRegistryItemAgainstSchema(registryItem, REGISTRY_ITEM_SCHEMA);
 
 /**
  * validates source registry

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
@@ -18,7 +18,7 @@ Created by Patrick Simonian
 
 // just a base schema validating root registration properties.
 // nothing internal yet.
-export const REGISTRY_ITEM_SCHEMA = {
+const REGISTRY_ITEM_SCHEMA = {
   name: {
     type: String,
     required: true,
@@ -39,4 +39,8 @@ export const REGISTRY_ITEM_SCHEMA = {
     type: String,
     required: false,
   },
+};
+
+module.exports = {
+  REGISTRY_ITEM_SCHEMA,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Province of British Columbia
+Copyright 2019 Province of British Columbia
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,9 +15,28 @@ limitations under the License.
 
 Created by Patrick Simonian
 */
-module.exports = {
-  ...require('./siphonNode'),
-  ...require('./sourceGithub'),
-  ...require('./sourceTypes'),
-  ...require('./registry'),
+
+// just a base schema validating root registration properties.
+// nothing internal yet.
+export const REGISTRY_ITEM_SCHEMA = {
+  name: {
+    type: String,
+    required: true,
+  },
+  sourceProperties: {
+    type: Object,
+    required: true,
+  },
+  resourceType: {
+    type: String,
+    required: false,
+  },
+  attributes: {
+    type: Object,
+    required: false,
+  },
+  description: {
+    type: String,
+    required: false,
+  },
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -186,7 +186,7 @@ const validateRegistryItemAgainstSchema = (registryItem, schema) => {
   return error.isValid;
 };
 
-/* validates a registry item's source Properties against a valid schema
+/** validates a registry item's source Properties against a valid schema
  * @param {Object} source the registry source item properties
  * @param {Object} schema has shape { type: String | Boolean | Date etc, required: true/false}
  * @returns {Boolean}

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -121,36 +121,87 @@ const getAbsolutePathFromRelative = (relativePath, absolutePath, queryParams) =>
   return absPathObj.toString();
 };
 
+/**
+ * validates an object against a schema
+ * schema is in format
+ * {
+ *  [object key name] : {
+ *    type: [object constructor String | Array | Object etc],
+ *    required: [Boolean]
+ *  }
+ * }
+ * @param {Object} obj the object that is being tested
+ * @param {Object} schema the schema object that is being tested against
+ * @returns {Object} an object containing error messages and isValid property
+ * {
+ *   errors: {Array},
+ *   isValid: {Boolean}
+ * }
+ */
+const validateAgainstSchema = (obj, schema) => {
+  const error = {
+    messages: [],
+  };
+
+  Object.keys(schema).every(key => {
+    const schemaItem = schema[key];
+    let isValid = true;
+    if (schemaItem.required) {
+      isValid =
+        Object.prototype.hasOwnProperty.call(obj, key) && TypeCheck.isA(schemaItem.type, obj[key]);
+      // does this source property have it anyways?
+    } else if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      isValid = TypeCheck.isA(schemaItem.type, obj[key]);
+    }
+
+    if (!isValid) {
+      error.messages.push(
+        `Error Validating Source: failed on property ${key}, received value ${obj[key]}`,
+      );
+    }
+    return isValid;
+  });
+
+  error.isValid = error.messages.length === 0;
+
+  return error;
+};
+
+/**
+ * verifies registry item against schema
+ * @param {Object} registryItem the registry item
+ * @param {Object} schema the schema to test against
+ * @returns {Boolean}
+ */
+const validateRegistryItemAgainstSchema = (registryItem, schema) => {
+  const error = validateAgainstSchema(registryItem, schema);
+  if (!error.isValid) {
+    console.error(
+      chalk`{red.bold \nError Validating Registry item}`,
+      '\n',
+      error.messages.join('\n-'),
+    );
+  }
+
+  return error.isValid;
+};
+
 /* validates a registry item's source Properties against a valid schema
  * @param {Object} source the registry source item properties
  * @param {Object} schema has shape { type: String | Boolean | Date etc, required: true/false}
  * @returns {Boolean}
  */
-const validateSourceAgainstSchema = (source, schema) => {
-  return Object.keys(schema).every(key => {
-    const schemaItem = schema[key];
-    let isValid = true;
+const validateSourcePropertiesAgainstSchema = (source, schema) => {
+  const error = validateAgainstSchema(source.sourceProperties, schema);
+  if (!error.isValid) {
+    console.error(
+      chalk`{red.bold \nError Validating Source type ${source.sourceType}}`,
+      '\n',
+      error.messages.join('\n-'),
+    );
+  }
 
-    if (schemaItem.required) {
-      isValid =
-        Object.prototype.hasOwnProperty.call(source.sourceProperties, key) &&
-        TypeCheck.isA(schemaItem.type, source.sourceProperties[key]);
-      // does this source property have it anyways?
-    } else if (Object.prototype.hasOwnProperty.call(source.sourceProperties, key)) {
-      isValid = TypeCheck.isA(schemaItem.type, source.sourceProperties[key]);
-    }
-
-    if (!isValid) {
-      console.error(
-        chalk`{red.bold \nError Validating Source type ${source.sourceType}} 
-
-       Source failed on validation on source property {yellow.bold ${key}}
-       received value {yellow.bold ${source.sourceProperties[key]}}`,
-      );
-    }
-
-    return isValid;
-  });
+  return error.isValid;
 };
 
 const unfurlWebURI = async uri => {
@@ -203,7 +254,8 @@ module.exports = {
   getClosestResourceType,
   getClosestPersona,
   getAbsolutePathFromRelative,
-  validateSourceAgainstSchema,
+  validateSourcePropertiesAgainstSchema,
+  validateRegistryItemAgainstSchema,
   unfurlWebURI,
   isSourceCollection,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
@@ -33,7 +33,7 @@ const {
   filterFilesFromDirectories,
   applyBaseMetadata,
 } = require('./helpers');
-const { validateSourceAgainstSchema } = require('../../helpers');
+const { validateSourcePropertiesAgainstSchema } = require('../../helpers');
 
 /**
  * Using the recursion param, this
@@ -162,7 +162,8 @@ const getFilesFromRepo = async ({ repo, owner, branch, context, ignores }, token
  * @param {Object} source
  * @returns {Boolean}
  */
-const validateSourceGithub = source => validateSourceAgainstSchema(source, GITHUB_SOURCE_SCHEMA);
+const validateSourceGithub = source =>
+  validateSourcePropertiesAgainstSchema(source, GITHUB_SOURCE_SCHEMA);
 
 /**
  * returns a flattened array of github files from a repository

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -16,14 +16,15 @@ limitations under the License.
 Created by Patrick Simonian
 */
 const { WEB_SOURCE_SCHEMA, MEDIATYPES } = require('../../constants');
-const { validateSourceAgainstSchema, unfurlWebURI } = require('../../helpers');
+const { validateSourcePropertiesAgainstSchema, unfurlWebURI } = require('../../helpers');
 
 /**
  * validates the source properties against the web source schema
  * @param {Object} source the registry source item
  * @returns {Boolean}
  */
-const validateSourceWeb = source => validateSourceAgainstSchema(source, WEB_SOURCE_SCHEMA);
+const validateSourceWeb = source =>
+  validateSourcePropertiesAgainstSchema(source, WEB_SOURCE_SCHEMA);
 
 /**
  * fetches data from a web source


### PR DESCRIPTION
## Summary
At this point registration configurations are not being validated, this pr is a slight refactor to the validation routine to allow for a predictable registry validation. 

## Notable Changes <!-- if any -->
- took a functional approach to the `validateSourceAgainstSchema` when refactoring, took out the common bits into `validateAgainstSchema` and use `validateSourceAgainstSchema` as a wrapper.


this is an effort for #258 