### PR TITLE
Integrate collection templates based on type

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -21,6 +21,9 @@
 // sample files that may be received when calling github v3 tree api
 // seperating them out in this obj so that we can recycle some of these properties
 // in tests as well as other fixtures
+
+const { COLLECTION_TEMPLATES } = require('../utils/constants');
+
 const TREE_FILES = {
   FILE1: {
     path: 'docs/readme1.md',
@@ -569,6 +572,7 @@ const COLLECTION_OBJ_FROM_FETCH_QUEUE = {
   name: 'foo',
   description: 'blah',
   sources: [WEB_SOURCE],
+  template: COLLECTION_TEMPLATES.DEFAULT,
   metadata: {
     position: [0],
   },

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -29,7 +29,7 @@ import {
   processCollection,
 } from '../sourceNodes';
 import { createSiphonNode, createCollectionNode } from '../utils/createNode';
-import { GRAPHQL_NODE_TYPE, COLLECTION_TYPES } from '../utils/constants';
+import { GRAPHQL_NODE_TYPE, COLLECTION_TYPES, COLLECTION_TEMPLATES } from '../utils/constants';
 import {
   GRAPHQL_NODES_WITH_REGISTRY,
   GRAPHQL_NODES_WITHOUT_REGISTRY,
@@ -254,6 +254,8 @@ describe('gatsby source github all plugin', () => {
       },
       _metadata: {
         position: [0],
+        template: COLLECTION_TEMPLATES.DEFAULT,
+        templateFile: undefined,
       },
     };
     hashString.mockReturnValue(null);

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -182,8 +182,8 @@ const getFetchQueue = async (sources, tokens) => {
         {
           name: rootSource.name,
           sources: [],
-          template: rootSource.templateName
-            ? getClosest(rootSource.templateName, COLLECTION_TEMPLATES_LIST)
+          template: rootSource.template
+            ? getClosest(rootSource.template, COLLECTION_TEMPLATES_LIST)
             : COLLECTION_TEMPLATES.DEFAULT,
           templateFile: rootSource.templateFile || '',
         },

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -185,7 +185,7 @@ const getFetchQueue = async (sources, tokens) => {
           template: rootSource.templateName
             ? getClosest(rootSource.templateName, COLLECTION_TEMPLATES_LIST)
             : COLLECTION_TEMPLATES.DEFAULT,
-          templateFile: rootSource.templateFile,
+          templateFile: rootSource.templateFile || '',
         },
         index,
       ),

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -28,9 +28,15 @@ const {
   getCollectionDescriptionBySourceType,
   assignPositionToCollection,
   assignPositionToSource,
+  getClosest,
 } = require('./utils/helpers');
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
-const { COLLECTION_TYPES, REGISTRY_ITEM_SCHEMA } = require('./utils/constants');
+const {
+  COLLECTION_TYPES,
+  REGISTRY_ITEM_SCHEMA,
+  COLLECTION_TEMPLATES,
+  COLLECTION_TEMPLATES_LIST,
+} = require('./utils/constants');
 const { createSiphonNode, createCollectionNode } = require('./utils/createNode');
 
 /**
@@ -176,6 +182,10 @@ const getFetchQueue = async (sources, tokens) => {
         {
           name: rootSource.name,
           sources: [],
+          template: rootSource.templateName
+            ? getClosest(rootSource.templateName, COLLECTION_TEMPLATES_LIST)
+            : COLLECTION_TEMPLATES.DEFAULT,
+          templateFile: rootSource.templateFile,
         },
         index,
       ),

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
@@ -39,7 +39,7 @@ const REGISTRY_ITEM_SCHEMA = {
     type: String,
     required: false,
   },
-  templateName: {
+  template: {
     type: String,
     required: false,
   },

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
@@ -39,6 +39,14 @@ const REGISTRY_ITEM_SCHEMA = {
     type: String,
     required: false,
   },
+  templateName: {
+    type: String,
+    required: false,
+  },
+  templatePath: {
+    type: String,
+    required: false,
+  },
 };
 
 module.exports = {

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/siphonNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/siphonNode.js
@@ -46,6 +46,13 @@ const PERSONAS = {
   PRODUCT_OWNER: 'Product Owner',
 };
 
+const COLLECTION_TEMPLATES = {
+  DEFAULT: 'default',
+  OVERVIEW: 'overview',
+};
+
+const COLLECTION_TEMPLATES_LIST = Object.values(COLLECTION_TEMPLATES);
+
 const PERSONAS_LIST = Object.values(PERSONAS);
 
 const GRAPHQL_NODE_TYPE = {
@@ -61,4 +68,6 @@ module.exports = {
   PERSONAS,
   PERSONAS_LIST,
   GRAPHQL_NODE_TYPE,
+  COLLECTION_TEMPLATES,
+  COLLECTION_TEMPLATES_LIST,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -40,6 +40,8 @@ const createCollectionNode = (collection, id) => {
     },
     _metadata: {
       position: metadata.position,
+      template: collection.template,
+      templateFile: collection.templateFile,
     },
   };
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -72,6 +72,12 @@ const createUnfurlObj = (
   };
 };
 
+const getClosest = (value, list) => {
+  const matches = stringSimilarity.findBestMatch(value, list);
+  // only return the best match if its greater than .5 in similarity
+  return matches.bestMatch.rating >= 0.5 ? matches.bestMatch.target : '';
+};
+
 /**
  * returns the closest resourceType from the constant resourceTypes array based on the
  * uncontrolled resourceType (given to us by contributors)
@@ -80,9 +86,7 @@ const createUnfurlObj = (
 const getClosestResourceType = resourceType => {
   // if its blank don't bother checking closeness
   if (resourceType === '') return '';
-  const matches = stringSimilarity.findBestMatch(resourceType, RESOURCE_TYPES_LIST);
-  // only return the best match if its greater than .5 in similarity
-  return matches.bestMatch.rating >= 0.5 ? matches.bestMatch.target : '';
+  return getClosest(resourceType, RESOURCE_TYPES_LIST);
 };
 
 /**
@@ -92,13 +96,11 @@ const getClosestResourceType = resourceType => {
  * @param {Array} personas the valid personas list
  */
 const getClosestPersona = (personaList, personas) => {
-  const RATING_THRESHOLD = 0.5; // rating is between 0 - 1, we only want a match if it's greater than half.
   // if its blank don't bother checking closeness
   if (personaList.length === 0) return [];
 
   return personaList.map(p => {
-    const matches = stringSimilarity.findBestMatch(p, personas);
-    return matches.bestMatch.rating >= RATING_THRESHOLD ? matches.bestMatch.target : '';
+    return getClosest(p, personas);
   });
 };
 
@@ -341,6 +343,7 @@ module.exports = {
   hashString,
   createPathWithDigest,
   createUnfurlObj,
+  getClosest,
   getClosestResourceType,
   getClosestPersona,
   getAbsolutePathFromRelative,

--- a/app-web/source-registry/registry.yml
+++ b/app-web/source-registry/registry.yml
@@ -80,6 +80,7 @@ sources:
         - Repository
       persona: 'Developer'
   - name: Github 101
+    template: overview
     description: "Whether you are new to Github as a platform or new to Github in government, here are
     some great resources and considerations to help you succeed."
     resourceType: Documentation


### PR DESCRIPTION
## Summary
integrated collection templates by type right now there are two different types
- default
- overview

they can be set in the registry with the following properties

```yaml
# a registry item
- name: foo
   template: overview # if not provided defaults to 'default'
   templateFile: [the template file name] # if templateFile and template are added, templateFile supersedes
```

#250 