### PR TITLE
Add a react link component that sets active class based on search params

### DIFF
--- a/app-web/__tests__/components/SearchAwareLink.test.js
+++ b/app-web/__tests__/components/SearchAwareLink.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { SearchAwareLink, Link } from '../../src/components/UI/Link';
+import { linkMatchesQueryString } from '../../src/components/UI/Link/SearchAwareLink';
+import { shallow, mount } from 'enzyme';
+
+describe('Search Aware Link', () => {
+  it('renders a Link component', () => {
+    const wrapper = shallow(<SearchAwareLink>foo</SearchAwareLink>);
+    expect(wrapper.find(Link)).toBeDefined();
+  });
+
+  it('linkMatchesQueryString returns true when strings match', () => {
+    const location = {
+      search: '?q=foo&l=bar',
+    };
+
+    const to = '/?q=foo';
+
+    const matches = linkMatchesQueryString(location, to);
+    expect(matches).toBe(true);
+  });
+
+  it('linkMatchesQueryString returns false when strings dont have a match', () => {
+    const location = {
+      search: '?q=foo&l=bar',
+    };
+
+    const to = '/?q=nancy';
+
+    const matches = linkMatchesQueryString(location, to);
+    expect(matches).toBe(false);
+  });
+
+  it('linkMatchesQueryString returns true when to matches within a set of search params', () => {
+    const location = {
+      search: '?q=foo&l=bar&matt=damon',
+    };
+
+    const to = '/?matt=damon';
+
+    const matches = linkMatchesQueryString(location, to);
+    expect(matches).toBe(true);
+  });
+});

--- a/app-web/src/components/UI/Link/SearchAwareLink.js
+++ b/app-web/src/components/UI/Link/SearchAwareLink.js
@@ -19,13 +19,14 @@ import queryString from 'query-string';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from './Link';
-import Search from '../../Search/Search';
 
-// bootstraps the gatsby link, when the 'to' prop is a relative path,
-// the active class is set based on if the if the query string parameter matches
-// this is not a replacement for the Link component, as setting activeClassName by path matching
-// doesn't work anymore
-export const linkMatchesQueryString = (location, to, activeClassName) => {
+/**
+ * returns true if the to attributes search param exists within the current location search params
+ * @param {Object} location the location prop for the current windo
+ * @param {String} to the actual href used by the link
+ * @returns {Boolean}
+ */
+export const linkMatchesQueryString = (location, to) => {
   // convert to into an URL object
   // at this point we absolutely know that 'to' must be a relative path,
   // there for we prepend a dummy url to it so that it can be processed by URL
@@ -39,13 +40,19 @@ export const linkMatchesQueryString = (location, to, activeClassName) => {
     key => linkQueryString[key] && currentQueryString[key] === linkQueryString[key],
   );
 
-  return matches ? { className: activeClassName } : null;
+  return matches;
 };
 
+// bootstraps the gatsby link, when the 'to' prop is a relative path,
+// the active class is set based on if the if the query string parameter matches
+// this is not a replacement for the Link component, as setting activeClassName by path matching
+// doesn't work anymore
 const SearchAwareLink = ({ activeClassName, children, ...rest }) => (
   <Link
     {...rest}
-    getProps={(location, href) => linkMatchesQueryString(location, href, activeClassName)}
+    getProps={(location, href) =>
+      linkMatchesQueryString(location, href) ? { className: activeClassName } : null
+    }
   >
     {children}
   </Link>

--- a/app-web/src/components/UI/Link/SearchAwareLink.js
+++ b/app-web/src/components/UI/Link/SearchAwareLink.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+import queryString from 'query-string';
+import React from 'react';
+import PropTypes from 'prop-types';
+import Link from './Link';
+import Search from '../../Search/Search';
+
+// bootstraps the gatsby link, when the 'to' prop is a relative path,
+// the active class is set based on if the if the query string parameter matches
+// this is not a replacement for the Link component, as setting activeClassName by path matching
+// doesn't work anymore
+export const linkMatchesQueryString = (location, to, activeClassName) => {
+  // convert to into an URL object
+  // at this point we absolutely know that 'to' must be a relative path,
+  // there for we prepend a dummy url to it so that it can be processed by URL
+  const url = new URL(`https://developer.gov.bc.ca/${to}`);
+
+  const currentQueryString = queryString.parse(location.search);
+  const linkQueryString = queryString.parse(url.search);
+
+  // see if current query string contains link query strings value and they match
+  const matches = Object.keys(currentQueryString).some(
+    key => linkQueryString[key] && currentQueryString[key] === linkQueryString[key],
+  );
+
+  return matches ? { className: activeClassName } : null;
+};
+
+const SearchAwareLink = ({ activeClassName, children, ...rest }) => (
+  <Link
+    {...rest}
+    getProps={(location, href) => linkMatchesQueryString(location, href, activeClassName)}
+  >
+    {children}
+  </Link>
+);
+
+SearchAwareLink.propTypes = {
+  activeClassName: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default SearchAwareLink;

--- a/app-web/src/components/UI/Link/index.js
+++ b/app-web/src/components/UI/Link/index.js
@@ -1,0 +1,4 @@
+import Link from './Link';
+import SearchAwareLink from './SearchAwareLink';
+
+export { Link, SearchAwareLink };


### PR DESCRIPTION
## Summary
This is a component that wraps the already in use `<Link>` component. Essentially it overrides the links behaviour of setting active class based on path matching. Instead it sets 'active' based on if query params match

__please note__ at this time the `<SearchAwareLink />` will only set active if it has one search parameter in its 'to' prop. multiple search param matching hasn't been implemented


## So why do we need this?

This component is a refactor with the logic used in #344 which allows links to be active based on what searchs are currently in use. The primary navigiation filters are essentially a set of canned searches. #344 addressed a bug where the active link styling was not being applied because it wasn't aware of query params. 