### PR TITLE
Rename siphon reducer state members

### DIFF
--- a/app-web/__tests__/redux/siphonReducer.test.js
+++ b/app-web/__tests__/redux/siphonReducer.test.js
@@ -37,35 +37,35 @@ describe('reducer', () => {
   it('should handle FILTER SIPHON NODES', () => {
     const state = {
       ...INITIAL_STATES.SIPHON,
+      _collections: COLLECTIONS,
       collections: COLLECTIONS,
-      primaryFilteredNodes: COLLECTIONS,
     };
 
     // this action filters out all nodes in collections that don't match resource type 'Components'
     const filteredState = reducer(state, ACTIONS.FILTER_SIPHON_NODES);
     // in the fixiture there are only 2 nodes, 1 of them having Components therefor only expect
     // the first collection to have one node left
-    expect(filteredState.primaryFilteredNodes[0].nodes.length).toBe(1);
+    expect(filteredState.collections[0].nodes.length).toBe(1);
   });
 
   it('should return all nodes if Filtered value is All', () => {
     const state = {
       ...INITIAL_STATES.SIPHON,
+      _collections: COLLECTIONS,
       collections: COLLECTIONS,
-      primaryFilteredNodes: COLLECTIONS,
     };
 
     const filteredState = reducer(state, ACTIONS.FILTER_SIPHON_NODES_BY_ALL);
 
-    expect(filteredState.primaryFilteredNodes[0].nodes.length).toBe(COLLECTIONS[0].nodes.length);
+    expect(filteredState.collections[0].nodes.length).toBe(COLLECTIONS[0].nodes.length);
   });
 
   it('should set filter to active when added and if there are available nodes', () => {
     // add some nodes to the initial state
     const state = {
       ...INITIAL_STATES.SIPHON,
+      _collections: COLLECTIONS,
       collections: COLLECTIONS,
-      primaryFilteredNodes: COLLECTIONS,
     };
     const newState = reducer(state, ACTIONS.ADD_FILTER);
     const filter = newState.filters.find(f => f.key === ACTIONS.ADD_FILTER.payload.key);
@@ -79,8 +79,8 @@ describe('reducer', () => {
   it("should set filter to inactive when added if there aren't any available nodes", () => {
     // the fixtured action ADD_FILTER targets personas that = designer
     // the fixture node that has resource type = documentation does not have this persona
-    const primaryFilteredNodes = COLLECTIONS.filter(n => n.resourceType === 'Documentation');
-    const state = { ...INITIAL_STATES.SIPHON, collections: COLLECTIONS, primaryFilteredNodes };
+    const collections = COLLECTIONS.filter(n => n.resourceType === 'Documentation');
+    const state = { ...INITIAL_STATES.SIPHON, _collections: COLLECTIONS, collections };
 
     const newState = reducer(state, ACTIONS.ADD_FILTER);
     const filter = newState.filters.find(f => f.key === ACTIONS.ADD_FILTER.payload.key);
@@ -93,8 +93,8 @@ describe('reducer', () => {
 
     const state = {
       ...INITIAL_STATES.SIPHON,
+      _collections: COLLECTIONS,
       collections: COLLECTIONS,
-      primaryFilteredNodes: COLLECTIONS,
     };
     const newState = reducer(state, ACTIONS.REMOVE_FILTER);
     const filter = newState.filters.find(f => f.key === ACTIONS.REMOVE_FILTER.payload.key);
@@ -106,13 +106,13 @@ describe('reducer', () => {
     // the default state has a the 'developer' persona filter group active
     const state = {
       ...INITIAL_STATES.SIPHON,
+      _collections: COLLECTIONS,
       collections: COLLECTIONS,
-      primaryFilteredNodes: COLLECTIONS,
     };
     // when calling the filter list action, we should expect the filtered nodes to tbe length
     // of 1 from 2 since there is only one node that has that persona
     const newState = reducer(state, ACTIONS.FILTER_SIPHON_NODES_BY_LIST);
-    expect(newState.secondaryFilteredNodes[0].nodes.length).toBe(1);
+    expect(newState.filteredCollections[0].nodes.length).toBe(1);
   });
 
   it('correctly sets available resources count', () => {

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -125,7 +125,7 @@ export const resourceQuery = graphql`
 
 const mapStateToProps = state => {
   return {
-    collections: state.siphon.secondaryFilteredNodes,
+    collections: state.siphon.filteredCollections,
     displayWelcome: !state.ui.welcomePanelWasViewed,
     filters: state.siphon.filters,
   };


### PR DESCRIPTION
## Summary
This is in an effort for #307, another PR will be made to first move all resource type queries to actual pages, this will make the search feature function better. In that effort variables are being renamed so that they are more sensible.
