### PR TITLE
Refactor Search Function and combine partial/full searching to get better search results

### DIFF
--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -4,7 +4,8 @@ import queryString from 'query-string';
 import shortid from 'shortid';
 import { connect } from 'react-redux';
 import { REACT_SCROLL } from '../constants/ui';
-import { flattenGatsbyGraphQL } from '../utils//dataHelpers';
+import { flattenGatsbyGraphQL } from '../utils/dataHelpers';
+import { getSearchResults } from '../utils/helpers';
 import * as actions from '../store/actions';
 
 import styles from './index.module.css';
@@ -15,7 +16,6 @@ import Loading from '../components/UI/Loading/Loading';
 import Layout from '../hoc/Layout';
 import Cards from '../components/Cards/Cards';
 import Masthead from '../components/Home/Masthead';
-import CollectionCard from '../components/Cards/Card/Collection';
 
 // selectors from reselect
 import {
@@ -70,29 +70,7 @@ export class Index extends PureComponent {
    */
   async getSearchResults(query) {
     const lunr = await window.__LUNR__.__loaded;
-    const lunrIndex = lunr.en;
-    let results = [];
-    let searchQuery = `*${query}*`;
-    // attempt to search by parsing query into fields
-    try {
-      results = lunrIndex.index.search(searchQuery);
-    } catch (e) {
-      // if that fails treat query as plain text and attempt search again
-      results = lunrIndex.index.query(function() {
-        this.term(searchQuery);
-      });
-    }
-    // search results is an array of reference keys
-    // we need to map those to the index store to get the actual
-    // node ids
-    const searchResultsMap = results
-      .map(({ ref }) => lunrIndex.store[ref])
-      .reduce((obj, result) => {
-        obj[result.id] = { ...result };
-        return obj;
-      }, {});
-
-    return searchResultsMap;
+    return getSearchResults(query, lunr);
   }
 
   render() {

--- a/app-web/src/templates/resourceType.js
+++ b/app-web/src/templates/resourceType.js
@@ -5,6 +5,7 @@ import queryString from 'query-string';
 import { connect } from 'react-redux';
 import { RESOURCE_TYPES } from '../constants/ui';
 import { flattenGatsbyGraphQL } from '../utils//dataHelpers';
+import { getSearchResults } from '../utils/helpers';
 import * as actions from '../store/actions';
 import { RESOURCE_TYPE_PAGES } from '../messages';
 // components
@@ -77,29 +78,7 @@ export class ResourceType extends PureComponent {
    */
   async getSearchResults(query) {
     const lunr = await window.__LUNR__.__loaded;
-    const lunrIndex = lunr.en;
-    let results = [];
-    let searchQuery = `*${query}*`;
-    // attempt to search by parsing query into fields
-    try {
-      results = lunrIndex.index.search(searchQuery);
-    } catch (e) {
-      // if that fails treat query as plain text and attempt search again
-      results = lunrIndex.index.query(function() {
-        this.term(searchQuery);
-      });
-    }
-    // search results is an array of reference keys
-    // we need to map those to the index store to get the actual
-    // node ids
-    const searchResultsMap = results
-      .map(({ ref }) => lunrIndex.store[ref])
-      .reduce((obj, result) => {
-        obj[result.id] = { ...result };
-        return obj;
-      }, {});
-
-    return searchResultsMap;
+    return getSearchResults(query, lunr);
   }
 
   render() {

--- a/app-web/src/utils/helpers.js
+++ b/app-web/src/utils/helpers.js
@@ -58,3 +58,41 @@ export const mapPagePathToResourceTypeConst = pathname => {
   // conver to upper case so we can access resource type enum properties
   return RESOURCE_TYPES[trimmedPath.toUpperCase()];
 };
+
+/**
+ * gets search results from lunr
+ * @param {String} query the search string
+ */
+export const getSearchResults = async (query, lunr) => {
+  const lunrIndex = lunr.en;
+  let results = [];
+  // search results by a partial query using wild cards
+  let partialResults = [];
+  let searchQueryPartial = `*${query}*`;
+  // attempt to search by parsing query into fields
+  try {
+    partialResults = lunrIndex.index.search(searchQueryPartial);
+    results = lunrIndex.index.search(query);
+  } catch (e) {
+    // if that fails treat query as plain text and attempt search again
+    partialResults = lunrIndex.index.query(function() {
+      this.term(searchQueryPartial);
+    });
+    results = lunrIndex.index.query(function() {
+      this.term(searchQueryPartial);
+    });
+  }
+  // combine all partial search results with full search results
+  results = results.concat(partialResults);
+  // search results is an array of reference keys
+  // we need to map those to the index store to get the actual
+  // node ids
+  const searchResultsMap = results
+    .map(({ ref }) => lunrIndex.store[ref])
+    .reduce((obj, result) => {
+      obj[result.id] = { ...result };
+      return obj;
+    }, {});
+
+  return searchResultsMap;
+};


### PR DESCRIPTION
## Summary
as pointed out by @jleach searching 'mobile' or 'signing' did not retrieve the mobile signing card as you would expect. This was found to be because searches were being conducted by partial tokenization eg __'*sign*'__.

I modified the search query to search in two ways, using partial and full matches and then combined the results to cast a larger net for relevant searches.

