### PR TITLE
fix a bug where smaller images wouldn't center in the cards

### DIFF
--- a/app-web/src/components/Cards/Card/Card.module.css
+++ b/app-web/src/components/Cards/Card/Card.module.css
@@ -97,6 +97,9 @@
     width: 100%;
     display: block;
     height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .Ribbon {


### PR DESCRIPTION
## Summary
I noticed smaller images in the cards aligned to the top of their container. This fix centers them. 