### PR TITLE
Implicitly add github repository descriptions when source collection is github

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
@@ -29,12 +29,9 @@ import {
   isConfigForFetchingFiles,
   createFetchFileRoute,
 } from '../utils/sources/github/helpers';
-import {
-  fetchGithubTree,
-  fetchFile,
-  fetchIgnoreFile,
-  validateSourceGithub,
-} from '../utils/sources/github';
+import { fetchIgnoreFile, validateSourceGithub } from '../utils/sources/github';
+import { fetchGithubTree, fetchFile } from '../utils/sources/github/api';
+
 import fetch from 'node-fetch';
 import { GITHUB_API_ENDPOINT } from '../utils/constants';
 import { GITHUB_API, GITHUB_SOURCE } from '../__fixtures__/fixtures';

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceGithub.test.js
@@ -30,7 +30,7 @@ import {
   createFetchFileRoute,
 } from '../utils/sources/github/helpers';
 import { fetchIgnoreFile, validateSourceGithub } from '../utils/sources/github';
-import { fetchGithubTree, fetchFile } from '../utils/sources/github/api';
+import { fetchGithubTree, fetchFile, fetchRepo } from '../utils/sources/github/api';
 
 import fetch from 'node-fetch';
 import { GITHUB_API_ENDPOINT } from '../utils/constants';
@@ -149,6 +149,20 @@ describe('Github API', () => {
         method: 'GET',
       }),
     );
+  });
+
+  test('fetchRepo returns data', async () => {
+    fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify({ description: 'foo' }))));
+    expect.assertions(1);
+    const res = await fetchRepo();
+    expect(res).toEqual({ description: 'foo' });
+  });
+
+  test('fetchRepo returns data if failed', async () => {
+    // simulating failure
+    const r = new Response(JSON.stringify(GITHUB_API.FAIL), { status: 500 });
+    fetch.mockReturnValue(Promise.reject(r));
+    expect(await fetchRepo()).toEqual({});
   });
 
   test('fetchGithubTree returns data', async () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -9,6 +9,9 @@ import {
 } from '../utils/helpers';
 import { RESOURCE_TYPES } from '../utils/constants';
 
+import { fetchRepo } from '../utils/sources/github/api';
+jest.mock('../utils/sources/github//api');
+
 describe('createPathWithDigest', () => {
   it('throws if base is not a string', () => {
     expect(() => createPathWithDigest(9, '123')).toThrow('base must be a string');
@@ -68,15 +71,16 @@ describe('unfurlWebURI', () => {
   });
 
   describe('getCollectionDescriptionBySourceType', () => {
-    it('returns a string', () => {
+    it('returns a string', async () => {
       const source = {
         sourceType: 'foo',
       };
-
-      expect(typeof getCollectionDescriptionBySourceType(source)).toBe('string');
+      const result = await getCollectionDescriptionBySourceType(source);
+      expect(typeof result).toBe('string');
     });
 
-    it('returns fetches github repo description', () => {
+    it('returns fetches github repo description', async () => {
+      fetchRepo.mockReturnValue(Promise.resolve({ description: 'matt damon' }));
       const source = {
         sourceType: 'github',
         sourceProperties: {
@@ -89,7 +93,8 @@ describe('unfurlWebURI', () => {
         GITHUB_API_TOKEN: 'foo',
       };
 
-      expect(getCollectionDescriptionBySourceType(source, tokens)).toBe('matt damon');
+      const result = await getCollectionDescriptionBySourceType(source, tokens);
+      expect(result).toBe('matt damon');
     });
   });
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -5,6 +5,7 @@ import {
   unfurlWebURI,
   validateAgainstSchema,
   newCollection,
+  getCollectionDescriptionBySourceType,
 } from '../utils/helpers';
 import { RESOURCE_TYPES } from '../utils/constants';
 
@@ -64,6 +65,32 @@ describe('unfurlWebURI', () => {
         error: 'The uri is not valid',
       });
     }
+  });
+
+  describe('getCollectionDescriptionBySourceType', () => {
+    it('returns a string', () => {
+      const source = {
+        sourceType: 'foo',
+      };
+
+      expect(typeof getCollectionDescriptionBySourceType(source)).toBe('string');
+    });
+
+    it('returns fetches github repo description', () => {
+      const source = {
+        sourceType: 'github',
+        sourceProperties: {
+          repo: 'foo',
+          owner: 'bar',
+        },
+      };
+
+      const tokens = {
+        GITHUB_API_TOKEN: 'foo',
+      };
+
+      expect(getCollectionDescriptionBySourceType(source, tokens)).toBe('matt damon');
+    });
   });
 
   describe('validateAgainstSchema', () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -41,6 +41,8 @@ describe('Integration Tests Source Nodes', () => {
   });
 
   test('sourceNodes runs without crashing', async () => {
+    jest.setTimeout(10000); // increase timeout to 10 seconds from 5 sec default, this seems to help tests
+    // in openshift
     const actions = {
       createNode: jest.fn(node => node),
       createParentChildLink: jest.fn(obj => obj),

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -281,29 +281,29 @@ describe('gatsby source github all plugin', () => {
   });
 
   // get fetch queue should return a list of collections that contain a list of sources to fetch
-  test('creates a fetch queue with for a source collection', () => {
+  test('creates a fetch queue with for a source collection', async () => {
     isSourceCollection.mockReturnValue(false);
-    const result = getFetchQueue(REGISTRY.sources);
+    const result = await getFetchQueue(REGISTRY.sources);
     expect(result.length).toBe(REGISTRY.sources.length);
     expect(result[0].sources.length).toBe(1);
   });
 
-  test('creates a fetch queue with for a curated collection', () => {
+  test('creates a fetch queue with for a curated collection', async () => {
     isSourceCollection.mockReturnValue(true);
-    const result2 = getFetchQueue(REGISTRY_WITH_COLLECTION.sources);
+    const result2 = await getFetchQueue(REGISTRY_WITH_COLLECTION.sources);
     expect(result2.length).toBe(REGISTRY_WITH_COLLECTION.sources.length);
     expect(result2[0].sources.length).toBe(
       REGISTRY_WITH_COLLECTION.sources[0].sourceProperties.sources.length,
     );
   });
 
-  test('getFetchQueue passes the correct collection type', () => {
+  test('getFetchQueue passes the correct collection type', async () => {
     isSourceCollection.mockReturnValue(false);
-    const result = getFetchQueue(REGISTRY.sources);
+    const result = await getFetchQueue(REGISTRY.sources);
     expect(result[0].type).toBe(COLLECTION_TYPES.github);
 
     isSourceCollection.mockReturnValue(true);
-    const result2 = getFetchQueue(REGISTRY_WITH_COLLECTION.sources);
+    const result2 = await getFetchQueue(REGISTRY_WITH_COLLECTION.sources);
     expect(result2[0].type).toBe(COLLECTION_TYPES.CURATED);
   });
 

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -25,7 +25,7 @@ const stringSimilarity = require('string-similarity');
 const scrape = require('html-metadata');
 const validUrl = require('valid-url');
 const { RESOURCE_TYPES_LIST, UNFURL_TYPES, SOURCE_TYPES } = require('./constants');
-
+const { fetchRepo } = require('./sources/github/api');
 /**
  * returns an idempotent path based on a base path plus a digestable string that is hashed
  * @param {String} base the base path (which is not changed)
@@ -262,10 +262,12 @@ const newCollection = (collection, props = {}) => ({ ...collection, ...props });
  * @param {Object} source
  * @param {Object} tokens
  */
-const getCollectionDescriptionBySourceType = (source, tokens) => {
+const getCollectionDescriptionBySourceType = async (source, tokens) => {
   switch (source.sourceType) {
     case SOURCE_TYPES.GITHUB:
-      return 'foo';
+      const { repo, owner } = source.sourceProperties;
+      const repoData = await fetchRepo(repo, owner, tokens.GITHUB_API_TOKEN);
+      return repoData.description;
     default:
       return '';
   }

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -24,7 +24,7 @@ const shorthash = require('shorthash');
 const stringSimilarity = require('string-similarity');
 const scrape = require('html-metadata');
 const validUrl = require('valid-url');
-const { RESOURCE_TYPES_LIST, UNFURL_TYPES } = require('./constants');
+const { RESOURCE_TYPES_LIST, UNFURL_TYPES, SOURCE_TYPES } = require('./constants');
 
 /**
  * returns an idempotent path based on a base path plus a digestable string that is hashed
@@ -257,6 +257,20 @@ const isSourceCollection = source =>
  */
 const newCollection = (collection, props = {}) => ({ ...collection, ...props });
 
+/** returns a description based on source type
+ * for example, github would retrieve the repo description
+ * @param {Object} source
+ * @param {Object} tokens
+ */
+const getCollectionDescriptionBySourceType = (source, tokens) => {
+  switch (source.sourceType) {
+    case SOURCE_TYPES.GITHUB:
+      return 'foo';
+    default:
+      return '';
+  }
+};
+
 module.exports = {
   newCollection,
   hashString,
@@ -270,4 +284,5 @@ module.exports = {
   validateAgainstSchema,
   unfurlWebURI,
   isSourceCollection,
+  getCollectionDescriptionBySourceType,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/api.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/api.js
@@ -17,6 +17,23 @@ Created by Patrick Simonian
 */
 const fetch = require('node-fetch');
 const { GITHUB_API_ENDPOINT } = require('../../constants');
+
+const fetchRepo = async (repo, owner, token) => {
+  const endPoint = `${GITHUB_API_ENDPOINT}/repos/${owner}/${repo}`;
+  try {
+    const result = await fetch(endPoint, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await result.json();
+    return data;
+  } catch (e) {
+    return {};
+  }
+};
+
 /**
  * Using the recursion param, this
  * function attempts to retrieve all directories/files from a repo
@@ -68,6 +85,7 @@ const fetchFile = async (path, token) => {
 };
 
 module.exports = {
+  fetchRepo,
   fetchFile,
   fetchGithubTree,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/api.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/api.js
@@ -28,7 +28,7 @@ const fetchRepo = async (repo, owner, token) => {
       },
     });
     const data = await result.json();
-    return data;
+    return result.ok ? data : {};
   } catch (e) {
     return {};
   }

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/api.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/api.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+const fetch = require('node-fetch');
+const { GITHUB_API_ENDPOINT } = require('../../constants');
+/**
+ * Using the recursion param, this
+ * function attempts to retrieve all directories/files from a repo
+ * there is a limit on how deep it can go down a tree
+ * as per https://developer.github.com/v3/git/trees/#get-a-tree-recursively
+ * @param {String} repo
+ * @param {String} owner
+ * @param {String} token
+ */
+const fetchGithubTree = async (repo, owner, token, branch = 'master') => {
+  const endPoint = `${GITHUB_API_ENDPOINT}/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
+  try {
+    const result = await fetch(endPoint, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await result.json();
+    return data;
+  } catch (e) {
+    throw e;
+  }
+};
+/**
+ * Fetches contents from file
+ * note the media type header, it converts what would have been a
+ * b64 encoded string of the file contents into either raw string data or json
+ * @param {String} repo
+ * @param {String} owner
+ * @param {String} path
+ * @param {String} token
+ */
+const fetchFile = async (path, token) => {
+  try {
+    const result = await fetch(path, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+      },
+    });
+    const data = await result.json();
+    if (result.ok) return data;
+    return undefined;
+  } catch (e) {
+    throw e;
+  }
+};
+
+module.exports = {
+  fetchFile,
+  fetchGithubTree,
+};

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
@@ -23,7 +23,7 @@ const { Base64 } = require('js-base64'); // eslint-disable-line
 const fetch = require('node-fetch'); // eslint-disable-line
 const ignore = require('ignore'); // eslint-disable-line
 const transformer = require('./githubFileTransformer');
-const { GITHUB_API_ENDPOINT, DEFUALT_IGNORES, GITHUB_SOURCE_SCHEMA } = require('../../constants');
+const { DEFUALT_IGNORES, GITHUB_SOURCE_SCHEMA } = require('../../constants');
 const {
   isConfigForFetchingAFile,
   isConfigForFetchingFiles,
@@ -33,57 +33,8 @@ const {
   filterFilesFromDirectories,
   applyBaseMetadata,
 } = require('./helpers');
+const { fetchFile, fetchGithubTree } = require('./api');
 const { validateSourcePropertiesAgainstSchema } = require('../../helpers');
-
-/**
- * Using the recursion param, this
- * function attempts to retrieve all directories/files from a repo
- * there is a limit on how deep it can go down a tree
- * as per https://developer.github.com/v3/git/trees/#get-a-tree-recursively
- * @param {String} repo
- * @param {String} owner
- * @param {String} token
- */
-const fetchGithubTree = async (repo, owner, token, branch = 'master') => {
-  const endPoint = `${GITHUB_API_ENDPOINT}/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
-  try {
-    const result = await fetch(endPoint, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    const data = await result.json();
-    return data;
-  } catch (e) {
-    throw e;
-  }
-};
-/**
- * Fetches contents from file
- * note the media type header, it converts what would have been a
- * b64 encoded string of the file contents into either raw string data or json
- * @param {String} repo
- * @param {String} owner
- * @param {String} path
- * @param {String} token
- */
-const fetchFile = async (path, token) => {
-  try {
-    const result = await fetch(path, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
-      },
-    });
-    const data = await result.json();
-    if (result.ok) return data;
-    return undefined;
-  } catch (e) {
-    throw e;
-  }
-};
 
 /**
  * returns array of fetch file promises


### PR DESCRIPTION
## Summary
If a source collection is made with source type github. a collection description is now grabbed from the github repo api.

## Notable Changes <!-- if any -->
- get fetch queue was turned async to handle api calls from `getCollectionDescriptionBySourceType`
- added more unit tests

Issue #258 

Not ready for merge until #275 is merged and this rebased on top of master
