### PR TITLE
Siphon node now has references to parent collection

### DIFF
--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -820,9 +820,9 @@
       }
     },
     "@bcgov/common-web-utils": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-0.4.2.tgz",
-      "integrity": "sha512-oc0q1SywLsnpfyTFhdpuezaCb+F8IcP00suT7nAP4rigJN46sEc3Pwgo4ov4bCid5Va6r+otF++Avrju4Zbhgg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-0.5.2.tgz",
+      "integrity": "sha512-tQHLZRcaJYEq2ZBxJI/LIZrrnFmSG1+0H56SLwZrlckoAvwgakgdMA6jvKu4RE6Fc0UPZ3we1jAVHzoD4knwVg==",
       "requires": {
         "hash.js": "^1.1.5",
         "jwt-decode": "^2.2.0",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -9,7 +9,7 @@
   "description": "DevHub aims to become the \"Central Nervous System\" for the growing gov developer community.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@bcgov/common-web-utils": "^0.4.2",
+    "@bcgov/common-web-utils": "^0.5.2",
     "@fortawesome/fontawesome-free-brands": "^5.0.13",
     "@fortawesome/fontawesome-svg-core": "^1.2.8",
     "@fortawesome/free-solid-svg-icons": "^5.5.0",

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -190,7 +190,7 @@ describe('gatsby source github all plugin', () => {
       fileType: 'Markdown',
       name: 'test',
       owner: 'Billy Bob',
-      parent: null,
+      parent: 'foo',
       path: '/test.md',
       collection: {
         name: 'foo',
@@ -236,7 +236,7 @@ describe('gatsby source github all plugin', () => {
 
     hashString.mockReturnValue(null);
 
-    expect(createSiphonNode(file, '123')).toEqual(expected);
+    expect(createSiphonNode(file, '123', 'foo')).toEqual(expected);
   });
 
   test('createCollectionNode returns an object', () => {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -243,7 +243,7 @@ const getFetchQueue = async (sources, tokens) => {
  * @param {Object} tokens the tokens passed from options
  * @returns {Array} the list of resources retrieved from the source
  */
-const processSource = async (source, createNodeId, createNode, tokens) => {
+const processSource = async (source, createNodeId, createNode, tokens, collectionId) => {
   const resources = await fetchFromSource(source.sourceType, source, tokens);
   // any resources that hvae the metadata ignore flag are filtered out to prevent a node being created
   const filteredResources = filterIgnoredResources(resources);
@@ -251,7 +251,7 @@ const processSource = async (source, createNodeId, createNode, tokens) => {
     filteredResources.map(async resource => {
       const hash = hashString(JSON.stringify(resource));
       const id = createNodeId(hash);
-      const siphonNode = createSiphonNode(resource, id);
+      const siphonNode = createSiphonNode(resource, id, collectionId);
       await createNode(siphonNode);
       return siphonNode;
     }),
@@ -284,7 +284,7 @@ const processCollection = async (
   const id = createNodeId(hash);
   // fetch all sources
   const sourceNodes = await Promise.all(
-    collection.sources.map(source => processSource(source, createNodeId, createNode, tokens)),
+    collection.sources.map(source => processSource(source, createNodeId, createNode, tokens, id)),
   );
   // flatten source nodes to get a list of all the resources
   const resources = _.flatten(sourceNodes, true);

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -52,14 +52,14 @@ const createCollectionNode = (collection, id) => {
  * @param {Object} data the siphon node data
  * @param {String} id the unique id
  */
-const createSiphonNode = (data, id) => ({
+const createSiphonNode = (data, id, collectionId) => ({
   id,
   children: [],
   fileName: data.metadata.fileName,
   fileType: data.metadata.fileType,
   name: data.metadata.name,
   owner: data.metadata.owner,
-  parent: null,
+  parent: collectionId,
   path: data.path,
   unfurl: data.metadata.unfurl, // normalized unfurled content from various sources https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254
   collection: {

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -51,6 +51,7 @@ const createCollectionNode = (collection, id) => {
  * many of these properties are assigned by convention
  * @param {Object} data the siphon node data
  * @param {String} id the unique id
+ * @param {String} collectionId the collection id that owns this resource
  */
 const createSiphonNode = (data, id, collectionId) => ({
   id,

--- a/docs/siphon.md
+++ b/docs/siphon.md
@@ -308,7 +308,9 @@ the graphQL schema (more on that [here](https://www.gatsbyjs.org/docs/plugin-aut
     fileType // the pretty printed name of the file type if exists, .md => Markdown, .yml => YAML, .json => JSON
     name // the file name minus extension
     owner // owner of resource
-    parent // gatsby required attribute, this is null
+    parent {
+        id // gatsby required attribute, this is normally null but in our case holds a reference to the devhubSiphonCollection id this node belongs too 
+    } 
     path // path to the resource
     collection {
         name // name of the collection, this is directly related to the name attribute in the registry


### PR DESCRIPTION
## Summary
Updated the siphon node schema so that parent id is defined
, in addition `@bcgov/common-web-utils` package was updated