### PR TITLE
Add general purpose selectors to be used for static renderings

### DIFF
--- a/app-web/__fixtures__/siphon-fixtures.js
+++ b/app-web/__fixtures__/siphon-fixtures.js
@@ -275,6 +275,11 @@ export const DESIGN_SYSTEM_COLLECTION = {
   title: 'Design System',
   description: 'baz',
   resources: DESIGN_SYSTEM_NODES.map(n => ({ id: n.id })),
+  childrenDevhubSiphon: DESIGN_SYSTEM_NODES.map(n => ({
+    id: n.id,
+    _metadata: { ...n._metadata },
+    resource: { ...n.resource },
+  })),
 };
 
 export const DEVHUB_COLLECTION = {
@@ -283,6 +288,11 @@ export const DEVHUB_COLLECTION = {
   title: 'Devhub',
   description: 'baz',
   resources: DEVHUB_NODES.map(n => ({ id: n.id })),
+  childrenDevhubSiphon: DEVHUB_NODES.map(n => ({
+    id: n.id,
+    _metadata: { ...n._metadata },
+    resource: { ...n.resource },
+  })),
 };
 
 export const SIPHON_NODES = DESIGN_SYSTEM_NODES.concat(DEVHUB_NODES);

--- a/app-web/__tests__/utils/selectors.test.js
+++ b/app-web/__tests__/utils/selectors.test.js
@@ -1,0 +1,43 @@
+import groupBy from 'lodash/groupBy';
+import {
+  selectCollectionsWithResourcesGroupedByType,
+  selectResourcesGroupedByType,
+} from '../../src/utils/selectors';
+import { RESOURCE_TYPES } from '../../src/constants/ui';
+import { SIPHON_NODES, COLLECTIONS } from '../../__fixtures__/siphon-fixtures';
+
+const defaultGroupings = Object.keys(RESOURCE_TYPES).reduce((obj, type) => {
+  obj[RESOURCE_TYPES[type]] = [];
+  return obj;
+}, {});
+
+describe('General Purpose Selectors', () => {
+  it('selects resources grouped by type', () => {
+    const selector = selectResourcesGroupedByType();
+    const groupedResources = groupBy(SIPHON_NODES, 'resource.type');
+
+    expect(selector(SIPHON_NODES)).toEqual({ ...defaultGroupings, ...groupedResources });
+  });
+
+  it('selects collections with resources (grouped by type) appeneded as a property', () => {
+    const selector = selectCollectionsWithResourcesGroupedByType();
+    const collectionWithGroupedResources = selector(COLLECTIONS);
+    const collection1Nodes = groupBy(
+      // mapping to only have id, _metadata, resource as in the future, the graphql query for AllDevhubCollection
+      // will be modified to query for childrenDevhubSiphon { id, _metadata, resouce }
+      SIPHON_NODES.filter(node => node.parent.id === collectionWithGroupedResources[0].id).map(
+        n => ({
+          id: n.id,
+          _metadata: { ...n._metadata },
+          resource: { ...n.resource },
+        }),
+      ),
+      'resource.type',
+    );
+
+    expect(collectionWithGroupedResources[0].resources).toEqual({
+      ...defaultGroupings,
+      ...collection1Nodes,
+    });
+  });
+});

--- a/app-web/src/utils/selectors.js
+++ b/app-web/src/utils/selectors.js
@@ -25,6 +25,10 @@ import groupBy from 'lodash/groupBy';
 export const selectCollections = collections => collections;
 export const selectResources = resources => resources;
 
+const defaultGroups = Object.keys(RESOURCE_TYPES).reduce((grouping, type) => {
+  grouping[RESOURCE_TYPES[type]] = [];
+  return grouping;
+}, {});
 /**
  * giving a list of resources
  * this selector memoizes and returns the resources grouped by resource.type
@@ -35,10 +39,6 @@ export const selectResourcesGroupedByType = () =>
   createSelector(
     selectResources,
     resources => {
-      const defaultGroups = Object.keys(RESOURCE_TYPES).reduce((grouping, type) => {
-        grouping[RESOURCE_TYPES[type]] = [];
-        return grouping;
-      }, {});
       return { ...defaultGroups, ...groupBy(resources, 'resource.type') };
     },
   );

--- a/app-web/src/utils/selectors.js
+++ b/app-web/src/utils/selectors.js
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+// these are general use selectors NOT tied to redux
+// reselect is perfectly capable for general purpose memoization
+import { createSelector } from 'reselect';
+import { RESOURCE_TYPES } from '../constants/ui';
+import groupBy from 'lodash/groupBy';
+
+// the following to fns are essentially stubs, this mocks the behaviour of a created selector
+export const selectCollections = collections => collections;
+export const selectResources = resources => resources;
+
+/**
+ * giving a list of resources
+ * this selector memoizes and returns the resources grouped by resource.type
+ * additionally if a set of resources is missing on of the standard 'resource types'
+ * a default value is provided as [resourceType]: [] (empty array)
+ */
+export const selectResourcesGroupedByType = () =>
+  createSelector(
+    selectResources,
+    resources => {
+      const defaultGroups = Object.keys(RESOURCE_TYPES).reduce((grouping, type) => {
+        grouping[RESOURCE_TYPES[type]] = [];
+        return grouping;
+      }, {});
+      return { ...defaultGroups, ...groupBy(resources, 'resource.type') };
+    },
+  );
+
+/**
+ * groups resources in a collection by type
+ */
+export const selectCollectionsWithResourcesGroupedByType = () =>
+  createSelector(
+    selectCollections,
+    collectionsWithResources =>
+      collectionsWithResources.map(collection => {
+        // combine a set of default groups to the result of the groupby
+        // so that all collections have all resource type groups
+        const selector = selectResourcesGroupedByType();
+        const groups = selector(collection.childrenDevhubSiphon);
+        return {
+          ...collection,
+          resources: groups,
+          hasResources: !Object.keys(groups).every(group => groups[group].length === 0),
+        };
+      }),
+  );


### PR DESCRIPTION
## Summary
add general purpose reselect selectors to memoize and transform properties on base devhub gatsby nodes. This is in effort to statically render the pages #522 
