### PR TITLE
bugs/380-381-componentpreview-bugs

### DIFF
--- a/app-web/__tests__/components/__snapshots__/ComponentPreview.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/ComponentPreview.test.js.snap
@@ -21,7 +21,7 @@ ShallowWrapper {
     },
     "ref": null,
     "rendered": "Loading...",
-    "type": "div",
+    "type": "span",
   },
   Symbol(enzyme.__nodes__): Array [
     Object {
@@ -33,7 +33,7 @@ ShallowWrapper {
       },
       "ref": null,
       "rendered": "Loading...",
-      "type": "div",
+      "type": "span",
     },
   ],
   Symbol(enzyme.__options__): Object {

--- a/app-web/__tests__/components/__snapshots__/ComponentPreview.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/ComponentPreview.test.js.snap
@@ -3,7 +3,9 @@
 exports[`ComponentPreview Component matches snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <ComponentPreview />,
+  Symbol(enzyme.__unrendered__): <ComponentPreview
+    branch="master"
+  />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],

--- a/app-web/src/components/ComponentPreview/ComponentPreview.js
+++ b/app-web/src/components/ComponentPreview/ComponentPreview.js
@@ -28,54 +28,55 @@ export default class ComponentPreview extends React.Component {
     };
   }
 
-  async componentDidMount() {
+    async componentDidMount() {
 
-    //pull in the values to retrieve to preview content from GitHub from props, if provided
-    let { owner, repo, path, branch } = this.props;
+        //pull in the values to retrieve to preview content from GitHub from props, if provided
+        let {owner, repo, path, branch} = this.props;
 
-    //allow for default values - relative to file that has embedded the component -  if values for props not provided
-    owner =  owner || this.props.node.source._properties.owner;
-    repo = repo || this.props.node.source._properties.repo;
-    branch = branch || this.props.node.source._properties.branch || 'master';
+        //allow for default values - relative to file that has embedded the component -  if values for props not provided
+        owner = owner || this.props.node.source._properties.owner;
+        repo = repo || this.props.node.source._properties.repo;
+        branch = branch || this.props.node.source._properties.branch || 'master';
 
-    const githubClient = new Octokit();
+        const githubClient = new Octokit();
 
-    try {
-      const result = await githubClient.repos.getContents({
-        owner: owner,
-        repo: repo,
-        path: path,
-        ref: branch,
-      });
+        try {
+            const result = await githubClient.repos.getContents({
+                owner: owner,
+                repo: repo,
+                path: path,
+                ref: branch,
+            });
 
-      this.setState({
-        isLoaded: true,
-        sampleContent: result.data.content,
-      });
-    } catch (error) {
-      console.error('Error: ' + error);
-      this.setState({
-        isLoaded: true,
-        error,
-      });
+            this.setState({
+                isLoaded: true,
+                sampleContent: result.data.content,
+            });
+        } catch (error) {
+            console.error('Error: ' + error);
+            this.setState({
+                isLoaded: true,
+                error,
+            });
+        }
     }
-  }
 
-  render() {
-    const { error, isLoaded, sampleContent } = this.state;
+    render() {
+        const {error, isLoaded, sampleContent} = this.state;
 
-    if (error) {
-      return <div>Error {error.message}</div>;
-    } else if (!isLoaded) {
-      return <div>Loading...</div>;
-    } else {
-      return (
-        <iframe
-          title="Component Preview"
-          src={'data:text/html;base64,' + sampleContent}
-          frameBorder={'0'}
-        />
-      );
+        if (error) {
+            return <span>Error {error.message}</span>;
+        } else if (!isLoaded) {
+            return <span>Loading...</span>;
+        } else {
+            return (
+                <iframe
+                    title="Component Preview"
+                    src={'data:text/html;base64,' + sampleContent}
+                    frameBorder={'0'}
+                    {...this.props}
+                />
+            );
+        }
     }
-  }
 }

--- a/app-web/src/components/ComponentPreview/ComponentPreview.js
+++ b/app-web/src/components/ComponentPreview/ComponentPreview.js
@@ -36,7 +36,7 @@ export default class ComponentPreview extends React.Component {
     //allow for default values - relative to file that has embedded the component -  if values for props not provided
     owner =  owner || this.props.node.source._properties.owner;
     repo = repo || this.props.node.source._properties.repo;
-    branch = branch || this.props.node.source._properties.branch;
+    branch = branch || this.props.node.source._properties.branch || 'master';
 
     const githubClient = new Octokit();
 

--- a/app-web/src/components/ComponentPreview/ComponentPreview.js
+++ b/app-web/src/components/ComponentPreview/ComponentPreview.js
@@ -16,6 +16,7 @@ limitations under the License.
 Created by Shea Phillips
 */
 import React from 'react';
+import PropTypes from 'prop-types';
 import Octokit from '@octokit/rest';
 
 export default class ComponentPreview extends React.Component {
@@ -80,3 +81,14 @@ export default class ComponentPreview extends React.Component {
         }
     }
 }
+
+ComponentPreview.propTypes = {
+    owner: PropTypes.string,
+    repo: PropTypes.string,
+    path: PropTypes.string
+};
+
+ComponentPreview.defaultProps = {
+    branch: 'master'
+};
+


### PR DESCRIPTION
- Modifications so that `master` is used as a default branch  to pull ifrmae content from when none is provided or can be extracted from the source.
- Add support for seeting arbitrary properties on on ComponentPreview and having tham passed through to the iframe.  `height` and `width` are the most obvious ones to help with bcgov/design-system#104

closes #381
close #380