### PR TITLE
Fix siphon failing when trying to unfurl sites that have no metadata

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/transfomer.test.js
@@ -19,6 +19,7 @@ import {
   getClosestPersona,
   unfurlWebURI,
   mergeUnfurls,
+  withUnfurlWarning,
 } from '../utils/helpers';
 
 jest.mock('../utils/helpers.js');
@@ -28,6 +29,7 @@ getClosestResourceType.mockReturnValue('');
 getClosestPersona.mockImplementation(persona => persona);
 unfurlWebURI.mockReturnValue({});
 mergeUnfurls.mockImplementation((oldUnfurl, newUnfurl) => newUnfurl);
+withUnfurlWarning.mockImplementation((url, unfurl) => unfurl);
 
 describe('Transformer System', () => {
   let file = null;

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -31,6 +31,7 @@ const {
   assignPositionToSource,
   getClosest,
 } = require('./utils/helpers');
+const siphonMessenger = require('./utils/console');
 const { fetchFromSource, validateSourceRegistry } = require('./utils/fetchSource');
 const {
   COLLECTION_TYPES,
@@ -126,11 +127,7 @@ const filterIgnoredResources = sources =>
     if (!Object.prototype.hasOwnProperty.call(s.metadata, 'ignore') || !s.metadata.ignore) {
       return true;
     }
-    console.log(
-      chalk`\n The resource {green.bold ${
-        s.metadata.name
-      }} has been flagged as {green.bold 'ignore'} and will not have a Siphon Node created for it`,
-    );
+    console.log(siphonMessenger.resourceIgnored(s.metadata.name));
     return false;
   });
 
@@ -177,8 +174,7 @@ const normalizeAttributes = attributes => {
  */
 const getFetchQueue = async (sources, tokens) => {
   const slugStore = new Store([], {
-    conflictCb: slug =>
-      chalk`\n{red WARNING from Siphon!} {red.bold ---} The collection slug {yellow.bold ${slug}}, has already been used. This is a warning message, in future versions we may remove your collection on conflicts such as this.`,
+    conflictCb: slug => siphonMessenger.collectionSlugConflict(slug),
   });
 
   const collectionPromises = sources.map(async (source, index) => {

--- a/app-web/plugins/gatsby-source-github-all/utils/console.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/console.js
@@ -1,0 +1,48 @@
+const chalk = require('chalk');
+
+const siphonMessages = (() => {
+  const warning = chalk.yellow('\nWARNING from Siphon! ---');
+  // eslint-disable-next-line no-unused-vars
+  const error = chalk.red('\nERROR from Siphon! ---');
+  const advisory = chalk.cyan('\nADVISORY from Siphon! ---');
+  const registrationInstructions = chalk.green(
+    'https://github.com/bcgov/devhub-app-web/blob/master/docs/registerRepo.md',
+  );
+
+  const unfurlLacksInfo = url => chalk`
+    ${warning} the URL {green ${url}}
+    Was unfurled and lacked metadata.
+    In addition there was little configuration in the registry to provide the missing metadata. 
+    Good Siphon Resources will have atleast a {cyan.bold title} and a {cyan.bold description} 
+    (adding an image as well would be awesome too).
+    You can add properties to overide unfurls.
+    -- instructions are found here ${registrationInstructions}\n`;
+
+  const resourceIgnored = resource => chalk`
+    ${advisory} The resource {green.bold ${resource}} has been flagged as
+    {green.bold 'ignore'} and will not have a Siphon Node created for it`;
+
+  const collectionSlugConflict = slug => chalk`
+    ${warning} The collection slug {yellow.bold ${slug}} has already been used.
+    This is a warning message. In future versions we may remove your collection
+    on conflicts such as this.`;
+
+  const markdownSlugConflict = (slug, conflictingSummary, currentSummary) => chalk`
+    ${warning} markdown file slug conflict {red.bold (slug: ${slug})} 
+    the following markdown file ---
+    {green ${conflictingSummary}}
+    has a naming conflict in the slug that is being used to produce a gatsby page. 
+    The slug is currently in use by this markdown file ---
+    {green ${currentSummary}}
+    {cyan.bold This may cause odd issues for links to the gatsby page if not rectified.}
+    detailed stack below..`;
+
+  return {
+    unfurlLacksInfo,
+    resourceIgnored,
+    collectionSlugConflict,
+    markdownSlugConflict,
+  };
+})();
+
+module.exports = siphonMessages;

--- a/app-web/plugins/gatsby-source-github-all/utils/console.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/console.js
@@ -1,3 +1,20 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
 const chalk = require('chalk');
 
 const siphonMessages = (() => {

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -25,6 +25,7 @@ const stringSimilarity = require('string-similarity');
 const scrape = require('html-metadata');
 const validUrl = require('valid-url');
 const { RESOURCE_TYPES_LIST, UNFURL_TYPES, SOURCE_TYPES } = require('./constants');
+const siphonMessenger = require('./console');
 const { fetchRepo } = require('./sources/github/api');
 /**
  * returns an idempotent path based on a base path plus a digestable string that is hashed
@@ -44,6 +45,11 @@ const createPathWithDigest = (base, ...digestables) => {
   const digested = shorthash.unique(digestables.join(''));
 
   return path.join('/', normalizedBase, digested);
+};
+
+const withUnfurlWarning = (url, unfurl) => {
+  if (!unfurl.title || !unfurl.description) console.log(siphonMessenger.unfurlLacksInfo(url));
+  return unfurl;
 };
 
 /**
@@ -383,4 +389,5 @@ module.exports = {
   unfurlWebURI,
   isSourceCollection,
   getCollectionDescriptionBySourceType,
+  withUnfurlWarning,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -211,7 +211,17 @@ const unfurlWebURI = async uri => {
   if (!uri || !validUrl.isUri(uri)) {
     throw new Error('The uri is not valid');
   }
-  const data = await scrape(uri);
+  let data;
+  try {
+    data = await scrape(uri);
+  } catch (e) {
+    if (e.message === 'No metadata found in page') {
+      //this is the only case we want to handle and to continue without throwing
+      data = {};
+    } else {
+      throw e;
+    }
+  }
 
   // metadata comes in with properties for each type of unfurl spec (twitter, openGraph etc)
   const combinedData = { ...data.general, ...data.twitter, ...data.openGraph };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -22,6 +22,7 @@ const {
   assignPositionToResource,
   mergeUnfurls,
   createUnfurlObj,
+  withUnfurlWarning,
 } = require('../../helpers');
 
 /**
@@ -55,10 +56,9 @@ const fetchSourceWeb = async ({
   const source = { metadata: { ...metadata } };
   const localUnfurl = extractUnfurlFromSourceProperties(sourceProperties);
   const assignPosToResourceBySource = assignPositionToResource(source);
-
   try {
     const externalUnfurl = await unfurlWebURI(url);
-    const unfurl = mergeUnfurls(localUnfurl, externalUnfurl);
+    const unfurl = withUnfurlWarning(url, mergeUnfurls(localUnfurl, externalUnfurl));
     const siphonData = {
       metadata: {
         unfurl,


### PR DESCRIPTION
## Summary
When an external website either declared in a markdown file or by source type `web` gets unfurled. The metascraper library throws if there isn't any metadata. 
> I feel thats a poor design thing but oh well

This particular exception is handled now. Other errors (like 500) are still thrown and handled as they would before.

## Notable Changes <!-- if any -->
- fix the issue
- abstracted most console messages into a class that holds these messages in one neat place
- added a warning message if web source type unfurls lack meta data. 

Fixes #325 