### PR TITLE
Imp/docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ Thumbs.db
 ######################
 .gradle/
 pipeline/build/
+
+# docker compose artifacts
+.config/

--- a/README.md
+++ b/README.md
@@ -217,17 +217,14 @@ This repository has been configured to send webhooks to a self-hosted Taiga inst
 * to run prettier: `npm run prettify`
 * to run test suites: `npm test`
 
-## Deployment (Docker for Local Development)
+## Deployment (Docker Compose for Local Development)
 
 * Requires **Docker**
-* move into `app-web` directory
-* build image `docker build -t devhub-client .`
-* run image as container with the following volumes (until a better solution is found) 
-```
-docker run -v `pwd`/src:/usr/src/app/src -v `pwd`/plugins:/usr/src/app/plugins -v `pwd`/__tests__:/usr/src/app/__tests__ -v `pwd`/__fixtures__:/usr/src/app/__fixtures__ -v `pwd`/__mocks__:/usr/src/app/__mocks__ -v `pwd`/source-registry:/usr/src/app/source-registry -p 8000:8000 devhub-client
-```
-* **Note** `npm run develop` calls gatsby develop and sets the host with `-H 0.0.0.0`. This is so docker can correctly
-listen for requests on your local machines localhost.
+* move into the root directory for the project (if your are in app-web `cd ../`)
+* run `docker-compose up`
+> if you make changes that do not reflect into the hot reloading (which shouldn't really happen)
+all you will need to do is rebuild the image by ending the current container session and running
+`docker-compose up --build`
 
 ## Deployment (OpenShift)
 

--- a/app-web/Dockerfile
+++ b/app-web/Dockerfile
@@ -29,4 +29,5 @@ RUN npm ci --silent
 
 USER app
 EXPOSE 8000
+
 CMD [ "npm", "run", "dev" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  web:
+    build: './app-web/'
+    env_file: './app-web/.env.production'
+    volumes:
+      - './app-web/:/home/app'
+      - '/home/app/node_modules'
+    ports:
+      - '8000:8000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# docker compose for local development
+# this allows for hot reloading of the app
 version: '3'
 services:
   web:
@@ -5,6 +7,8 @@ services:
     env_file: './app-web/.env.production'
     volumes:
       - './app-web/:/home/app'
-      - '/home/app/node_modules'
+      # a hack to ignore node_modules so that local version, 
+      # if existing does not mount ontop of the images installed version
+      - '/home/app/node_modules' 
     ports:
       - '8000:8000'


### PR DESCRIPTION
## Summary
Added Docker Compose file for local development. We were having issues with no Hot module reloading when running the dev server. Using docker compose fixed this and provides a much easier developer experience when trying to get set up in minimal time. 

