### PR TITLE
Imp/design system order

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
+++ b/app-web/plugins/gatsby-source-github-all/__fixtures__/fixtures.js
@@ -212,6 +212,7 @@ const PROCESSED_FILE_HTML = {
       name: 'foo',
       type: 'bar',
     },
+    position: [0, 0, 2],
   },
 };
 
@@ -335,6 +336,7 @@ const PROCESSED_FILE_MD = {
       name: 'foo',
       type: 'bar',
     },
+    position: [0, 0, 1],
   },
 };
 
@@ -535,6 +537,7 @@ const CONFIG_OPTIONS = {
 
 const PROCESSED_WEB_SOURCE = {
   metadata: {
+    position: [1, 1, 1],
     unfurl: {
       author: 'foo',
       description: 'bar',

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -47,6 +47,7 @@ import {
   newCollection,
   assignPositionToCollection,
   assignPositionToSource,
+  convertPositionToSortableString,
 } from '../utils/helpers';
 
 jest.mock('../utils/helpers');
@@ -57,6 +58,7 @@ newCollection.mockImplementation((collection, props) => ({ ...collection, ...pro
 assignPositionToCollection.mockImplementation(collection => () => ({
   metadata: { position: [0] },
 }));
+convertPositionToSortableString.mockImplementation((padding, position) => position.join('.'));
 
 assignPositionToSource.mockImplementation(source => () => ({ metadata: { position: [0, 0] } }));
 
@@ -142,6 +144,7 @@ describe('gatsby source github all plugin', () => {
   test('createSiphonNode returns data', () => {
     const file = {
       metadata: {
+        position: [1, 1, 1],
         collection: {
           name: 'foo',
           type: COLLECTION_TYPES.CURATED,
@@ -230,7 +233,7 @@ describe('gatsby source github all plugin', () => {
         content: 'content',
       },
       _metadata: {
-        position: undefined,
+        position: '1.1.1',
       },
     };
 
@@ -253,7 +256,7 @@ describe('gatsby source github all plugin', () => {
         type: GRAPHQL_NODE_TYPE.COLLECTION,
       },
       _metadata: {
-        position: [0],
+        position: COLLECTION_OBJ_FROM_FETCH_QUEUE.metadata.position.join('.'),
         slug: COLLECTION_OBJ_FROM_FETCH_QUEUE.slug,
         template: COLLECTION_TEMPLATES.DEFAULT,
         templateFile: undefined,

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -326,7 +326,6 @@ const sourceNodes = async ({ getNodes, actions, createNodeId }, { tokens, source
     checkRegistry(registry);
     // map of over registry and create a queue of collections to fetch
     const fetchQueue = await getFetchQueue(registry.sources, tokens);
-
     const collections = await Promise.all(
       fetchQueue.map(async collection =>
         processCollection(collection, createNodeId, createNode, createParentChildLink, tokens),

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 Created by Patrick Simonian
 */
-const { hashString } = require('./helpers');
+const { hashString, convertPositionToSortableString } = require('./helpers');
 const { GRAPHQL_NODE_TYPE } = require('./constants');
 
 /**
@@ -39,7 +39,7 @@ const createCollectionNode = (collection, id) => {
       type: GRAPHQL_NODE_TYPE.COLLECTION,
     },
     _metadata: {
-      position: metadata.position,
+      position: convertPositionToSortableString(10, metadata.position),
       template: collection.template,
       templateFile: collection.templateFile,
       slug: collection.slug,
@@ -97,7 +97,7 @@ const createSiphonNode = (data, id, collectionId) => ({
     content: data.content,
   },
   _metadata: {
-    position: data.metadata.position,
+    position: convertPositionToSortableString(10, data.metadata.position),
   },
 });
 

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -369,9 +369,23 @@ const assignPositionToResource = source => (resource, position) => ({
   },
 });
 
+/**
+ * creates a string that is usable in a natural sort
+ * it padds numbers with zeros so that it will sort normally
+ * ie [0, 0, 1], [0, 0, 10] => 0000.0000.0001 , 0000.0000.0010
+ * @param {Array} pos the position array
+ */
+const convertPositionToSortableString = (maxPadding, pos) =>
+  pos.reduce((acc, position, index) => {
+    const posLength = maxPadding - (position + '').length;
+    const paddedPosition = '0'.repeat(posLength) + position;
+    return acc + paddedPosition + '.';
+  }, '');
+
 module.exports = {
   assignPositionToResource,
   createPosition,
+  convertPositionToSortableString,
   assignPositionToSource,
   assignPositionToCollection,
   newCollection,

--- a/app-web/source-registry/registry.yml
+++ b/app-web/source-registry/registry.yml
@@ -5,6 +5,24 @@ sources:
       url: https://github.com/bcgov/design-system/
       owner: bcgov
       repo: 'design-system'
+      files: 
+        - components/about/about.md
+        - components/about/accessibility.md
+        - styles/colours/colourpalette.md
+        - styles/typography/typography.md
+        - styles/Icons/icons.md
+        - components/about/component_workflow.md
+        - components/header/README.md
+        - components/footer/README.md
+        - components/navbar/README.md
+        - components/primary_button/README.md
+        - components/link/README.md
+        - components/radio/README.md
+        - components/checkbox/README.md
+        - components/text_input/README.md
+        - components/textarea/README.md
+        - components/about/propose_a_component.md
+        - components/about/prototyping_tools.md
     attributes:
       labels:
         - Components

--- a/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
+++ b/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
@@ -39,22 +39,8 @@ class SourceNavigation extends Component {
     // map over components and generate links
     const links = components
       .sort((a, b) => a.node._metadata.position.localeCompare(b.node._metadata.position))
-      .map(n => n.node);
-    // sorts are broken because of the way the 'ip' is generated.
-    // it should be padded with zero based on the highest number
-    // if there are 30 resources to a source
-    // the resource indicator should be padded with a 0
-    // 1.1.01
-    // 1.1.02
-    console.log(links);;
-    const blah = components.map(
-      ({
-        node: {
-          unfurl: { title },
-          resource: { path },
-          source: { type },
-        },
-      }) => (
+      .map(n => n.node)
+      .map(({ node: { unfurl: { title }, resource: { path }, source: { type } } }) => (
         <li key={shortid.generate()}>
           <Link
             exact="true"
@@ -74,11 +60,10 @@ class SourceNavigation extends Component {
             ) : null}
           </Link>
         </li>
-      ),
-    );
+      ));
     return (
       <nav className={styles.Navigation}>
-        <ul className={styles.List}>{blah}</ul>
+        <ul className={styles.List}>{links}</ul>
       </nav>
     );
   }

--- a/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
+++ b/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
@@ -35,8 +35,19 @@ class SourceNavigation extends Component {
 
   render() {
     const { components } = this.props;
+
     // map over components and generate links
-    const links = components.map(
+    const links = components
+      .sort((a, b) => a.node._metadata.position.localeCompare(b.node._metadata.position))
+      .map(n => n.node);
+    // sorts are broken because of the way the 'ip' is generated.
+    // it should be padded with zero based on the highest number
+    // if there are 30 resources to a source
+    // the resource indicator should be padded with a 0
+    // 1.1.01
+    // 1.1.02
+    console.log(links);;
+    const blah = components.map(
       ({
         node: {
           unfurl: { title },
@@ -67,7 +78,7 @@ class SourceNavigation extends Component {
     );
     return (
       <nav className={styles.Navigation}>
-        <ul className={styles.List}>{links}</ul>
+        <ul className={styles.List}>{blah}</ul>
       </nav>
     );
   }
@@ -83,6 +94,9 @@ export const query = graphql`
     }
     source {
       type
+    }
+    _metadata {
+      position
     }
   }
 `;

--- a/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
+++ b/app-web/src/components/GithubTemplate/SourceNavigation/SourceNavigation.js
@@ -35,11 +35,9 @@ class SourceNavigation extends Component {
 
   render() {
     const { components } = this.props;
-
     // map over components and generate links
     const links = components
       .sort((a, b) => a.node._metadata.position.localeCompare(b.node._metadata.position))
-      .map(n => n.node)
       .map(({ node: { unfurl: { title }, resource: { path }, source: { type } } }) => (
         <li key={shortid.generate()}>
           <Link

--- a/app-web/src/store/reducers/siphon.js
+++ b/app-web/src/store/reducers/siphon.js
@@ -262,11 +262,9 @@ const setCollections = (state, collections) => {
   // sort collection nodes by position
   let sortedCollections = collections.map(c => {
     c.nodes = c.nodes.sort((a, b) => {
-      // lexographic search
-      const address1 = getTruePositionFromWeightedScale(a._metadata.position);
-      const address2 = getTruePositionFromWeightedScale(b._metadata.position);
-      if (address1 < address2) return -1;
-      if (address1 > address2) return 1;
+      // lexographic sort
+      if (a._metadata.position < b._metadata.position) return -1;
+      if (a._metadata.position > b._metadata.position) return 1;
       return 0;
     });
     return c;


### PR DESCRIPTION
## Summary
Change registry file for design system to declare components in order. This exposed a bug where ordering would break if the # resources > 10. This bug was rectified in the pr as well. 