### PR TITLE
Feat/470 GitHub issues

### DIFF
--- a/app-web/__tests__/components/GithubTemplateActions.test.js
+++ b/app-web/__tests__/components/GithubTemplateActions.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Actions, { IDS } from '../../src/components/GithubTemplate/Actions/Actions';
+
+describe('Github Resource Page Actions', () => {
+  const props = {
+    repo: 'foo',
+    owner: 'bar',
+    pageTitle: 'About',
+    originalSource: '/about.md',
+  };
+
+  it('creates a link to the appropriate github repo issue page with params', () => {
+    const wrapper = shallow(<Actions {...props} />);
+    const link = wrapper.find(`#${IDS.issue}`);
+
+    expect(link.prop('to')).toBe(
+      `https://www.github.com/bar/foo/issues/new?title=Devhub%20Issue%3A%20About%20%5Bshort%20description%20here%5D&body=%3E%20path%3A%20(do%20not%20delete)%20%2Fabout.md%0A%20%3E%20(do%20not%20delete)%20devhub%20page%3A%20undefined%0A%0A%23%23%20Devhub%20Content%20Issue%0A%5Bdescription%20of%20your%20issue%20here%5D`,
+    );
+  });
+});

--- a/app-web/__tests__/components/Link.test.js
+++ b/app-web/__tests__/components/Link.test.js
@@ -6,8 +6,7 @@ describe('Gatsby Link Component', () => {
   test("it renders an anchor tag if passed a path that doesn't link to a page component", () => {
     const to = 'https://www.google.com';
     const wrapper = shallow(<Link to={to} />); // eslint-disable-line
-    const expected = <a href={to} />; // eslint-disable-line
-    expect(wrapper.matchesElement(expected)).toBe(true);
+    expect(wrapper.find('Anchor').exists()).toBe(true);
   });
 
   test('it renders a gatsby link if passed a path that links to a page componented', () => {

--- a/app-web/__tests__/components/__snapshots__/Banner.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/Banner.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button Component matches snapshot 1`] = `
-<GatsbyLink
+<StyledLink
   activeClassName=""
   activeStyle={Object {}}
   className="Logo"
@@ -13,5 +13,5 @@ exports[`Button Component matches snapshot 1`] = `
   <PhaseBanner
     phase="Beta"
   />
-</GatsbyLink>
+</StyledLink>
 `;

--- a/app-web/src/components/GithubTemplate/Actions/Actions.js
+++ b/app-web/src/components/GithubTemplate/Actions/Actions.js
@@ -55,8 +55,9 @@ const Actions = ({ repo, owner, pageTitle, originalSource, devhubPath }) => (
       <Link
         id={IDS.issue}
         to={getCannedIssueMessage(repo, owner, pageTitle, originalSource, devhubPath)}
+        aria-label="create an issue for this page on github"
       >
-        <FontAwesomeIcon icon={faGithub} /> Make an Issue
+        <FontAwesomeIcon icon={faGithub} /> Create an Issue
       </Link>
     </LI>
   </Container>

--- a/app-web/src/components/GithubTemplate/Actions/Actions.js
+++ b/app-web/src/components/GithubTemplate/Actions/Actions.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { getGithubIssuesRoute } from '../../../utils/helpers';
-import { Link } from '../../UI/Link';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/fontawesome-free-brands';
+import { getCannedIssueMessage } from '../../../utils/helpers';
+import { Link } from '../../UI/Link';
 
 const Container = styled.ul`
   display: flex;
@@ -26,24 +26,6 @@ const LI = styled.li`
     text-decoration: underline;
   }
 `;
-
-/**
- * gets a github issue route with a precanned message as params
- * @param {String} repo
- * @param {String} owner
- * @param {String} pageTitle the title of the resource page
- * @param {String} originalSource path to the markdown file as found in github
- * @param {String} devhubPath path to the resource page as found in devhub
- * @returns {String} the url to the issues route
- */
-export const getCannedIssueMessage = (repo, owner, pageTitle, originalSource, devhubPath) => {
-  const route = getGithubIssuesRoute(repo, owner);
-  const title = encodeURIComponent(`Devhub Issue: ${pageTitle} [short description here]`);
-  const body = encodeURIComponent(
-    `> path: (do not delete) ${originalSource}\n > (do not delete) devhub page: ${devhubPath}\n\n## Devhub Content Issue\n[description of your issue here]`,
-  );
-  return `${route}/new?title=${title}&body=${body}`;
-};
 
 export const IDS = {
   issue: 'actions-issue',

--- a/app-web/src/components/GithubTemplate/Actions/Actions.js
+++ b/app-web/src/components/GithubTemplate/Actions/Actions.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { getGithubIssuesRoute } from '../../../utils/helpers';
 import { Link } from '../../UI/Link';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGithub } from '@fortawesome/fontawesome-free-brands';
 
 const Container = styled.ul`
   display: flex;
@@ -18,7 +20,7 @@ const LI = styled.li`
   padding: 4px;
   flex: 1 0 45px;
   > a {
-    color: inherit;
+    text-decoration: none;
   }
 `;
 
@@ -51,7 +53,7 @@ const Actions = ({ repo, owner, pageTitle, originalSource, devhubPath }) => (
         id={IDS.issue}
         to={getCannedIssueMessage(repo, owner, pageTitle, originalSource, devhubPath)}
       >
-        Make an Issue
+        <FontAwesomeIcon icon={faGithub} /> Make an Issue
       </Link>
     </LI>
   </Container>

--- a/app-web/src/components/GithubTemplate/Actions/Actions.js
+++ b/app-web/src/components/GithubTemplate/Actions/Actions.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { getGithubIssuesRoute } from '../../../utils/helpers';
+import { Link } from '../../UI/Link';
+
+const Container = styled.ul`
+  display: flex;
+  flex-flow: row nowrap;
+  margin: 0 0 15px;
+  padding: 0;
+  border: 1px solid #ccc;
+  list-style: none;
+`;
+
+const LI = styled.li`
+  margin: 0;
+  padding: 4px;
+  flex: 1 0 45px;
+  > a {
+    color: inherit;
+  }
+`;
+
+/**
+ * gets a github issue route with a precanned message as params
+ * @param {String} repo
+ * @param {String} owner
+ * @param {String} pageTitle the title of the resource page
+ * @param {String} originalSource path to the markdown file as found in github
+ * @param {String} devhubPath path to the resource page as found in devhub
+ * @returns {String} the url to the issues route
+ */
+export const getCannedIssueMessage = (repo, owner, pageTitle, originalSource, devhubPath) => {
+  const route = getGithubIssuesRoute(repo, owner);
+  const title = encodeURIComponent(`Devhub Issue: ${pageTitle} [short description here]`);
+  const body = encodeURIComponent(
+    `> path: (do not delete) ${originalSource}\n > (do not delete) devhub page: ${devhubPath}\n\n## Devhub Content Issue\n[description of your issue here]`,
+  );
+  return `${route}/new?title=${title}&body=${body}`;
+};
+
+export const IDS = {
+  issue: 'actions-issue',
+};
+
+const Actions = ({ repo, owner, pageTitle, originalSource, devhubPath }) => (
+  <Container>
+    <LI>
+      <Link
+        id={IDS.issue}
+        to={getCannedIssueMessage(repo, owner, pageTitle, originalSource, devhubPath)}
+      >
+        Make an Issue
+      </Link>
+    </LI>
+  </Container>
+);
+
+Actions.propTypes = {
+  repo: PropTypes.string.isRequired,
+  owner: PropTypes.string.isRequired,
+  pageTitle: PropTypes.string.isRequired,
+  originalSource: PropTypes.string.isRequired,
+  devhubPath: PropTypes.string.isRequired,
+};
+
+export default Actions;

--- a/app-web/src/components/GithubTemplate/Actions/Actions.js
+++ b/app-web/src/components/GithubTemplate/Actions/Actions.js
@@ -22,6 +22,9 @@ const LI = styled.li`
   > a {
     text-decoration: none;
   }
+  > a:hover {
+    text-decoration: underline;
+  }
 `;
 
 /**

--- a/app-web/src/components/GithubTemplate/Navigation/NavItem.js
+++ b/app-web/src/components/GithubTemplate/Navigation/NavItem.js
@@ -29,7 +29,7 @@ const LI = styled.li`
 `;
 
 const StyledLink = styled(Link)`
-  color: #1a5a96;
+  text-decoration: none;
 `;
 
 const Icon = styled.small`

--- a/app-web/src/components/UI/Banner/Banner.js
+++ b/app-web/src/components/UI/Banner/Banner.js
@@ -7,14 +7,19 @@ import AppLogo from '../AppLogo/AppLogo';
 import PhaseBanner from '../PhaseBanner/PhaseBanner';
 import Link from '../Link/Link';
 import classes from './Banner.module.css';
+import styled from '@emotion/styled';
 
+const StyledLink = styled(Link)`
+  color: #fff;
+  text-decoration: none;
+`;
 const Banner = () => {
   return (
-    <Link id={BANNER_ID} className={classes.Logo} to={HOME_ROUTE}>
+    <StyledLink id={BANNER_ID} className={classes.Logo} to={HOME_ROUTE}>
       <GovLogo />
       <AppLogo />
       <PhaseBanner />
-    </Link>
+    </StyledLink>
   );
 };
 

--- a/app-web/src/components/UI/Banner/Banner.module.css
+++ b/app-web/src/components/UI/Banner/Banner.module.css
@@ -15,6 +15,11 @@
     color: inherit;
 }
 
-.Logo a:visited {
+.Logo {
+    text-decoration: none;
+    color: #fff;
+}
+
+.Logo:visited {
     color: inherit;
 }

--- a/app-web/src/components/UI/Link/ChevronLink.js
+++ b/app-web/src/components/UI/Link/ChevronLink.js
@@ -18,24 +18,14 @@ Created by Patrick Simonian
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Link from './Link';
 
-const StyledLink = styled(Link)`
-  text-decoration: underline;
-  color: ${props => props.theme.colors.link};
-  font-weight: 400;
-  text-transform: capitalize;
-  padding: 0 4px;
-  margin: 0 2px;
-`;
-
 const ChevronLink = ({ to, children }) => (
-  <StyledLink to={to}>
+  <Link to={to}>
     {children} <FontAwesomeIcon icon={faChevronRight} />
-  </StyledLink>
+  </Link>
 );
 
 ChevronLink.propTypes = {

--- a/app-web/src/components/UI/Link/Link.js
+++ b/app-web/src/components/UI/Link/Link.js
@@ -1,5 +1,17 @@
 import React from 'react';
 import { Link } from 'gatsby';
+import styled from '@emotion/styled';
+
+const StyledLink = styled(Link)`
+  text-decoration: underline;
+  color: ${props => props.theme.colors.link};
+  font-weight: 400;
+  text-transform: capitalize;
+  padding: 0 4px;
+  margin: 0 2px;
+`;
+
+const Anchor = StyledLink.withComponent('a');
 
 const GatsbyLink = ({ children, to, activeClassName, activeStyle, ...rest }) => {
   // Tailor the following test to your environment.
@@ -10,15 +22,15 @@ const GatsbyLink = ({ children, to, activeClassName, activeStyle, ...rest }) => 
   // Use Gatsby Link for internal links, and <a> for rests
   if (internal) {
     return (
-      <Link to={to} activeStyle={activeStyle} activeClassName={activeClassName} {...rest}>
+      <StyledLink to={to} activeStyle={activeStyle} activeClassName={activeClassName} {...rest}>
         {children}
-      </Link>
+      </StyledLink>
     );
   }
   return (
-    <a href={to} {...rest}>
+    <Anchor href={to} {...rest}>
       {children}
-    </a>
+    </Anchor>
   );
 };
 

--- a/app-web/src/html.js
+++ b/app-web/src/html.js
@@ -36,10 +36,6 @@ class HTML extends React.Component {
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
           <link
-            href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap-reboot.min.css"
-            rel="stylesheet"
-          />
-          <link
             rel="stylesheet"
             href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
             integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"

--- a/app-web/src/templates/SourceGithub_default.js
+++ b/app-web/src/templates/SourceGithub_default.js
@@ -116,6 +116,12 @@ class SourceGithubMarkdownDefault extends React.Component {
               <span>{collection.name} Content</span>
             </SideDrawerToggleButton>
             <div className={styles.MarkdownBody}>
+              {/* 
+              if there is a tag in the markdown <component-preview> 
+              the renderAst will drop in the rehype component
+              otherwise if not tag exists it is biz as usual
+            */}
+              {renderAst(devhubSiphon.childMarkdownRemark.htmlAst)}
               <Actions
                 repo={repo}
                 owner={owner}
@@ -123,12 +129,6 @@ class SourceGithubMarkdownDefault extends React.Component {
                 originalSource={originalSource}
                 devhubPath={href}
               />
-              {/* 
-              if there is a tag in the markdown <component-preview> 
-              the renderAst will drop in the rehype component
-              otherwise if not tag exists it is biz as usual
-            */}
-              {renderAst(devhubSiphon.childMarkdownRemark.htmlAst)}
             </div>
           </Main>
         </div>

--- a/app-web/src/templates/SourceGithub_default.js
+++ b/app-web/src/templates/SourceGithub_default.js
@@ -168,7 +168,6 @@ export const devhubSiphonMarkdown = graphql`
       }
       resource {
         originalSource
-        path
       }
       owner
       fileName

--- a/app-web/src/templates/SourceGithub_default.js
+++ b/app-web/src/templates/SourceGithub_default.js
@@ -85,6 +85,7 @@ class SourceGithubMarkdownDefault extends React.Component {
   render() {
     const {
       data: { devhubSiphon, nav, collection },
+      location,
     } = this.props;
     // bind the devhub siphon data to the preview node
     const previewWithNode = withNode(devhubSiphon)(ComponentPreview);
@@ -95,6 +96,11 @@ class SourceGithubMarkdownDefault extends React.Component {
     }).Compiler;
 
     const navigation = <Navigation items={nav.items} />;
+
+    const { repo, owner } = devhubSiphon.source._properties;
+    const { title } = devhubSiphon.childMarkdownRemark.frontmatter;
+    const { originalSource } = devhubSiphon.resource;
+    const { href } = location;
     return (
       <Layout>
         <div>
@@ -110,6 +116,13 @@ class SourceGithubMarkdownDefault extends React.Component {
               <span>{collection.name} Content</span>
             </SideDrawerToggleButton>
             <div className={styles.MarkdownBody}>
+              <Actions
+                repo={repo}
+                owner={owner}
+                pageTitle={title}
+                originalSource={originalSource}
+                devhubPath={href}
+              />
               {/* 
               if there is a tag in the markdown <component-preview> 
               the renderAst will drop in the rehype component
@@ -155,6 +168,7 @@ export const devhubSiphonMarkdown = graphql`
       }
       resource {
         originalSource
+        path
       }
       owner
       fileName

--- a/app-web/src/templates/SourceGithub_default.js
+++ b/app-web/src/templates/SourceGithub_default.js
@@ -33,6 +33,7 @@ import SideDrawer from '../components/SideDrawer/SideDrawer';
 import Layout from '../hoc/Layout';
 import Masthead from '../components/GithubTemplate/Masthead/Masthead';
 import Navigation from '../components/GithubTemplate/Navigation/Navigation';
+import Actions from '../components/GithubTemplate/Actions/Actions';
 import withNode from '../hoc/withNode';
 
 const Main = styled.main`

--- a/app-web/src/templates/SourceGithub_overview.js
+++ b/app-web/src/templates/SourceGithub_overview.js
@@ -34,6 +34,7 @@ import Layout from '../hoc/Layout';
 import Masthead from '../components/GithubTemplate/Masthead/Masthead';
 import Navigation from '../components/GithubTemplate/Navigation/Navigation';
 import withNode from '../hoc/withNode';
+import Actions from '../components/GithubTemplate/Actions/Actions';
 
 const Main = styled.main`
   background-color: #fff;
@@ -84,6 +85,7 @@ class SourceGithubMarkdownOverview extends React.Component {
   render() {
     const {
       data: { devhubSiphon, nav, collection },
+      location,
     } = this.props;
     // bind the devhub siphon data to the preview node
     const previewWithNode = withNode(devhubSiphon)(ComponentPreview);
@@ -94,6 +96,11 @@ class SourceGithubMarkdownOverview extends React.Component {
     }).Compiler;
 
     const navigation = <Navigation items={nav.items} />;
+    const { repo, owner } = devhubSiphon.source._properties;
+    const { title } = devhubSiphon.childMarkdownRemark.frontmatter;
+    const { originalSource } = devhubSiphon.resource;
+    const { href } = location;
+
     return (
       <Layout>
         <div>
@@ -109,6 +116,13 @@ class SourceGithubMarkdownOverview extends React.Component {
               <span>{collection.name} Content</span>
             </SideDrawerToggleButton>
             <div className={styles.MarkdownBody}>
+              <Actions
+                repo={repo}
+                owner={owner}
+                pageTitle={title}
+                originalSource={originalSource}
+                devhubPath={href}
+              />
               {/* 
               if there is a tag in the markdown <component-preview> 
               the renderAst will drop in the rehype component

--- a/app-web/src/templates/SourceGithub_overview.js
+++ b/app-web/src/templates/SourceGithub_overview.js
@@ -116,6 +116,12 @@ class SourceGithubMarkdownOverview extends React.Component {
               <span>{collection.name} Content</span>
             </SideDrawerToggleButton>
             <div className={styles.MarkdownBody}>
+              {/* 
+              if there is a tag in the markdown <component-preview> 
+              the renderAst will drop in the rehype component
+              otherwise if not tag exists it is biz as usual
+            */}
+              {renderAst(devhubSiphon.childMarkdownRemark.htmlAst)}
               <Actions
                 repo={repo}
                 owner={owner}
@@ -123,12 +129,6 @@ class SourceGithubMarkdownOverview extends React.Component {
                 originalSource={originalSource}
                 devhubPath={href}
               />
-              {/* 
-              if there is a tag in the markdown <component-preview> 
-              the renderAst will drop in the rehype component
-              otherwise if not tag exists it is biz as usual
-            */}
-              {renderAst(devhubSiphon.childMarkdownRemark.htmlAst)}
             </div>
           </Main>
         </div>

--- a/app-web/src/templates/SourceMarkdown.module.css
+++ b/app-web/src/templates/SourceMarkdown.module.css
@@ -4,6 +4,7 @@
 */
 .MarkdownBody {
     min-width: 250px;
+    flex-grow: 1;
 }
 
 /*

--- a/app-web/src/utils/helpers.js
+++ b/app-web/src/utils/helpers.js
@@ -47,6 +47,24 @@ export const getGithubAvatarFromUsername = (username, size) => {
 };
 
 /**
+ * gets a github issue route with a precanned message as params
+ * @param {String} repo
+ * @param {String} owner
+ * @param {String} pageTitle the title of the resource page
+ * @param {String} originalSource path to the markdown file as found in github
+ * @param {String} devhubPath path to the resource page as found in devhub
+ * @returns {String} the url to the issues route
+ */
+export const getCannedIssueMessage = (repo, owner, pageTitle, originalSource, devhubPath) => {
+  const route = getGithubIssuesRoute(repo, owner);
+  const title = encodeURIComponent(`Devhub Issue: ${pageTitle} [short description here]`);
+  const body = encodeURIComponent(
+    `> path: (do not delete) ${originalSource}\n > (do not delete) devhub page: ${devhubPath}\n\n## Devhub Content Issue\n[description of your issue here]`,
+  );
+  return `${route}/new?title=${title}&body=${body}`;
+};
+
+/**
  * gets the constant resource type related to a page path
  * @param {String} pathname
  * @returns {String} the resource type


### PR DESCRIPTION
## Summary
Add a component that has a link to the appropriate github repo issues page with precanned description and title

Fixes #470 

## Other Changes

- restyled the main Link component so that its default 'look' is based on the design system. This reduced duplication within the code. 