### PR TITLE
Abstract 'devhubSiphon' query into a reusable component

### DIFF
--- a/app-web/src/hoc/withResourceQuery.js
+++ b/app-web/src/hoc/withResourceQuery.js
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+
+/**
+ * passes all devhubSiphon data to the child component
+ */
+import React from 'react';
+import { StaticQuery, graphql } from 'gatsby';
+
+const withResourceQuery = WrappedComponent => () => props => (
+  <StaticQuery
+    query={graphql`
+      query resourceQuery {
+        allDevhubSiphon {
+          edges {
+            node {
+              id
+              name
+              owner
+              parent {
+                id
+              }
+              _metadata {
+                position
+              }
+              attributes {
+                personas
+              }
+              source {
+                displayName
+                sourcePath
+                type
+                name
+              }
+              resource {
+                path
+                type
+              }
+              unfurl {
+                title
+                description
+                type
+                image
+                author
+              }
+              childMarkdownRemark {
+                frontmatter {
+                  pageOnly
+                }
+              }
+            }
+          }
+        }
+      }
+    `}
+    render={data => <WrappedComponent data={data} {...props} />}
+  />
+);
+
+export default withResourceQuery;

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -31,11 +31,13 @@ import {
 
 import { SEARCH } from '../messages';
 import ResourcePreview from '../components/ResourcePreview/ResourcePreview';
+import withResourceQuery from '../hoc/withResourceQuery';
 
 export class Index extends PureComponent {
   componentDidMount() {
     // flatted nodes from graphql
     if (!this.props.resourcesLoaded) {
+      // note this.props.data is received from the withResourceQuery Component
       const resources = flattenGatsbyGraphQL(this.props.data.allDevhubSiphon.edges);
       this.props.loadResources(resources);
     }
@@ -141,51 +143,6 @@ export class Index extends PureComponent {
   }
 }
 
-export const resourceQuery = graphql`
-  query resourceQuery {
-    allDevhubSiphon {
-      edges {
-        node {
-          id
-          name
-          owner
-          parent {
-            id
-          }
-          _metadata {
-            position
-          }
-          attributes {
-            personas
-          }
-          source {
-            displayName
-            sourcePath
-            type
-            name
-          }
-          resource {
-            path
-            type
-          }
-          unfurl {
-            title
-            description
-            type
-            image
-            author
-          }
-          childMarkdownRemark {
-            frontmatter {
-              pageOnly
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
 const mapStateToProps = createStructuredSelector({
   resourcesLoaded: selectResourcesLoaded,
   query: selectQuery,
@@ -209,4 +166,4 @@ const mapDispatchToProps = dispatch => {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(Index);
+)(withResourceQuery(Index)());


### PR DESCRIPTION
## Summary
The query is going to be used by the upcoming 'resource type' pages. I refactored it into its own component so that we can maintain the query in one place. 
