### PR TITLE
Register rocketchat instructions

### DIFF
--- a/app-web/source-registry/registry.yml
+++ b/app-web/source-registry/registry.yml
@@ -212,7 +212,6 @@ sources:
             - resources/community/chat_conventions.md
         - sourceType: 'github'
           sourceProperties:
-            resourceType: 'Documentation'
             url: https://github.com/bcgov/reggie-web/
             owner: bcgov
             repo: reggie-web

--- a/app-web/source-registry/registry.yml
+++ b/app-web/source-registry/registry.yml
@@ -209,6 +209,15 @@ sources:
             repo: devhub-resources
             files:
             - resources/community/events.md
+            - resources/community/chat_conventions.md
+        - sourceType: 'github'
+          sourceProperties:
+            resourceType: 'Documentation'
+            url: https://github.com/bcgov/reggie-web/
+            owner: bcgov
+            repo: reggie-web
+            files:
+            - UserInstructions.md
   - name: 'Authentication and Authorization'
     description: 'Technical resources related to implementing authentication and authorization in government applications.'
     resourceType: Documentation


### PR DESCRIPTION
## Summary
Add rocketchat documentations to DevHub


## Notable Changes <!-- if any -->
- in collection `Community Enablers and Events` as Documentation
- including chat conventions and user instructions
