### PR TITLE
Adjust max width of markdown page content container

### DIFF
--- a/app-web/src/templates/SourceMarkdown.module.css
+++ b/app-web/src/templates/SourceMarkdown.module.css
@@ -1,3 +1,6 @@
+.MarkdownBody {
+    max-width: 800px;
+}
 
 .MarkdownBody h1,
 .MarkdownBody h2,


### PR DESCRIPTION
##Summary 

Set max width of markdown container to 800px for better readability.
