### PR TITLE
Add support for collection descriptions

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -548,6 +548,7 @@ const PROCESSED_WEB_SOURCE = {
 const COLLECTION_OBJ_FROM_FETCH_QUEUE = {
   type: 'curated',
   name: 'foo',
+  description: 'blah',
   sources: [WEB_SOURCE],
 };
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -3,6 +3,7 @@ import {
   createUnfurlObj,
   getClosestResourceType,
   unfurlWebURI,
+  validateAgainstSchema,
 } from '../utils/helpers';
 import { RESOURCE_TYPES } from '../utils/constants';
 
@@ -62,5 +63,61 @@ describe('unfurlWebURI', () => {
         error: 'The uri is not valid',
       });
     }
+  });
+
+  describe('validateAgainstSchema', () => {
+    let schema;
+    beforeEach(() => {
+      schema = {
+        foo: {
+          type: String,
+          required: true,
+        },
+        bar: {
+          type: String,
+          required: false,
+        },
+      };
+    });
+
+    it('returns an object with a messages property that is an array', () => {
+      const result = validateAgainstSchema({}, schema);
+      expect(typeof result).toBe('object');
+      expect(result.messages instanceof Array).toBe(true);
+    });
+
+    it('returns an object with an isValid property that is boolean', () => {
+      const result = validateAgainstSchema({}, schema);
+      expect(typeof result).toBe('object');
+      expect(typeof result.isValid).toBe('boolean');
+    });
+
+    it('validates schema and returns true when valid', () => {
+      const object = {
+        foo: 'foo',
+        bar: 'bar',
+      };
+      const result = validateAgainstSchema(object, schema);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('validates not required properties if passed in', () => {
+      const object = {
+        foo: 'foo',
+        bar: 1, // bar is not required but sould be a string
+      };
+      const result = validateAgainstSchema(object, schema);
+      expect(result.isValid).toBe(false);
+      expect(result.messages.length).toBe(1);
+    });
+
+    it('validates required properties', () => {
+      const object = {
+        bar: 'foo',
+      };
+      const result = validateAgainstSchema(object, schema);
+      expect(result.isValid).toBe(false);
+      expect(result.messages.length).toBe(1);
+    });
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -4,6 +4,7 @@ import {
   getClosestResourceType,
   unfurlWebURI,
   validateAgainstSchema,
+  newCollection,
 } from '../utils/helpers';
 import { RESOURCE_TYPES } from '../utils/constants';
 
@@ -118,6 +119,23 @@ describe('unfurlWebURI', () => {
       const result = validateAgainstSchema(object, schema);
       expect(result.isValid).toBe(false);
       expect(result.messages.length).toBe(1);
+    });
+  });
+
+  describe('newCollection', () => {
+    it('it binds properties to a new collection object', () => {
+      const collection = {
+        name: 'foo',
+        sources: [],
+      };
+
+      const props = {
+        description: 'bar',
+      };
+
+      const updatedCollection = newCollection(collection, props);
+      expect(updatedCollection).not.toBe(collection);
+      expect(updatedCollection.description).toBe(props.description);
     });
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -28,6 +28,19 @@ describe('Integration Tests Source Nodes', () => {
     expect(validateRegistryItem(registryItem)).toBe(true);
   });
 
+  test("validateRegistry returns false if name or sourceProperties don't exist", () => {
+    const registryItem1 = {
+      sourceProperties: {},
+    };
+
+    const registryItem2 = {
+      name: 'foo',
+    };
+
+    expect(validateRegistryItem(registryItem1)).toBe(false);
+    expect(validateRegistryItem(registryItem2)).toBe(false);
+  });
+
   test('sourceNodes runs without crashing', async () => {
     const actions = {
       createNode: jest.fn(node => node),

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -5,7 +5,6 @@ import {
   GRAPHQL_NODES_WITH_REGISTRY,
   CONFIG_OPTIONS,
 } from '../__fixtures__/fixtures';
-import { GRAPHQL_NODE_TYPE } from '../utils/constants';
 import { sourceNodes, validateRegistryItem } from '../sourceNodes';
 import { fetchSourceGithub, validateSourceGithub } from '../utils/sources/github';
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -228,8 +228,9 @@ describe('gatsby source github all plugin', () => {
     const result = createCollectionNode(COLLECTION_OBJ_FROM_FETCH_QUEUE, '123');
     const expected = {
       id: '123',
-      name: result.name,
-      type: result.type,
+      name: COLLECTION_OBJ_FROM_FETCH_QUEUE.name,
+      type: COLLECTION_OBJ_FROM_FETCH_QUEUE.type,
+      description: COLLECTION_OBJ_FROM_FETCH_QUEUE.description,
       children: [],
       parent: null,
       internal: {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -41,7 +41,7 @@ import {
   PROCESSED_WEB_SOURCE,
 } from '../__fixtures__/fixtures';
 import { validateSourceRegistry, fetchFromSource } from '../utils/fetchSource';
-import { isSourceCollection, hashString } from '../utils/helpers';
+import { isSourceCollection, hashString, validateRegistryItemAgainstSchema } from '../utils/helpers';
 
 jest.mock('../utils/helpers');
 jest.mock('crypto');
@@ -109,6 +109,7 @@ describe('gatsby source github all plugin', () => {
 
   test('checkRegistry returns true if sources are valid', () => {
     validateSourceRegistry.mockReturnValue(true);
+    validateRegistryItemAgainstSchema.mockReturnValue(true);
     expect(checkRegistry(REGISTRY)).toBe(true);
   });
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -27,7 +27,6 @@ import {
   normalizePersonas,
   processSource,
   processCollection,
-  validateRegistryItem,
 } from '../sourceNodes';
 import { createSiphonNode, createCollectionNode } from '../utils/createNode';
 import { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } from '../utils/constants';
@@ -41,7 +40,11 @@ import {
   PROCESSED_WEB_SOURCE,
 } from '../__fixtures__/fixtures';
 import { validateSourceRegistry, fetchFromSource } from '../utils/fetchSource';
-import { isSourceCollection, hashString, validateRegistryItemAgainstSchema } from '../utils/helpers';
+import {
+  isSourceCollection,
+  hashString,
+  validateRegistryItemAgainstSchema,
+} from '../utils/helpers';
 
 jest.mock('../utils/helpers');
 jest.mock('crypto');
@@ -412,7 +415,7 @@ describe('gatsby source github all plugin', () => {
     const createNode = jest.fn(node => node);
     const createParentChildLink = jest.fn();
 
-    const collection = await processCollection(
+    await processCollection(
       COLLECTION_OBJ_FROM_FETCH_QUEUE,
       createNodeId,
       createNode,

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -44,13 +44,14 @@ import {
   isSourceCollection,
   hashString,
   validateRegistryItemAgainstSchema,
+  newCollection,
 } from '../utils/helpers';
 
 jest.mock('../utils/helpers');
 jest.mock('crypto');
 jest.mock('../utils/fetchSource.js');
 fetchFromSource.mockReturnValue(Promise.resolve([PROCESSED_WEB_SOURCE]));
-
+newCollection.mockImplementation((collection, props) => ({ ...collection, ...props }));
 describe('gatsby source github all plugin', () => {
   afterEach(() => {
     isSourceCollection.mockReset();

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -50,6 +50,13 @@ const mapInheritedSourceAttributes = ({ name, attributes, resourceType }, target
 });
 
 /**
+ * @param {Object} registryItem the registry item found within the registry file sources[index]
+ * @returns {Boolean} true if registry item is valid
+ */
+const validateRegistryItem = registryItem =>
+  validateRegistryItemAgainstSchema(registryItem, REGISTRY_ITEM_SCHEMA);
+
+/**
  * loops over sources and validates them based on their type
  * @param {Array} sources the sources
  * @returns {Boolean}
@@ -66,15 +73,8 @@ const sourcesAreValid = sources => {
     }
   });
 
-  return sourcesToCheck.every(validateSourceRegistry);
+  return sourcesToCheck.every(validateSourceRegistry) && sources.every(validateRegistryItem);
 };
-
-/**
- * @param {Object} registryItem the registry item found within the registry file sources[index]
- * @returns {Boolean} true if registry item is valid
- */
-const validateRegistryItem = registryItem =>
-  validateRegistryItemAgainstSchema(registryItem, REGISTRY_ITEM_SCHEMA);
 
 /**
  * validates source registry

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -73,7 +73,7 @@ const sourcesAreValid = sources => {
     }
   });
 
-  return sourcesToCheck.every(validateSourceRegistry) && sources.every(validateRegistryItem);
+  return sourcesToCheck.every(validateSourceRegistry);
 };
 
 /**
@@ -168,12 +168,12 @@ const getFetchQueue = sources => {
   sources.forEach(rootSource => {
     const collection = {
       name: rootSource.name,
-      description: rootSource.description,
       sources: [],
     };
 
     if (isSourceCollection(rootSource)) {
       collection.type = COLLECTION_TYPES.CURATED;
+      collection.description = rootSource.description;
       // if its a collection, the child sources need some properties from the root source to be
       // mapped to it
       const mappedChildSources = rootSource.sourceProperties.sources.map(childSource =>
@@ -255,6 +255,7 @@ const processCollection = async (
   // flatten source nodes to get a list of all the resources
   const resources = _.flatten(sourceNodes, true);
   const collectionNode = createCollectionNode(collection, id);
+
   await createNode(collectionNode);
   resources.forEach(r => createParentChildLink({ parent: collectionNode, child: r }));
   // establish a parent child link between all resources and the collection node

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -168,6 +168,7 @@ const getFetchQueue = sources => {
   sources.forEach(rootSource => {
     const collection = {
       name: rootSource.name,
+      description: rootSource.description,
       sources: [],
     };
 

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -25,13 +25,15 @@ const { GRAPHQL_NODE_TYPE } = require('./constants');
  * @param {String} id the unique id
  */
 const createCollectionNode = (collection, id) => {
-  const { name, type } = collection;
+  const { name, type, description } = collection;
+
   return {
     id,
     children: [],
     parent: null,
     name,
     type,
+    description: description || '',
     internal: {
       contentDigest: hashString(JSON.stringify(collection)),
       type: GRAPHQL_NODE_TYPE.COLLECTION,

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -256,6 +256,7 @@ module.exports = {
   getAbsolutePathFromRelative,
   validateSourcePropertiesAgainstSchema,
   validateRegistryItemAgainstSchema,
+  validateAgainstSchema,
   unfurlWebURI,
   isSourceCollection,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -247,7 +247,18 @@ const isSourceCollection = source =>
   Object.prototype.hasOwnProperty.call(source.sourceProperties, 'sources') &&
   TypeCheck.isArray(source.sourceProperties.sources);
 
+/**
+ * creates the main collection object
+ * which is used later on to create the collection siphon node
+ * optionally allows to bind props to it later
+ * @param {Object} collection
+ * @param {Object} props
+ * @returns {Object} the new collection object
+ */
+const newCollection = (collection, props = {}) => ({ ...collection, ...props });
+
 module.exports = {
+  newCollection,
   hashString,
   createPathWithDigest,
   createUnfurlObj,


### PR DESCRIPTION
## Summary
Siphon supports collection descriptions now
just add description to the collection registry confg
```yaml
- name: Foo
   description: description here
   sourceProperties: 
      ...
```

## Notable Changes <!-- if any -->
- Added unit tests for the schema validation routines as created from pr #274 
- Added more integration tests to siphon

## Notes
Please notes this PR is for siphon only and doesn't not include any UI changes. 

#258 
