### PR TITLE
Ability to override unfurl properties

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceWeb.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceWeb.itest.js
@@ -1,0 +1,23 @@
+import { WEB_SOURCE } from '../__fixtures__/fixtures';
+import { validateSourceWeb } from '../utils/sources/web';
+jest.unmock('../utils/helpers');
+// mock console logs so that any error logs are not outputed during suite
+global.console = {
+  log: console.log,
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+describe('sourceType Web integration', () => {
+  test('validateSourceGithub returns true when valid', () => {
+    expect(validateSourceWeb(WEB_SOURCE)).toBe(true);
+  });
+
+  test('validateSourceWeb returns false when source is invalid', () => {
+    const BAD_SOURCE = {
+      ...WEB_SOURCE,
+      sourceProperties: { url: null },
+    };
+    expect(validateSourceWeb(BAD_SOURCE)).toBe(false);
+  });
+});

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceWeb.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSourceWeb.test.js
@@ -1,16 +1,17 @@
-import { WEB_SOURCE } from '../__fixtures__/fixtures';
-import { validateSourceWeb } from '../utils/sources/web/';
+import { extractUnfurlFromSourceProperties } from '../utils/sources/web/';
+import { createUnfurlObj, mergeUnfurls } from '../utils/helpers';
+jest.mock('../utils/helpers.js');
+
+mergeUnfurls.mockImplementation((oldUnfurl, newUnfurl) => newUnfurl);
+createUnfurlObj.mockImplementation(obj => obj);
 
 describe('sourceType Web', () => {
-  test('validateSourceGithub returns true when valid', () => {
-    expect(validateSourceWeb(WEB_SOURCE)).toBe(true);
-  });
-
-  test('validateSourceWeb returns false when source is invalid', () => {
-    const BAD_SOURCE = {
-      ...WEB_SOURCE,
-      sourceProperties: { url: null },
+  test('extractUnfurlFromSourceProperties returns an unfurl object', () => {
+    const sourceProperties = {
+      url: 'blah',
+      author: 'yo',
+      title: 'boop',
     };
-    expect(validateSourceWeb(BAD_SOURCE)).toBe(false);
+    expect(extractUnfurlFromSourceProperties(sourceProperties)).toBeDefined();
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -10,6 +10,7 @@ import {
   assignPositionToResource,
   assignPositionToSource,
   createPosition,
+  mergeUnfurls,
 } from '../utils/helpers';
 import { RESOURCE_TYPES } from '../utils/constants';
 
@@ -233,6 +234,35 @@ describe('unfurlWebURI', () => {
       };
 
       expect(cb(resource, 0)).toEqual(expected);
+    });
+  });
+  describe('mergeUnfurls', () => {
+    it('merges unfurls with old unfurls taking priority', () => {
+      const oldUnfurl = createUnfurlObj('internal', {
+        title: 'foo',
+        description: 'blah',
+        author: undefined,
+        image: undefined,
+      });
+
+      const externalUnfurl = {
+        title: 'bar',
+        image: 'cool.png',
+      };
+
+      const expected = {
+        title: 'foo',
+        description: 'blah',
+        image: 'cool.png',
+        author: undefined,
+        data1: undefined,
+        data2: undefined,
+        label1: undefined,
+        label2: undefined,
+        type: 'internal',
+      };
+
+      expect(mergeUnfurls(oldUnfurl, externalUnfurl)).toEqual(expected);
     });
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/helpers.test.js
@@ -15,7 +15,7 @@ import {
 import { RESOURCE_TYPES } from '../utils/constants';
 
 import { fetchRepo } from '../utils/sources/github/api';
-jest.mock('../utils/sources/github//api');
+jest.mock('../utils/sources/github/api');
 
 describe('createPathWithDigest', () => {
   it('throws if base is not a string', () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
@@ -16,6 +16,7 @@ import {
   getClosestResourceType,
   getClosestPersona,
   unfurlWebURI,
+  mergeUnfurls,
 } from '../utils/helpers';
 jest.mock('../utils/helpers.js');
 
@@ -23,6 +24,7 @@ createUnfurlObj.mockReturnValue({});
 getClosestResourceType.mockReturnValue('');
 getClosestPersona.mockImplementation(persona => persona);
 unfurlWebURI.mockReturnValue({});
+mergeUnfurls.mockImplementation((oldUnfurl, newUnfurl) => newUnfurl);
 
 describe('Transformer System', () => {
   let file = null;
@@ -126,7 +128,18 @@ describe('Transformer System', () => {
       expect(result).toBeDefined();
     });
 
-    it('returns files with unfurl property defined', async () => {
+    it('returns files with unfurl property defined when no original unfurl exists', async () => {
+      // remove the unfurl property
+      file.metadata.unfurl = undefined;
+      file.metadata.resourcePath =
+        'http://www.bloomberg.com/news/articles/2016-05-24/as-zenefits-stumbles-gusto-goes-head-on-by-selling-insurance';
+      const result = await externalLinkUnfurlPlugin(file.metadata.extension, file);
+      expect(result.metadata.unfurl).toBeDefined();
+    });
+
+    it('returns files with unfurl property defined when original unfurl does exist', async () => {
+      // remove the unfurl property
+      file.metadata.unfurl = { title: 'boopity boop' };
       file.metadata.resourcePath =
         'http://www.bloomberg.com/news/articles/2016-05-24/as-zenefits-stumbles-gusto-goes-head-on-by-selling-insurance';
       const result = await externalLinkUnfurlPlugin(file.metadata.extension, file);

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/sourceTypes.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/sourceTypes.js
@@ -58,6 +58,38 @@ const WEB_SOURCE_SCHEMA = {
     type: String,
     required: true,
   },
+  author: {
+    type: String,
+    required: false,
+  },
+  image: {
+    type: String,
+    required: false,
+  },
+  description: {
+    type: String,
+    required: false,
+  },
+  title: {
+    type: String,
+    required: false,
+  },
+  data1: {
+    type: String,
+    required: false,
+  },
+  label1: {
+    type: String,
+    required: false,
+  },
+  data2: {
+    type: String,
+    required: false,
+  },
+  label2: {
+    type: String,
+    required: false,
+  },
 };
 
 module.exports = {

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -246,7 +246,8 @@ const mergeUnfurls = (configurationLevelUnfurl, externalUnfurl) => {
     }
   });
   return newUnfurl;
-}
+};
+
 /**
  * returns a md5 hash
  * @param {String} content the string to be hashed

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -230,6 +230,24 @@ const unfurlWebURI = async uri => {
 };
 
 /**
+ * merges unfurls from a configuration setting with ones that are externally sourced
+ * the configuration one takes priority in the merge
+ * @param {Object} configurationLevelUnfurl
+ * @param {Object} externalUnfurl
+ */
+const mergeUnfurls = (configurationLevelUnfurl, externalUnfurl) => {
+  const newUnfurl = {};
+  Object.keys(configurationLevelUnfurl).forEach(key => {
+    const value = configurationLevelUnfurl[key];
+    if (value !== undefined) {
+      newUnfurl[key] = value;
+    } else {
+      newUnfurl[key] = externalUnfurl[key];
+    }
+  });
+  return newUnfurl;
+}
+/**
  * returns a md5 hash
  * @param {String} content the string to be hashed
  * @returns {String} the hash
@@ -343,6 +361,7 @@ module.exports = {
   hashString,
   createPathWithDigest,
   createUnfurlObj,
+  mergeUnfurls,
   getClosest,
   getClosestResourceType,
   getClosestPersona,

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -27,6 +27,7 @@ const {
   createUnfurlObj,
   getClosestResourceType,
   getClosestPersona,
+  mergeUnfurls,
   unfurlWebURI,
 } = require('./helpers'); // eslint-disable-line
 const { MARKDOWN_FRONTMATTER_SCHEMA, UNFURL_TYPES, RESOURCE_TYPES } = require('./constants');
@@ -227,7 +228,12 @@ const markdownResourceTypePlugin = (extension, file) => {
 const externalLinkUnfurlPlugin = async (extension, file) => {
   try {
     const unfurl = await unfurlWebURI(file.metadata.resourcePath);
-    file.metadata.unfurl = unfurl;
+    if (Object.prototype.hasOwnProperty.call(file.metadata, 'unfurl') && file.metadata.unfurl) {
+      // if unfurl exists in file already merge the results with the prexsisting unfurl taking priority
+      file.metadata.unfurl = mergeUnfurls(file.metadata.unfurls, unfurl);
+    } else {
+      file.metadata.unfurl = unfurl;
+    }
     return file;
   } catch (e) {
     return file;

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -20,6 +20,8 @@ const {
   validateSourcePropertiesAgainstSchema,
   unfurlWebURI,
   assignPositionToResource,
+  mergeUnfurls,
+  createUnfurlObj,
 } = require('../../helpers');
 
 /**
@@ -30,6 +32,8 @@ const {
 const validateSourceWeb = source =>
   validateSourcePropertiesAgainstSchema(source, WEB_SOURCE_SCHEMA);
 
+const extractUnfurlFromSourceProperties = sourceProperties =>
+  createUnfurlObj('local', sourceProperties);
 /**
  * fetches data from a web source
  * based on the configuration passed into the routine
@@ -49,11 +53,12 @@ const fetchSourceWeb = async ({
   const { url } = sourceProperties;
   // fetch information from the url
   const source = { metadata: { ...metadata } };
-
+  const localUnfurl = extractUnfurlFromSourceProperties(sourceProperties);
   const assignPosToResourceBySource = assignPositionToResource(source);
 
   try {
-    const unfurl = await unfurlWebURI(url);
+    const externalUnfurl = await unfurlWebURI(url);
+    const unfurl = mergeUnfurls(localUnfurl, externalUnfurl);
     const siphonData = {
       metadata: {
         unfurl,
@@ -83,4 +88,5 @@ const fetchSourceWeb = async ({
 module.exports = {
   validateSourceWeb,
   fetchSourceWeb,
+  extractUnfurlFromSourceProperties,
 };

--- a/docs/registerRepo.md
+++ b/docs/registerRepo.md
@@ -127,6 +127,10 @@ with the exceptions of the ones that are configured not too or are ignored.
 The following source level configurations are available for source type `web`
 
 - **url**: the path to the website ie https://gatsbyjs.org
+- **image**: the path to an external image
+- **author**: a github username which loads an avatar as well as a link to the github user profile
+- **description**: a description for the resource
+- **title**: a title for the resource
 
 #### Registering a Github Source
 
@@ -256,6 +260,7 @@ Valid front matter properties:
 - **image**: (optional)
     A valid link to an image, avoid using a *relative* path to an image *ie ../my_image.png* and instead
     use a *absolute* path such as *https://www.mysite.com/my_image.png*
+    or a relative path to an image in your github repository
 - **author**: (optional but recommended)
     The author of the markdown file (this should be your github username)
 - **persona**: (optional)


### PR DESCRIPTION
## Summary
When github resource types have a resource path their metadata was automatically unfurled based on the external resource. This is the same for web source types.

Now both are configurable so that any meta data in front matter (for github sourcetypes) or source properties (in web sourcetypes) that conflicts with the external unfurl is preserved

## Notable Changes <!-- if any -->
- added tests for new spec on the file transformer external unfurl plugin
- added integration tests for web source type
- updated docs

Fixes #299 