### PR TITLE
Search/reset query building

### DIFF
--- a/app-web/__tests__/utils/search.test.js
+++ b/app-web/__tests__/utils/search.test.js
@@ -1,4 +1,4 @@
-import { getSearchResults } from '../../src/utils/search';
+import { getSearchResults, tokenizer, getGroupedQueriesForLunr } from '../../src/utils/search';
 
 describe('Search Helpers', () => {
   test('when __LUNR__ does not exist it returns {}', async () => {
@@ -40,5 +40,61 @@ describe('Search Helpers', () => {
     // mock out lunrs global object
     const results = await getSearchResults('foo');
     expect(results).toEqual(expected);
+  });
+
+  describe('Tokenizer Integration with wink-nlp-utils', () => {
+    // i feel like this is not the best code but it works?
+    test('when a string is passed it, it gets tokenized into a list', () => {
+      const query1 = 'Hello World!';
+      const query2 = ' Hello World!  extra spaces ';
+      const tokenized1 = tokenizer(query1);
+      const tokenized2 = tokenizer(query2);
+
+      expect(tokenized1.terms()).toEqual(['Hello', 'World', '!']);
+      expect(tokenized2.terms()).toEqual(['Hello', 'World', '!', 'extra', 'spaces']);
+    });
+
+    test('when filtering by punctuation it removes it', () => {
+      const query1 = 'Hello World!';
+      const query2 = ' Hello World!  extra spaces ';
+      const tokenized1 = tokenizer(query1);
+      const tokenized2 = tokenizer(query2);
+
+      expect(tokenized1.withoutPunctuation().terms()).toEqual(['Hello', 'World']);
+      expect(tokenized2.withoutPunctuation().terms()).toEqual([
+        'Hello',
+        'World',
+        'extra',
+        'spaces',
+      ]);
+    });
+
+    test('when reseting it returns original tokens', () => {
+      const query1 = 'Hello World!';
+      const tokenized1 = tokenizer(query1);
+      const originalTokens = tokenized1.terms();
+      const filteredTokens = tokenized1.withoutPunctuation().terms();
+      const resetTokens = tokenized1.reset().terms();
+
+      expect(originalTokens).not.toEqual(filteredTokens);
+      expect(resetTokens).toEqual(originalTokens);
+    });
+
+    test('when removing stop words it returns a list without them', () => {
+      const query1 = 'Hello this World!';
+      const tokenized1 = tokenizer(query1);
+      const originalTokens = tokenized1.terms();
+      const withoutStopwords = tokenized1.withoutStopwords();
+
+      expect(originalTokens).not.toEqual(withoutStopwords);
+      expect(withoutStopwords).toEqual(['Hello', 'World', '!']);
+    });
+  });
+
+  describe('getGroupedQueriesForLunr integration with tokenizer', () => {
+    it('groups a search', () => {
+      const results = getGroupedQueriesForLunr('hello this world!');
+      expect(results).toEqual(['hello+ this+ world!+', 'hello', 'world']);
+    });
   });
 });

--- a/app-web/__tests__/utils/search.test.js
+++ b/app-web/__tests__/utils/search.test.js
@@ -54,6 +54,13 @@ describe('Search Helpers', () => {
       expect(tokenized2.terms()).toEqual(['Hello', 'World', '!', 'extra', 'spaces']);
     });
 
+    test('when a string is passed it, it gets tokenized into a list without duplicates', () => {
+      const query1 = 'Hello World! World!';
+      const tokenized1 = tokenizer(query1);
+
+      expect(tokenized1.terms()).toEqual(['Hello', 'World', '!']);
+    });
+
     test('when filtering by punctuation it removes it', () => {
       const query1 = 'Hello World!';
       const query2 = ' Hello World!  extra spaces ';

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -24633,6 +24633,46 @@
         "execa": "^0.10.0"
       }
     },
+    "wink-distance": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wink-distance/-/wink-distance-2.0.0.tgz",
+      "integrity": "sha512-xJn1rbT/I23q0CZjyvQzzax2XAnCWsOcxowKJheiDflYawF7vG1uN1mDeLy0gmgw3IqRwg0HX1I/9NUW+purqg==",
+      "requires": {
+        "wink-helpers": "^2.0.0",
+        "wink-jaro-distance": "^2.0.0"
+      }
+    },
+    "wink-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wink-helpers/-/wink-helpers-2.0.0.tgz",
+      "integrity": "sha512-I/ZzXrHcNRXuoeFJmp2vMVqDI6UCK02Tds1WP4kSGAmx520gjL1BObVzF7d2ps24tyHIly9ngdB2jwhlFUjPvg=="
+    },
+    "wink-jaro-distance": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wink-jaro-distance/-/wink-jaro-distance-2.0.0.tgz",
+      "integrity": "sha512-9bcUaXCi9N8iYpGWbFkf83OsBkg17r4hEyxusEzl+nnReLRPqxhB9YNeRn3g54SYnVRNXP029lY3HDsbdxTAuA=="
+    },
+    "wink-nlp-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/wink-nlp-utils/-/wink-nlp-utils-2.0.3.tgz",
+      "integrity": "sha512-3j0o2+bB5rgyVApEW4kJxTOBbr8sNg6ZCCl1jasdvmVlV0l+HKl/hretrbixUx/+qdiRj/lR0bf9Tljr7UsdfQ==",
+      "requires": {
+        "wink-distance": "^2.0.0",
+        "wink-helpers": "^2.0.0",
+        "wink-porter2-stemmer": "^2.0.0",
+        "wink-tokenizer": "^5.0.0"
+      }
+    },
+    "wink-porter2-stemmer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wink-porter2-stemmer/-/wink-porter2-stemmer-2.0.0.tgz",
+      "integrity": "sha512-FWhpKShRnZvYWOWzbRs5r2IpfXOmYWkk0C5Fjj8nInBAH5mFtIRpla2mViM8iC0K3QreyMIARXSACf5xC8IAKg=="
+    },
+    "wink-tokenizer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/wink-tokenizer/-/wink-tokenizer-5.2.0.tgz",
+      "integrity": "sha512-CSM1RiIZRMmD9r1tB9+8nnW/pGpf0nnHHbkuD+/tPfeaKhBKaGWWzRLScIl/O/8o6ETmAy9gJv9AnoHrDxDN2Q=="
+    },
     "with-open-file": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.5.tgz",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -111,7 +111,8 @@
     "unist-util-visit": "^1.4.0",
     "uri-parser": "^1.0.1",
     "url-parse": "^1.4.4",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "wink-nlp-utils": "^2.0.3"
   },
   "scripts": {
     "dev": "node_modules/.bin/gatsby develop -H 0.0.0.0",

--- a/app-web/src/utils/search.js
+++ b/app-web/src/utils/search.js
@@ -2,6 +2,7 @@
 // we may replpace lunr with elastic lunr in the future
 
 import nlp from 'wink-nlp-utils';
+import uniq from 'lodash/uniq';
 /**
  * tokenizes a searchs string and removes punctuation
  * @param {String} query the search query
@@ -17,7 +18,7 @@ export const tokenizer = function(query) {
      * returns the list of tokens as a array of strings ['foo', 'bar']
      */
     terms: function() {
-      return this.tokens.map(t => t.value);
+      return uniq(this.tokens.map(t => t.value));
     },
     /**
      * sets the list of tokens minus punctuation


### PR DESCRIPTION
## Summary
Add utilities for tokenizing search queries into groupings of logical AND term presence as well as logic OR term presence.

The idea is that a search will be broken up into into two groups the original search with all terms maintaining a term presence predicate IE

Searching for '__API docs for Node js__' will translate to `'API+ docs+ for+ Node+ js+'` 
this means that all terms must be present in the document to succeed

As well as a grouping of tokenized terms

The terms will then also be broken up into a tokenized form with all stop words, punctation filtered

Searching for '__API docs for Node js__' will translate to `['API', 'docs', 'Node', 'js']` 

These two groupings are combined to produce a search pills
[entirequery, token1, token2, token3, ...etc]

## Notable Changes <!-- if any -->
- added integration tests for tokenization of search
-
