### PR TITLE
Allow registry items to have a slug property to control page path urls

### DIFF
--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -20546,6 +20546,11 @@
         }
       }
     },
+    "slugify": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
+      "integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw=="
+    },
     "smartquotes": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/smartquotes/-/smartquotes-2.3.1.tgz",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -89,6 +89,7 @@
     "remark": "^10.0.0",
     "shorthash": "0.0.2",
     "shortid": "^2.2.14",
+    "slugify": "^1.3.4",
     "string-similarity": "^3.0.0",
     "styled-components": "^4.1.2",
     "styled-system": "^3.1.11",

--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -570,6 +570,7 @@ const PROCESSED_WEB_SOURCE = {
 const COLLECTION_OBJ_FROM_FETCH_QUEUE = {
   type: 'curated',
   name: 'foo',
+  slug: 'foo',
   description: 'blah',
   sources: [WEB_SOURCE],
   template: COLLECTION_TEMPLATES.DEFAULT,

--- a/app-web/plugins/gatsby-source-github-all/__tests__/Store.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/Store.test.js
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+import Store from '../utils/Store';
+
+describe('Store Object', () => {
+  let ns;
+
+  beforeEach(() => {
+    ns = new Store();
+  });
+
+  it('creates a store', () => {
+    expect(ns instanceof Map).toBe(true);
+  });
+
+  it('can set a value in the store', () => {
+    ns.set('foo', 'bar');
+    expect(ns.get('foo')).toBe('bar');
+  });
+
+  it('can check for conflicts', () => {
+    expect(ns.checkConflict('foo').set('foo', 'baz'));
+  });
+
+  it('can check for conflicts and warn if there is a conflict', () => {
+    ns.set('foo', 'bar');
+    global.console.warn = jest.fn();
+    ns.checkConflict('foo');
+    expect(global.console.warn).toHaveBeenCalled();
+  });
+
+  it('provides default options', () => {
+    expect(ns.options).toBeDefined();
+  });
+
+  it('can throw if configured to do so on conflict', () => {
+    const ns2 = new Store([], { throwOnConflict: true });
+    ns2.set('foo', 'bar');
+
+    expect(() => {
+      ns2.checkConflict('foo');
+    }).toThrow(ns2.options.conflictCb('foo'));
+  });
+
+  it('checkConlict is chainable', () => {
+    let nextNs = ns.checkConflict('foo');
+    expect(nextNs).toBe(ns);
+  });
+});

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -254,6 +254,7 @@ describe('gatsby source github all plugin', () => {
       },
       _metadata: {
         position: [0],
+        slug: COLLECTION_OBJ_FROM_FETCH_QUEUE.slug,
         template: COLLECTION_TEMPLATES.DEFAULT,
         templateFile: undefined,
       },

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
@@ -126,9 +126,15 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
 
   test('transformer sets pagePath to gatsby create page path by default', async () => {
     const data = matter(mdFile.content);
+
+    mdFile.metadata.collection = {
+      slug: 'foo',
+    };
+
     const {
-      metadata: { source, name },
+      metadata: { source, name, collection },
     } = mdFile;
+
     expect(data.data.resourcePath).not.toBeDefined();
 
     const transformedFile = await fileTransformer(mdFile.metadata.extension, mdFile)
@@ -136,7 +142,9 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
       .resolve();
 
     expect(transformedFile.metadata.resourcePath).toBe(
-      `/${source}/${source}${name}https:/github.com/bcgov/design-system/blob/master/components/header/README.md`,
+      `/${
+        collection.slug
+      }/${source}${name}https:/github.com/bcgov/design-system/blob/master/components/header/README.md`,
     );
   });
 

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -177,7 +177,7 @@ const normalizeAttributes = attributes => {
 const getFetchQueue = async (sources, tokens) => {
   const slugStore = new Store([], {
     conflictCb: slug =>
-      `The collection slug ${slug}, has already been used. This is a warning message, in future versions we may remove your collection on conflict`,
+      chalk`\n{yellow warning from Siphon!} {red.bold ---} The collection slug {yellow.bold ${slug}}, has already been used. This is a warning message, in future versions we may remove your collection on conflicts such as this.`,
   });
 
   const collectionPromises = sources.map(async (source, index) => {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -46,7 +46,7 @@ const Store = require('./utils/Store');
  * @param {Object} rootSource
  * @param {Object} targetSource
  */
-const mapInheritedSourceAttributes = ({ name, attributes, resourceType }, targetSource) => ({
+const mapInheritedSourceAttributes = ({ name, attributes, resourceType, slug }, targetSource) => ({
   attributes: normalizeAttributes({
     ...attributes,
     ...targetSource.attributes,
@@ -56,6 +56,7 @@ const mapInheritedSourceAttributes = ({ name, attributes, resourceType }, target
   collection: {
     name,
     type: COLLECTION_TYPES.CURATED,
+    slug,
   },
   ...targetSource,
 });
@@ -210,7 +211,7 @@ const getFetchQueue = async (sources, tokens) => {
       const mappedChildSources = rootSource.sourceProperties.sources.map(
         (childSource, sourceIndex) =>
           setSourcePositionByCollection(
-            mapInheritedSourceAttributes(rootSource, childSource),
+            mapInheritedSourceAttributes({ ...rootSource, slug }, childSource),
             sourceIndex,
           ),
       );
@@ -228,6 +229,7 @@ const getFetchQueue = async (sources, tokens) => {
           collection: {
             name: rootSource.name,
             type: COLLECTION_TYPES[rootSource.sourceType],
+            slug,
           },
         },
       ].map((source, sourceIndex) => setSourcePositionByCollection(source, sourceIndex));

--- a/app-web/plugins/gatsby-source-github-all/utils/Store.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/Store.js
@@ -52,4 +52,4 @@ class Store extends Map {
   }
 }
 
-export default Store;
+module.exports = Store;

--- a/app-web/plugins/gatsby-source-github-all/utils/Store.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/Store.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+
+// creates a simple store of key value pairs with the ability to check for conflicts
+// prior to setting by chaining the .checkConflict(name) method
+/**
+ * @param { Object } options
+ * {
+ *   throwOnConflict: {Boolean}
+ *   conflictCb: {Function}
+ * }
+ */
+class Store extends Map {
+  constructor(mapData = [], options) {
+    super(mapData);
+    this.options = { ...this.defaultOptions, ...options };
+  }
+
+  get defaultOptions() {
+    return {
+      throwOnConflict: false,
+      conflictCb: name => `The name ${name} already exists in the store`,
+    };
+  }
+
+  checkConflict(name) {
+    const nameExists = this.get(name) !== undefined;
+    const { throwOnConflict, conflictCb } = this.options;
+    const warning = conflictCb(name);
+    // if there is a conflict in the store
+    if (nameExists && throwOnConflict) {
+      throw new Error(warning);
+    } else if (nameExists) {
+      console.warn(warning);
+    }
+    return this;
+  }
+}
+
+export default Store;

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
@@ -27,6 +27,10 @@ const REGISTRY_ITEM_SCHEMA = {
     type: Object,
     required: true,
   },
+  slug: {
+    type: String,
+    required: true,
+  },
   resourceType: {
     type: String,
     required: false,

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
@@ -29,7 +29,7 @@ const REGISTRY_ITEM_SCHEMA = {
   },
   slug: {
     type: String,
-    required: true,
+    required: false,
   },
   resourceType: {
     type: String,

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -42,6 +42,7 @@ const createCollectionNode = (collection, id) => {
       position: metadata.position,
       template: collection.template,
       templateFile: collection.templateFile,
+      slug: collection.slug,
     },
   };
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -125,10 +125,14 @@ const pagePathPlugin = (extension, file) => {
       return file;
     }
   }
+  let basePath = file.metadata.source;
+  if (file.metadata.collection && file.metadata.collection.slug) {
+    basePath = file.metadata.collection.slug;
+  }
   // no resource path, this file is destined to be turned into a page,
   // the page page is composed of the source name, the title of the file plus an id
   file.metadata.resourcePath = createPathWithDigest(
-    file.metadata.source,
+    basePath,
     file.metadata.source,
     file.metadata.name,
     file.html_url,

--- a/docs/registerRepo.md
+++ b/docs/registerRepo.md
@@ -85,6 +85,9 @@ The following Registry Level Configurations are available:
 - **description**: ***To only be used by collections!*** This gives a description of the collection.
     A github repository receives this property for free based on the description of the repo as found in
     github for the repo.
+- **slug**: (optional) This is the url all of your resources will show under... ie a slug of `my awesome collection` would have all resources found under the url `https://developer.gov.bc.ca/my-awesome-collection/{resource id}`.
+If you choose not provide a slug, one will be made based on the ***name*** for the registry item.
+> it is advised that once you have set a slug value, you avoid changing it. This is because it will break any bookmarks users have made to your resources! 
 - **sourceType**: This tells DevHub how to grab information from your source
 - **sourceProperties**: These are properties as required for a source type **and is not a registry level configuration**
 - **resourceType**: (optional) This is a global resource type, any singular chunk of data (such as a markdown file or a yaml file or a  link to a website) that DevHubg grabs from your source can have it's individual resourceType defaulted to this value see the main readme for valid resource types.


### PR DESCRIPTION
## Summary
Page paths to resources were based on the github repo name, now there is a registry item `slug` configuration to allow for that to be changed. By default the collection `name` property is used as the slug in absence of the slug configuration

This is part one of two prs to fix #298 
Part two will involve providing slugs to resources as configuration instead of a generated id.