### PR TITLE
Siphon Supports Collection Overview Content 

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/utils/console.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/console.js
@@ -54,11 +54,16 @@ const siphonMessages = (() => {
     {cyan.bold This may cause odd issues for links to the gatsby page if not rectified.}
     detailed stack below..`;
 
+  const collectionSourceFailed = (errors, name) => chalk`
+    ${warning} Attempted to get content for a collection {green.bold ${name}} but was unable to due bad configuration.
+    - ${errors.join('\n- ')}
+  `;
   return {
     unfurlLacksInfo,
     resourceIgnored,
     collectionSlugConflict,
     markdownSlugConflict,
+    collectionSourceFailed,
   };
 })();
 

--- a/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/constants/registry.js
@@ -53,6 +53,27 @@ const REGISTRY_ITEM_SCHEMA = {
   },
 };
 
+// specific validation for the collection.sourceProperties.collectionSource property
+const COLLECTION_SOURCE = {
+  repo: {
+    type: String,
+    required: true,
+  },
+  owner: {
+    type: String,
+    required: true,
+  },
+  file: {
+    type: String,
+    required: true,
+  },
+  branch: {
+    type: String,
+    required: false,
+  },
+};
+
 module.exports = {
   REGISTRY_ITEM_SCHEMA,
+  COLLECTION_SOURCE,
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -24,9 +24,14 @@ const { GRAPHQL_NODE_TYPE } = require('./constants');
  * @param {Object} collection the collection object
  * @param {String} id the unique id
  */
-const createCollectionNode = (collection, id) => {
+const createCollectionNode = (collection, id, collectionContent = null) => {
   const { name, type, description, metadata } = collection;
-
+  const internalContent = collectionContent
+    ? {
+        content: collectionContent.content,
+        mediaType: collectionContent.metadata.mediaType,
+      }
+    : {};
   return {
     id,
     children: [],
@@ -35,6 +40,7 @@ const createCollectionNode = (collection, id) => {
     type,
     description: description || '',
     internal: {
+      ...internalContent,
       contentDigest: hashString(JSON.stringify(collection)),
       type: GRAPHQL_NODE_TYPE.COLLECTION,
     },

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -142,7 +142,7 @@ const getAbsolutePathFromRelative = (relativePath, absolutePath, queryParams) =>
  * @param {Object} schema the schema object that is being tested against
  * @returns {Object} an object containing error messages and isValid property
  * {
- *   errors: {Array},
+ *   messages: {Array},
  *   isValid: {Boolean}
  * }
  */

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
@@ -130,21 +130,13 @@ const validateSourceGithub = source =>
  * @returns {Array} The array of files
  */
 const fetchSourceGithub = async (
-  {
-    sourceType,
-    resourceType,
-    name,
-    sourceProperties,
-    attributes: { labels, personas },
-    collection,
-    metadata,
-  },
+  { sourceType, resourceType, name, sourceProperties, attributes, collection, metadata },
   token,
 ) => {
   const { repo, owner, branch, url } = sourceProperties;
   const source = { metadata };
-  const assignPosToResourceBySource = assignPositionToResource(source);
-
+  // const assignPosToResourceBySource = assignPositionToResource(source);
+  const { labels, personas } = attributes ? attributes : { labels: null, personas: null };
   let filesToFetch = [];
   // how are we sourcing this?
   if (isConfigForFetchingAFile(sourceProperties)) {
@@ -160,7 +152,7 @@ const fetchSourceGithub = async (
     filesToFetch = await getFilesFromRepo(sourceProperties, token);
   }
 
-  filesToFetch = filesToFetch.map((file, index) => assignPosToResourceBySource(file, index));
+  // filesToFetch = filesToFetch.map((file, index) => assignPosToResourceBySource(file, index));
   // actually fetch file contents and transform
   const filesWithContents = fetchFiles(filesToFetch, token);
   const filesResponse = await Promise.all(filesWithContents);

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -55,7 +55,6 @@ const fetchSourceWeb = async ({
   // fetch information from the url
   const source = { metadata: { ...metadata } };
   const localUnfurl = extractUnfurlFromSourceProperties(sourceProperties);
-  const assignPosToResourceBySource = assignPositionToResource(source);
   try {
     const externalUnfurl = await unfurlWebURI(url);
     const unfurl = withUnfurlWarning(url, mergeUnfurls(localUnfurl, externalUnfurl));
@@ -78,7 +77,7 @@ const fetchSourceWeb = async ({
       path: url,
     };
 
-    return [siphonData].map((s, index) => assignPosToResourceBySource(s, index));
+    return [siphonData];
   } catch (e) {
     console.error(e);
     return [];

--- a/app-web/source-registry/__fixtures__/registry.yml
+++ b/app-web/source-registry/__fixtures__/registry.yml
@@ -1,3 +1,5 @@
+## to do, this is out of date and needs to be reworked to include collections
+## and all the different types of metadata
 sources:
   - name: DevHub
     sourceType: 'github'


### PR DESCRIPTION
## Summary
Added support for siphon to have collections point to a markdown file for overview content. The content is processed in the same way all siphon nodes are. 

This is not the implementation of the over view page. Only the base content!.

Fixes #246 
