### PR TITLE
Fix card show more/less toggle button to render an appropriate number of cards in groups of 3

### DIFF
--- a/app-web/__tests__/components/Cards.test.js
+++ b/app-web/__tests__/components/Cards.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Cards from '../../src/components/Cards/Cards';
+import Cards, { getIdealCardsLargeLimit } from '../../src/components/Cards/Cards';
 import { COLLECTIONS } from '../../__fixtures__/redux-fixtures';
 
 describe('Card Component', () => {
@@ -15,5 +15,25 @@ describe('Card Component', () => {
   it('matches snapshot', () => {
     const wrapper = shallow(<Cards cards={[CARDS.DEFAULT]} topic="topic" />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('calculates toggle card limit correctly', () => {
+    const MAX_CARD_LIMIT = 9;
+    const CARDS_PER_ROW = 3;
+    const NUM_CARDS1 = 8;
+    const NUM_CARDS2 = 6;
+    const NUM_CARDS3 = 2;
+    const NUM_CARDS4 = 9;
+    const NUM_CARDS5 = 10;
+    const NUM_CARDS6 = 0;
+    const NUM_CARDS7 = 4;
+
+    expect(getIdealCardsLargeLimit(MAX_CARD_LIMIT, NUM_CARDS1, CARDS_PER_ROW)).toBe(6);
+    expect(getIdealCardsLargeLimit(MAX_CARD_LIMIT, NUM_CARDS2, CARDS_PER_ROW)).toBe(6);
+    expect(getIdealCardsLargeLimit(MAX_CARD_LIMIT, NUM_CARDS3, CARDS_PER_ROW)).toBe(3);
+    expect(getIdealCardsLargeLimit(MAX_CARD_LIMIT, NUM_CARDS4, CARDS_PER_ROW)).toBe(9);
+    expect(getIdealCardsLargeLimit(MAX_CARD_LIMIT, NUM_CARDS5, CARDS_PER_ROW)).toBe(9);
+    expect(getIdealCardsLargeLimit(MAX_CARD_LIMIT, NUM_CARDS6, CARDS_PER_ROW)).toBe(3);
+    expect(getIdealCardsLargeLimit(MAX_CARD_LIMIT, NUM_CARDS7, CARDS_PER_ROW)).toBe(3);
   });
 });

--- a/app-web/__tests__/components/__snapshots__/Cards.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/Cards.test.js.snap
@@ -87,7 +87,7 @@ ShallowWrapper {
                 />,
               ]
             }
-            cardLimits={4}
+            cardLimits={3}
           />
         </div>,
         <div
@@ -176,7 +176,7 @@ ShallowWrapper {
                 />,
               ]
             }
-            cardLimits={4}
+            cardLimits={3}
           />,
           "className": "LargeView",
         },
@@ -197,7 +197,7 @@ ShallowWrapper {
                 title="About"
               />,
             ],
-            "cardLimits": 4,
+            "cardLimits": 3,
           },
           "ref": null,
           "rendered": null,
@@ -290,7 +290,7 @@ ShallowWrapper {
                   />,
                 ]
               }
-              cardLimits={4}
+              cardLimits={3}
             />
           </div>,
           <div
@@ -379,7 +379,7 @@ ShallowWrapper {
                   />,
                 ]
               }
-              cardLimits={4}
+              cardLimits={3}
             />,
             "className": "LargeView",
           },
@@ -400,7 +400,7 @@ ShallowWrapper {
                   title="About"
                 />,
               ],
-              "cardLimits": 4,
+              "cardLimits": 3,
             },
             "ref": null,
             "rendered": null,

--- a/app-web/src/components/Cards/Cards.js
+++ b/app-web/src/components/Cards/Cards.js
@@ -8,7 +8,7 @@ import RepositoryCard from './Card/RepositoryCard';
 import SelfServiceCard from './Card/SelfServiceCard';
 import ComponentCard from './Card/ComponentCard';
 import Toggle from './Toggle';
-import { CARD_TOGGLE_LIMIT, RESOURCE_TYPES } from '../../constants/ui';
+import { CARD_TOGGLE_LIMIT, RESOURCE_TYPES, CARDS_PER_ROW } from '../../constants/ui';
 
 /**
  * @param {Number} limit the maximum limit of cards to show in toggle component
@@ -98,7 +98,7 @@ const Cards = ({ topic, description, sourcePath, cards }) => {
 
   if (cardComponents.length > 0) {
     // find the ideal large screen limit based on number of cards, and cards rendering per row
-    const CARDS_PER_ROW = 3; // ideally in a true grid system we would have a more concrete styling
+    // ideally in a true grid system we would have a more concrete styling
     // to ensure cards are 3 per row. When this container is transferred to bootsraps grid system, this
     // will be so.
     const idealLimit = getIdealCardsLargeLimit(

--- a/app-web/src/components/Cards/Cards.js
+++ b/app-web/src/components/Cards/Cards.js
@@ -10,6 +10,20 @@ import ComponentCard from './Card/ComponentCard';
 import Toggle from './Toggle';
 import { LARGE_SCREEN_LIMIT, SMALL_SCREEN_LIMIT, RESOURCE_TYPES } from '../../constants/ui';
 
+/**
+ * @param {Number} limit the maximum limit of cards to show in toggle component
+ * @param {Number} numCards the number of cards to render
+ * @param {Number} cardsPerRow
+ * @returns {Number} the idea limit
+ */
+const getIdealCardsLargeLimit = (limit, numCards, cardsPerRow) => {
+  let newLimit = limit;
+  while (numCards < newLimit && newLimit - cardsPerRow > 0) {
+    newLimit -= cardsPerRow;
+  }
+  return newLimit;
+};
+
 const Cards = ({ topic, description, sourcePath, cards }) => {
   const cardComponents = cards.map(c => {
     switch (c.resource.type) {
@@ -83,6 +97,16 @@ const Cards = ({ topic, description, sourcePath, cards }) => {
   });
 
   if (cardComponents.length > 0) {
+    // find the ideal large screen limit based on number of cards, and cards rendering per row
+    const CARDS_PER_ROW = 3; // ideally in a true grid system we would have a more concrete styling
+    // to ensure cards are 3 per row. When this container is transferred to bootsraps grid system, this
+    // will be so.
+    const idealLimit = getIdealCardsLargeLimit(
+      LARGE_SCREEN_LIMIT,
+      cardComponents.length,
+      CARDS_PER_ROW,
+    );
+
     return (
       <section className={styles.CardsContainer}>
         <div className={styles.TopicContainer}>
@@ -90,7 +114,7 @@ const Cards = ({ topic, description, sourcePath, cards }) => {
           <p>{description}</p>
         </div>
         <div className={styles.LargeView}>
-          <Toggle cardComponents={cardComponents} cardLimits={LARGE_SCREEN_LIMIT} />
+          <Toggle cardComponents={cardComponents} cardLimits={idealLimit} />
         </div>
         <div className={styles.MobileView}>
           <Toggle cardComponents={cardComponents} cardLimits={SMALL_SCREEN_LIMIT} />

--- a/app-web/src/components/Cards/Cards.js
+++ b/app-web/src/components/Cards/Cards.js
@@ -107,8 +107,6 @@ const Cards = ({ topic, description, sourcePath, cards }) => {
       CARDS_PER_ROW,
     );
 
-    console.log('achieving ideal limit', idealLimit);
-
     return (
       <section className={styles.CardsContainer}>
         <div className={styles.TopicContainer}>

--- a/app-web/src/components/Cards/Cards.js
+++ b/app-web/src/components/Cards/Cards.js
@@ -8,7 +8,7 @@ import RepositoryCard from './Card/RepositoryCard';
 import SelfServiceCard from './Card/SelfServiceCard';
 import ComponentCard from './Card/ComponentCard';
 import Toggle from './Toggle';
-import { LARGE_SCREEN_LIMIT, SMALL_SCREEN_LIMIT, RESOURCE_TYPES } from '../../constants/ui';
+import { CARD_TOGGLE_LIMIT, RESOURCE_TYPES } from '../../constants/ui';
 
 /**
  * @param {Number} limit the maximum limit of cards to show in toggle component
@@ -16,7 +16,7 @@ import { LARGE_SCREEN_LIMIT, SMALL_SCREEN_LIMIT, RESOURCE_TYPES } from '../../co
  * @param {Number} cardsPerRow
  * @returns {Number} the idea limit
  */
-const getIdealCardsLargeLimit = (limit, numCards, cardsPerRow) => {
+export const getIdealCardsLargeLimit = (limit, numCards, cardsPerRow) => {
   let newLimit = limit;
   while (numCards < newLimit && newLimit - cardsPerRow > 0) {
     newLimit -= cardsPerRow;
@@ -102,10 +102,12 @@ const Cards = ({ topic, description, sourcePath, cards }) => {
     // to ensure cards are 3 per row. When this container is transferred to bootsraps grid system, this
     // will be so.
     const idealLimit = getIdealCardsLargeLimit(
-      LARGE_SCREEN_LIMIT,
+      CARD_TOGGLE_LIMIT.LARGE,
       cardComponents.length,
       CARDS_PER_ROW,
     );
+
+    console.log('achieving ideal limit', idealLimit);
 
     return (
       <section className={styles.CardsContainer}>
@@ -117,7 +119,7 @@ const Cards = ({ topic, description, sourcePath, cards }) => {
           <Toggle cardComponents={cardComponents} cardLimits={idealLimit} />
         </div>
         <div className={styles.MobileView}>
-          <Toggle cardComponents={cardComponents} cardLimits={SMALL_SCREEN_LIMIT} />
+          <Toggle cardComponents={cardComponents} cardLimits={CARD_TOGGLE_LIMIT.SMALL} />
         </div>
       </section>
     );

--- a/app-web/src/constants/ui.js
+++ b/app-web/src/constants/ui.js
@@ -91,6 +91,8 @@ export const CARD_TOGGLE_LIMIT = {
   SMALL: 1,
 };
 
+export const CARDS_PER_ROW = 3;
+
 export const RESOURCE_TYPES_CONFIG = {
   COMPONENTS: {
     DISPLAY_NAME: 'Components',

--- a/app-web/src/constants/ui.js
+++ b/app-web/src/constants/ui.js
@@ -86,8 +86,10 @@ export const BANNER_ID = 'dh-banner';
 export const MAIN_NAVIGATION_BTN = 'dh-main-nav';
 
 // for the card toggle component card limit prop
-export const LARGE_SCREEN_LIMIT = 4;
-export const SMALL_SCREEN_LIMIT = 1;
+export const CARD_TOGGLE_LIMIT = {
+  LARGE: 6,
+  SMALL: 1,
+};
 
 export const RESOURCE_TYPES_CONFIG = {
   COMPONENTS: {


### PR DESCRIPTION
## Summary
The number of cards that rendered within a collection in the devhub would sometimes show up in a less than ideal fashion. There maybe singled out cards that would wrap to a new row. This PR forces all cards to show up in atleast a group of three (if numCard >= 3);

## Notable Changes <!-- if any -->
- added a helper to calculate the ideal card limit for toggling
- added unit tests for said helper

Fixes #244 