### PR TITLE
Relative page links map to internal pages if they exist

### DIFF
--- a/app-web/__fixtures__/plugin-fixtures.js
+++ b/app-web/__fixtures__/plugin-fixtures.js
@@ -30,6 +30,7 @@ export const SIPHON_QL_NODE = {
   resource: {
     originalSource:
       'https://github.com/bcgov/design-system/blob/master/components/footer/something/README.md',
+    path: '/design-system/README_123o8123',
   },
   resourcePath: '/design-system/README_123o8123',
   path: 'components/footer/README.md',

--- a/app-web/__tests__/components/__snapshots__/ActionRibbon.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/ActionRibbon.test.js.snap
@@ -52,6 +52,8 @@ ShallowWrapper {
         >
           <li>
             <GatsbyLink
+              activeClassName=""
+              activeStyle={Object {}}
               aria-label="ariaLabel"
             >
               <FontAwesomeIcon
@@ -90,6 +92,8 @@ ShallowWrapper {
         "props": Object {
           "children": <li>
             <GatsbyLink
+              activeClassName=""
+              activeStyle={Object {}}
               aria-label="ariaLabel"
             >
               <FontAwesomeIcon
@@ -125,6 +129,8 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": <GatsbyLink
+              activeClassName=""
+              activeStyle={Object {}}
               aria-label="ariaLabel"
             >
               <FontAwesomeIcon
@@ -157,6 +163,8 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "function",
             "props": Object {
+              "activeClassName": "",
+              "activeStyle": Object {},
               "aria-label": "ariaLabel",
               "children": <FontAwesomeIcon
                 border={false}
@@ -232,6 +240,8 @@ ShallowWrapper {
           >
             <li>
               <GatsbyLink
+                activeClassName=""
+                activeStyle={Object {}}
                 aria-label="ariaLabel"
               >
                 <FontAwesomeIcon
@@ -270,6 +280,8 @@ ShallowWrapper {
           "props": Object {
             "children": <li>
               <GatsbyLink
+                activeClassName=""
+                activeStyle={Object {}}
                 aria-label="ariaLabel"
               >
                 <FontAwesomeIcon
@@ -305,6 +317,8 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <GatsbyLink
+                activeClassName=""
+                activeStyle={Object {}}
                 aria-label="ariaLabel"
               >
                 <FontAwesomeIcon
@@ -337,6 +351,8 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "function",
               "props": Object {
+                "activeClassName": "",
+                "activeStyle": Object {},
                 "aria-label": "ariaLabel",
                 "children": <FontAwesomeIcon
                   border={false}

--- a/app-web/__tests__/components/__snapshots__/Banner.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/Banner.test.js.snap
@@ -19,6 +19,8 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "function",
     "props": Object {
+      "activeClassName": "",
+      "activeStyle": Object {},
       "children": Array [
         <GovLogo />,
         <AppLogo />,
@@ -70,6 +72,8 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "function",
       "props": Object {
+        "activeClassName": "",
+        "activeStyle": Object {},
         "children": Array [
           <GovLogo />,
           <AppLogo />,

--- a/app-web/__tests__/components/__snapshots__/Card.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/Card.test.js.snap
@@ -43,6 +43,8 @@ ShallowWrapper {
           className="BodyImage"
         >
           <GatsbyLink
+            activeClassName=""
+            activeStyle={Object {}}
             aria-label="Learn more about this article"
             to="resourcePath"
           >
@@ -82,6 +84,8 @@ ShallowWrapper {
             className="BodyImage"
           >
             <GatsbyLink
+              activeClassName=""
+              activeStyle={Object {}}
               aria-label="Learn more about this article"
               to="resourcePath"
             >
@@ -133,6 +137,8 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": <GatsbyLink
+              activeClassName=""
+              activeStyle={Object {}}
               aria-label="Learn more about this article"
               to="resourcePath"
             >
@@ -152,6 +158,8 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "function",
             "props": Object {
+              "activeClassName": "",
+              "activeStyle": Object {},
               "aria-label": "Learn more about this article",
               "children": <Img
                 container={[Function]}
@@ -212,6 +220,8 @@ ShallowWrapper {
             className="BodyImage"
           >
             <GatsbyLink
+              activeClassName=""
+              activeStyle={Object {}}
               aria-label="Learn more about this article"
               to="resourcePath"
             >
@@ -251,6 +261,8 @@ ShallowWrapper {
               className="BodyImage"
             >
               <GatsbyLink
+                activeClassName=""
+                activeStyle={Object {}}
                 aria-label="Learn more about this article"
                 to="resourcePath"
               >
@@ -302,6 +314,8 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <GatsbyLink
+                activeClassName=""
+                activeStyle={Object {}}
                 aria-label="Learn more about this article"
                 to="resourcePath"
               >
@@ -321,6 +335,8 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "function",
               "props": Object {
+                "activeClassName": "",
+                "activeStyle": Object {},
                 "aria-label": "Learn more about this article",
                 "children": <Img
                   container={[Function]}

--- a/app-web/__tests__/components/__snapshots__/NavigationItem.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/NavigationItem.test.js.snap
@@ -21,6 +21,8 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": <GatsbyLink
+        activeClassName=""
+        activeStyle={Object {}}
         to="/"
       >
         banana
@@ -32,6 +34,8 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "function",
       "props": Object {
+        "activeClassName": "",
+        "activeStyle": Object {},
         "children": "banana",
         "to": "/",
       },
@@ -48,6 +52,8 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": <GatsbyLink
+          activeClassName=""
+          activeStyle={Object {}}
           to="/"
         >
           banana
@@ -59,6 +65,8 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "function",
         "props": Object {
+          "activeClassName": "",
+          "activeStyle": Object {},
           "children": "banana",
           "to": "/",
         },

--- a/app-web/__tests__/components/__snapshots__/PrimaryFilter.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/PrimaryFilter.test.js.snap
@@ -25,6 +25,7 @@ ShallowWrapper {
         <li>
           <GatsbyLink
             activeClassName="ActiveFilter"
+            activeStyle={Object {}}
             aria-label="Select to filter cards by the resource type"
             exact={true}
             to="/"
@@ -35,6 +36,7 @@ ShallowWrapper {
         <li>
           <GatsbyLink
             activeClassName="ActiveFilter"
+            activeStyle={Object {}}
             aria-label="Select to filter cards by the resource type"
             exact={true}
             to="/components"
@@ -45,6 +47,7 @@ ShallowWrapper {
         <li>
           <GatsbyLink
             activeClassName="ActiveFilter"
+            activeStyle={Object {}}
             aria-label="Select to filter cards by the resource type"
             exact={true}
             to="/documentation"
@@ -55,6 +58,7 @@ ShallowWrapper {
         <li>
           <GatsbyLink
             activeClassName="ActiveFilter"
+            activeStyle={Object {}}
             aria-label="Select to filter cards by the resource type"
             exact={true}
             to="/self-service-tools"
@@ -65,6 +69,7 @@ ShallowWrapper {
         <li>
           <GatsbyLink
             activeClassName="ActiveFilter"
+            activeStyle={Object {}}
             aria-label="Select to filter cards by the resource type"
             exact={true}
             to="/repositories"
@@ -85,6 +90,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/"
@@ -95,6 +101,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/components"
@@ -105,6 +112,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/documentation"
@@ -115,6 +123,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/self-service-tools"
@@ -125,6 +134,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/repositories"
@@ -144,6 +154,7 @@ ShallowWrapper {
           "props": Object {
             "children": <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/"
@@ -158,6 +169,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "activeClassName": "ActiveFilter",
+              "activeStyle": Object {},
               "aria-label": "Select to filter cards by the resource type",
               "children": "All",
               "exact": true,
@@ -176,6 +188,7 @@ ShallowWrapper {
           "props": Object {
             "children": <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/components"
@@ -190,6 +203,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "activeClassName": "ActiveFilter",
+              "activeStyle": Object {},
               "aria-label": "Select to filter cards by the resource type",
               "children": "Components",
               "exact": true,
@@ -208,6 +222,7 @@ ShallowWrapper {
           "props": Object {
             "children": <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/documentation"
@@ -222,6 +237,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "activeClassName": "ActiveFilter",
+              "activeStyle": Object {},
               "aria-label": "Select to filter cards by the resource type",
               "children": "Documentation",
               "exact": true,
@@ -240,6 +256,7 @@ ShallowWrapper {
           "props": Object {
             "children": <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/self-service-tools"
@@ -254,6 +271,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "activeClassName": "ActiveFilter",
+              "activeStyle": Object {},
               "aria-label": "Select to filter cards by the resource type",
               "children": "Self-Service Tools",
               "exact": true,
@@ -272,6 +290,7 @@ ShallowWrapper {
           "props": Object {
             "children": <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/repositories"
@@ -286,6 +305,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "activeClassName": "ActiveFilter",
+              "activeStyle": Object {},
               "aria-label": "Select to filter cards by the resource type",
               "children": "Repositories",
               "exact": true,
@@ -314,6 +334,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/"
@@ -324,6 +345,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/components"
@@ -334,6 +356,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/documentation"
@@ -344,6 +367,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/self-service-tools"
@@ -354,6 +378,7 @@ ShallowWrapper {
           <li>
             <GatsbyLink
               activeClassName="ActiveFilter"
+              activeStyle={Object {}}
               aria-label="Select to filter cards by the resource type"
               exact={true}
               to="/repositories"
@@ -374,6 +399,7 @@ ShallowWrapper {
             <li>
               <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/"
@@ -384,6 +410,7 @@ ShallowWrapper {
             <li>
               <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/components"
@@ -394,6 +421,7 @@ ShallowWrapper {
             <li>
               <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/documentation"
@@ -404,6 +432,7 @@ ShallowWrapper {
             <li>
               <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/self-service-tools"
@@ -414,6 +443,7 @@ ShallowWrapper {
             <li>
               <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/repositories"
@@ -433,6 +463,7 @@ ShallowWrapper {
             "props": Object {
               "children": <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/"
@@ -447,6 +478,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "activeClassName": "ActiveFilter",
+                "activeStyle": Object {},
                 "aria-label": "Select to filter cards by the resource type",
                 "children": "All",
                 "exact": true,
@@ -465,6 +497,7 @@ ShallowWrapper {
             "props": Object {
               "children": <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/components"
@@ -479,6 +512,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "activeClassName": "ActiveFilter",
+                "activeStyle": Object {},
                 "aria-label": "Select to filter cards by the resource type",
                 "children": "Components",
                 "exact": true,
@@ -497,6 +531,7 @@ ShallowWrapper {
             "props": Object {
               "children": <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/documentation"
@@ -511,6 +546,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "activeClassName": "ActiveFilter",
+                "activeStyle": Object {},
                 "aria-label": "Select to filter cards by the resource type",
                 "children": "Documentation",
                 "exact": true,
@@ -529,6 +565,7 @@ ShallowWrapper {
             "props": Object {
               "children": <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/self-service-tools"
@@ -543,6 +580,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "activeClassName": "ActiveFilter",
+                "activeStyle": Object {},
                 "aria-label": "Select to filter cards by the resource type",
                 "children": "Self-Service Tools",
                 "exact": true,
@@ -561,6 +599,7 @@ ShallowWrapper {
             "props": Object {
               "children": <GatsbyLink
                 activeClassName="ActiveFilter"
+                activeStyle={Object {}}
                 aria-label="Select to filter cards by the resource type"
                 exact={true}
                 to="/repositories"
@@ -575,6 +614,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "activeClassName": "ActiveFilter",
+                "activeStyle": Object {},
                 "aria-label": "Select to filter cards by the resource type",
                 "children": "Repositories",
                 "exact": true,

--- a/app-web/__tests__/gatsby-plugins/gatsby-remark-transform-path.test.js
+++ b/app-web/__tests__/gatsby-plugins/gatsby-remark-transform-path.test.js
@@ -24,6 +24,17 @@ import {
 import { FILE_QL_NODE, SIPHON_QL_NODE } from '../../__fixtures__/plugin-fixtures';
 
 describe('Gatsby Remark Transform Path Converter Callback', () => {
+  const getNode = jest.fn(() => ({
+    _metadata: {
+      sourceLocations: [
+        [
+          'https://github.com/bcgov/design-system/blob/master/components/footer/something/foo.md',
+          '/foo/foo',
+        ],
+      ],
+    },
+  }));
+
   describe('Unit Tests', () => {
     it('normalizes paths', () => {
       const p1 = 'path1.md';
@@ -47,7 +58,7 @@ describe('Gatsby Remark Transform Path Converter Callback', () => {
     it('converts only SourceDevhubGithub nodes', () => {
       const astType = 'image';
       const relativePath = '../images/banana.png';
-      const transformedPath = converter(astType, relativePath, FILE_QL_NODE);
+      const transformedPath = converter(astType, relativePath, FILE_QL_NODE, getNode);
 
       expect(transformedPath).toBe(relativePath);
     });
@@ -55,7 +66,7 @@ describe('Gatsby Remark Transform Path Converter Callback', () => {
     it('returns a a transformed url', () => {
       const astType = 'image';
       const relativePath = '../images/banana.png';
-      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE);
+      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE, getNode);
       expect(transformedPath).not.toBe(relativePath);
     });
 
@@ -80,7 +91,8 @@ describe('Gatsby Remark Transform Path Converter Callback', () => {
     it('converts relative path to absolute', () => {
       const astType = 'link';
       const relativePath = '../something.md';
-      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE);
+
+      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE, getNode);
       const expectedPath =
         'https://github.com/bcgov/design-system/blob/master/components/footer/something.md';
       expect(transformedPath).toBe(expectedPath);
@@ -89,7 +101,7 @@ describe('Gatsby Remark Transform Path Converter Callback', () => {
     it('converts path with no leading slash to relative', () => {
       const astType = 'link';
       const relativePath = 'doc.md';
-      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE);
+      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE, getNode);
       const expectedPath =
         'https://github.com/bcgov/design-system/blob/master/components/footer/something/doc.md';
       expect(transformedPath).toBe(expectedPath);
@@ -98,10 +110,17 @@ describe('Gatsby Remark Transform Path Converter Callback', () => {
     it('converts relative path for image to absolute with raw paramater', () => {
       const astType = 'image';
       const relativePath = '../banana.png';
-      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE);
+      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE, getNode);
       const expectedPath =
         'https://github.com/bcgov/design-system/blob/master/components/footer/banana.png?raw=true';
       expect(transformedPath).toBe(expectedPath);
+    });
+
+    it('converts a relative path to a gatsby page path if it exists in source locations', () => {
+      const astType = 'link';
+      const relativePath = './foo.md';
+      const transformedPath = converter(astType, relativePath, SIPHON_QL_NODE, getNode);
+      expect(transformedPath).toBe('/foo/foo');
     });
   });
 });

--- a/app-web/__tests__/utils/utils.test.js
+++ b/app-web/__tests__/utils/utils.test.js
@@ -3,6 +3,12 @@ import { SIPHON_QL_NODE } from '../../__fixtures__/plugin-fixtures';
 import { converter } from '../../src/utils/gatsby-remark-transform-path';
 
 describe('Gatsby Remark Transformer Path Converter', () => {
+  const getNode = jest.fn(() => ({
+    _metadata: {
+      sourceLocations: [],
+    },
+  }));
+
   test('it only transforms sourceDevHubGithub nodes', () => {
     const path = './something.png';
     const astType = 'image';
@@ -11,13 +17,13 @@ describe('Gatsby Remark Transformer Path Converter', () => {
         type: 'notsourceDevhubGithub',
       },
     };
-    expect(converter(astType, path, node)).toBe(path);
+    expect(converter(astType, path, node, getNode)).toBe(path);
   });
 
   test('it returns path on sourceDevhubGithub nodes', () => {
     const path = './somthing.png';
     const astType = 'image';
-    const newPath = converter(astType, path, SIPHON_QL_NODE);
+    const newPath = converter(astType, path, SIPHON_QL_NODE, getNode);
     expect(typeof newPath).toBe('string');
     expect(newPath).not.toBe(path);
   });

--- a/app-web/gatsby-config.js
+++ b/app-web/gatsby-config.js
@@ -106,6 +106,7 @@ module.exports = {
               maxWidth: 590,
             },
           },
+          'gatsby-plugin-catch-links',
         ],
       },
     },

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -8123,6 +8123,15 @@
         "prop-types": "^15.6.1"
       }
     },
+    "gatsby-plugin-catch-links": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.0.9.tgz",
+      "integrity": "sha512-0I78VTwy9GJkh8nEt33VASo/cvBmDtdChoISQ+U0Pio5pXEXT2RQIesuHwcm4pXG/VRDVnEYxa95PLUccW5vFg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
     "gatsby-plugin-emotion": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-3.0.1.tgz",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -29,6 +29,7 @@
     "feather-icons": "^3.3.0",
     "flag": "^3.0.0-1",
     "gatsby": "^2.0.64",
+    "gatsby-plugin-catch-links": "^2.0.9",
     "gatsby-plugin-emotion": "^3.0.1",
     "gatsby-plugin-favicon": "^3.1.4",
     "gatsby-plugin-google-analytics": "^2.0.8",

--- a/app-web/plugins/gatsby-remark-path-transform/__tests__/utils.test.js
+++ b/app-web/plugins/gatsby-remark-path-transform/__tests__/utils.test.js
@@ -50,7 +50,7 @@ describe('gatsby-remark-path-transform', () => {
 
       transformRelativePaths({ getNode, markdownAST, markdownNode }, { converter });
 
-      expect(converter).toHaveBeenCalledWith('image', oldURL, GRAPH_QL_PARENT_NODE);
+      expect(converter).toHaveBeenCalledWith('image', oldURL, GRAPH_QL_PARENT_NODE, getNode);
       // expect url to hvae been changed
       expect(oldURL).not.toBe(markdownAST.url);
     });

--- a/app-web/plugins/gatsby-remark-path-transform/index.js
+++ b/app-web/plugins/gatsby-remark-path-transform/index.js
@@ -25,7 +25,7 @@ const { IMAGE, LINK } = require('./utils/constants');
 /**
  * sifts through ast (see https://www.huynguyen.io/2018-05-remark-gatsby-plugin-part-2/)
  * and converts relative paths to absolute paths for images and links via a converter cb
- * the converter cb receives (ast node type, relative url, parent graphql node)
+ * the converter cb receives (ast node type, relative url, parent graphql node, getNode (to get nodes further up the tree if needed))
  * @param {Object} remark
  * @param {Object} options
  */
@@ -47,7 +47,7 @@ const transformRelativePaths = ({ markdownAST, markdownNode, getNode }, { conver
     if (validURL.isWebUri(url) || url.indexOf('#') === 0) {
       return url;
     }
-    const absolutePath = converter(nodeType, url, parentQLNode);
+    const absolutePath = converter(nodeType, url, parentQLNode, getNode);
     return absolutePath; // eslint-disable-line
   };
 

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -257,6 +257,7 @@ describe('gatsby source github all plugin', () => {
         slug: COLLECTION_OBJ_FROM_FETCH_QUEUE.slug,
         template: COLLECTION_TEMPLATES.DEFAULT,
         templateFile: undefined,
+        sourceLocations: undefined,
       },
     };
     hashString.mockReturnValue(null);

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -302,6 +302,10 @@ const processCollection = async (
   );
   // flatten source nodes to get a list of all the resources
   const resources = _.flatten(sourceNodes, true);
+  // create a hash map of all resources: resource paths original source against the path created
+  // for a gatsby page
+  collection.sourceLocations = resources.map(r => [r.resource.originalSource, r.resource.path]);
+
   const collectionNode = createCollectionNode(collection, id);
 
   await createNode(collectionNode);

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -43,6 +43,7 @@ const createCollectionNode = (collection, id) => {
       template: collection.template,
       templateFile: collection.templateFile,
       slug: collection.slug,
+      sourceLocations: collection.sourceLocations,
     },
   };
 };

--- a/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
+++ b/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
@@ -27,7 +27,7 @@ import styles from './SourceNavigation.module.css';
 class SourceNavigation extends Component {
   componentDidMount() {
     // scroll into view of active link if exists
-    const activeLi = document.querySelector(`.${styles.Navigation} li[data-active="true"]`);
+    const activeLi = document.querySelector(`.${styles.Navigation} a.active`);
     if (activeLi) {
       activeLi.scrollIntoView();
     }
@@ -44,8 +44,10 @@ class SourceNavigation extends Component {
           source: { type },
         },
       }) => (
-        <li key={shortid.generate()} data-active={this.props.activeLink.pathname === path}>
+        <li key={shortid.generate()}>
           <Link
+            exact="true"
+            activeClassName="active"
             to={path}
             target={type === 'web' ? '_blank' : ''}
             activeStyle={{

--- a/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.module.css
+++ b/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.module.css
@@ -14,19 +14,8 @@
     overflow-y: scroll;
 }
 
-.Navigation ul li {
-    padding: 4px .5em;
-}
-
-.Navigation li[data-active="true"] {
-    text-decoration: underline;
-    background-color: #fff;
-    display: flex;
-    align-items: center;
-    position: relative;
-}
-
 .Navigation a {
+    padding: 4px .5em;
     overflow: hidden;
     color: #2e2e2e;
     display: inline-block;

--- a/app-web/src/components/UI/Link/Link.js
+++ b/app-web/src/components/UI/Link/Link.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'gatsby';
 
-const GatsbyLink = ({ children, to, ...rest }) => {
+const GatsbyLink = ({ children, to, activeClassName, activeStyle, ...rest }) => {
   // Tailor the following test to your environment.
   // This example assumes that any internal link (intended for Gatsby)
   // will start with exactly one slash, and that anything else is external.
@@ -10,7 +10,7 @@ const GatsbyLink = ({ children, to, ...rest }) => {
   // Use Gatsby Link for internal links, and <a> for rests
   if (internal) {
     return (
-      <Link to={to} {...rest}>
+      <Link to={to} activeStyle={activeStyle} activeClassName={activeClassName} {...rest}>
         {children}
       </Link>
     );
@@ -20,6 +20,11 @@ const GatsbyLink = ({ children, to, ...rest }) => {
       {children}
     </a>
   );
+};
+
+GatsbyLink.defaultProps = {
+  activeClassName: '',
+  activeStyle: {},
 };
 
 export default GatsbyLink;

--- a/app-web/src/components/UI/PhaseBanner/PhaseBanner.js
+++ b/app-web/src/components/UI/PhaseBanner/PhaseBanner.js
@@ -41,7 +41,7 @@ const PhaseBanner = ({ phase }) => {
   );
 };
 
-PhaseBanner.PropTypes = {
+PhaseBanner.propTypes = {
   phase: PropTypes.string,
 };
 

--- a/docs/gatsby-custom-plugins/gatsby-remark-path-transform.md
+++ b/docs/gatsby-custom-plugins/gatsby-remark-path-transform.md
@@ -77,6 +77,7 @@ Example:
  * @param {String} astNodeType is only 'image' or 'link'
  * @param {String} relativePath 
  * @param {Object} parentQLNode
+ * @param {Function} getNode gatsby getNode function
  */
 const converter = (astNodeType, relativePath, parentQLNode) => {
     if(parentQLNode.internal.type === 'myParentNode') {


### PR DESCRIPTION
## Summary
Fixes #263 

This is done by maintaining a hash map of all gatsby page paths and the originating source that are related to a collection..

### The data structure is as follows
```js
collection._metadata.sourceLocations = [
   [originalSource, pagePath],
]
```

The reason that it is in this data structure vs a **object literal** is that gatsby converts object literals into a graphql query object, and so the only way to grab the key/value pairs is to interface with graphql. 

Another benefit to this data structure is that it translates into a javascript `Map` object cleanly (which can be interfaced in a similar manner to a object literal).

## Notable Changes <!-- if any -->
- updates the gatsby path remark transform plugin
- the collection node now holds a hash map like object of all original resource paths and their gatsby page paths in the property `_metadata.sourceLocations`
- modified the `Link` UI Component to properly respond to when its considered active (when the url matches the link href)