### PR TITLE
Markdown files can provide the `slug` front matter property

### DIFF
--- a/app-web/__mocks__/slugify.js
+++ b/app-web/__mocks__/slugify.js
@@ -1,0 +1,3 @@
+jest.requireActual('got');
+
+module.exports = text => text;

--- a/app-web/__mocks__/valid-url.js
+++ b/app-web/__mocks__/valid-url.js
@@ -1,6 +1,6 @@
 jest.requireActual('valid-url');
 
 module.exports = {
-  isUri: url => url,
-  isWebUri: url => url,
+  isUri: jest.fn(url => url),
+  isWebUri: jest.fn(url => url),
 };

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
@@ -1,3 +1,4 @@
+import validUrl from 'valid-url';
 import { fileTransformer } from '../utils/transformer';
 import {
   markdownFrontmatterPlugin,
@@ -8,6 +9,7 @@ import {
   externalLinkUnfurlPlugin,
   markdownPersonaPlugin,
   repositoryResourcePathPlugin,
+  markdownSlugPlugin,
 } from '../utils/plugins';
 import { PROCESSED_FILE_MD } from '../__fixtures__/fixtures';
 import { PERSONAS_LIST, RESOURCE_TYPES } from '../utils/constants';
@@ -18,6 +20,7 @@ import {
   unfurlWebURI,
   mergeUnfurls,
 } from '../utils/helpers';
+
 jest.mock('../utils/helpers.js');
 
 createUnfurlObj.mockReturnValue({});
@@ -202,7 +205,7 @@ describe('Transformer System', () => {
           extension: 'md',
         },
       };
-
+      validUrl.isWebUri.mockReturnValueOnce(false);
       const newFile = markDownUnfurlImagePlugin(file.metadata.extension, file);
       expect(newFile.metadata.unfurl.image).toBe(
         'https://github.com/foo/bar/blob/master/components/docs/image.png?raw=true',
@@ -221,7 +224,7 @@ describe('Transformer System', () => {
           extension: 'md',
         },
       };
-
+      validUrl.isWebUri.mockReturnValueOnce(false);
       const newFile = markDownUnfurlImagePlugin(file.metadata.extension, file);
       expect(newFile.metadata.unfurl.image).toBe(
         'https://github.com/foo/bar/blob/master/docs/image.png?raw=true',
@@ -234,10 +237,24 @@ describe('Transformer System', () => {
         html_url: 'https://github.com/foo/bar/blob/master/components/header/readme.md',
         metadata: {
           unfurl: { image },
+          extension: 'md',
         },
       };
+      validUrl.isWebUri.mockReturnValueOnce(true);
       const newFile = markDownUnfurlImagePlugin(file.metadata.extension, file);
       expect(newFile.metadata.unfurl.image).toBe(image);
+    });
+
+    it("applies a slug property based on title if slug doesn't exist", () => {
+      const file = {
+        content: '---\ntitle: foo\n---',
+        metadata: {
+          extension: 'md',
+        },
+      };
+
+      const newFile = markdownSlugPlugin(file.metadata.extension, file);
+      expect(newFile.metadata.slug).toBe('foo');
     });
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
@@ -18,6 +18,7 @@ jest.unmock('remark');
 jest.unmock('string-similarity');
 jest.unmock('gray-matter');
 jest.unmock('../utils/helpers');
+jest.unmock('valid-url');
 
 describe('Integration Tests Gatsby source github all transformer and Plugins', () => {
   let mdFile = PROCESSED_FILE_MD;
@@ -127,12 +128,16 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
   test('transformer sets pagePath to gatsby create page path by default', async () => {
     const data = matter(mdFile.content);
 
-    mdFile.metadata.collection = {
-      slug: 'foo',
+    mdFile.metadata = {
+      ...mdFile.metadata,
+      slug: 'yo yo yo',
+      collection: {
+        slug: 'foo',
+      },
     };
 
     const {
-      metadata: { source, name, collection },
+      metadata: { slug, collection },
     } = mdFile;
 
     expect(data.data.resourcePath).not.toBeDefined();
@@ -141,11 +146,15 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
       .use(pagePathPlugin)
       .resolve();
 
+<<<<<<< HEAD
     expect(transformedFile.metadata.resourcePath).toBe(
       `/${
         collection.slug
       }/${source}${name}https:/github.com/bcgov/design-system/blob/master/components/header/README.md`,
     );
+=======
+    expect(transformedFile.metadata.resourcePath).toBe(`/${collection.slug}/${slug}`);
+>>>>>>> integrate collection slug into page path creation
   });
 
   test('transformer sets resourceType by the globalResourceType', async () => {

--- a/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transformer.itest.js
@@ -146,15 +146,7 @@ describe('Integration Tests Gatsby source github all transformer and Plugins', (
       .use(pagePathPlugin)
       .resolve();
 
-<<<<<<< HEAD
-    expect(transformedFile.metadata.resourcePath).toBe(
-      `/${
-        collection.slug
-      }/${source}${name}https:/github.com/bcgov/design-system/blob/master/components/header/README.md`,
-    );
-=======
     expect(transformedFile.metadata.resourcePath).toBe(`/${collection.slug}/${slug}`);
->>>>>>> integrate collection slug into page path creation
   });
 
   test('transformer sets resourceType by the globalResourceType', async () => {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -178,7 +178,7 @@ const normalizeAttributes = attributes => {
 const getFetchQueue = async (sources, tokens) => {
   const slugStore = new Store([], {
     conflictCb: slug =>
-      chalk`\n{yellow warning from Siphon!} {red.bold ---} The collection slug {yellow.bold ${slug}}, has already been used. This is a warning message, in future versions we may remove your collection on conflicts such as this.`,
+      chalk`\n{red WARNING from Siphon!} {red.bold ---} The collection slug {yellow.bold ${slug}}, has already been used. This is a warning message, in future versions we may remove your collection on conflicts such as this.`,
   });
 
   const collectionPromises = sources.map(async (source, index) => {

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/sourceGithub.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/sourceGithub.js
@@ -63,6 +63,10 @@ const MARKDOWN_FRONTMATTER_SCHEMA = {
     type: String,
     required: false,
   },
+  slug: {
+    type: String,
+    required: false,
+  },
   ignore: {
     type: Boolean,
     required: false,

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -38,7 +38,7 @@ const { MARKDOWN_FRONTMATTER_SCHEMA, UNFURL_TYPES, RESOURCE_TYPES } = require('.
 
 const slugStore = new Store([], {
   throwOnConflict: true,
-  conflictCb: slug => `\n warning from Siphon! --- The slug ${slug} for a markdown file already
+  conflictCb: slug => `\nWARNING from Siphon! --- The slug ${slug} for a markdown file already
     exists, this is a conflict that will lead to wierd results as more than one siphon node will point
     to the same gatsby page on build. Consider fixing this!`,
 });
@@ -326,15 +326,24 @@ const markdownSlugPlugin = (extension, file) => {
       slugStore.checkConflict(slug);
     } catch (e) {
       // throwing allows for a more detailed message.
-      console.error(chalk`\n{red.bold WARNING from Siphon!} --- the following markdown file
-         ${JSON.stringify(file.metadata, null, 2)} 
-      has a naming conflict in the slug that is being used to produce a gatsby page. The slug is currently
-      in use by the following resource:
-         ${JSON.stringify(
-           currentResource,
-           null,
-           2,
-         )}. This may cause odd issues for links to the gatsby page if not rectified.`);
+      const produceSummary = metadata =>
+        `Source: ${metadata.sourceName}, fileName: ${metadata.fileName}, title: ${
+          metadata.resourceTitle
+        }`;
+      const currentSummary = produceSummary(currentResource);
+      const conflictingSummary = produceSummary(file.metadata);
+      const warning = chalk`\n
+        {red WARNING from Siphon!} --- markdown file slug conflict {red.bold (slug: ${slug}) } 
+        the following markdown file ---
+        {green ${conflictingSummary}}
+        has a naming conflict in the slug that is being used to produce a gatsby page. 
+        The slug is currently in use by this markdown file ---
+        {green ${currentSummary}}
+        {cyan.bold This may cause odd issues for links to the gatsby page if not rectified.}
+        detailed stack below..
+      `;
+
+      console.error(warning);
       console.error(e);
     }
     // continue to set new slug in store

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/githubFileTransformer.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/githubFileTransformer.js
@@ -26,6 +26,7 @@ const {
   markdownPersonaPlugin,
   repositoryResourcePathPlugin,
   markDownUnfurlImagePlugin,
+  markdownSlugPlugin,
 } = require('../../plugins');
 
 const transfomer = (extension, file) => {
@@ -33,6 +34,7 @@ const transfomer = (extension, file) => {
 
   return ft
     .use(markdownFrontmatterPlugin)
+    .use(markdownSlugPlugin)
     .use(pagePathPlugin)
     .use(markdownUnfurlPlugin)
     .use(markdownResourceTypePlugin)

--- a/app-web/source-registry/registry.yml
+++ b/app-web/source-registry/registry.yml
@@ -129,3 +129,4 @@ sources:
           branch: feature/243-openshift-svc-def
           files:
           - docs/OCP/OCPServiceDefinition.md
+  

--- a/docs/registerRepo.md
+++ b/docs/registerRepo.md
@@ -271,7 +271,8 @@ Valid front matter properties:
     filtering the markdown files in the devhub by persona (valid personas: 'Developer', 'Designer', 'Product Owner')
 - **resourceType**: (optional)
     this will override the global resource Type as defined in the registry level configuration
-
+- **slug**: (optional)
+    this is the way you choose to expose your markdown file as a url. The url is composed of the collection slug, *as described by [registry level configurations above](#registry-level-configuration)*, plus the value of this slug. If no slug is provided a default one is made from the title of the markdown file. 
 #### Registering a Web Source
 
 Registering a web source is very easy. Here is an example registration item. 


### PR DESCRIPTION
> This is PR 2 of 2 for #298 
__This is not to be merged until pr #318 is merged and this rebased ontop of it__
## Summary

Markdown files support the `slug` property. In addition slug defaults to title and prints out a very clear warning message in the logs during name conflicts. 

Fixes #298
/bot-ignore-length