### PR TITLE
update registry devex logo image to use the non white version

### DIFF
--- a/app-web/source-registry/registry.yml
+++ b/app-web/source-registry/registry.yml
@@ -174,7 +174,7 @@ sources:
             url: https://www.bcdevexchange.org
             title: BC Developers Exchange
             description: Finding better ways for government and developers to work together.
-            image: https://www.bcdevexchange.org/modules/core/client/img/logo/new-logo-white.svg
+            image: https://www.bcdevexchange.org/modules/core/client/img/logo/new-logo.svg
         - sourceType: 'web'
           sourceProperties:
             url: https://devopspathfinder.slack.com/


### PR DESCRIPTION
## Summary
Changed the registry to source a non white version of the devex logo so that it the 'DevExchange' name is visible on the card.