### PR TITLE
Add logic to re route the eventbrite feature when not available

### DIFF
--- a/app-web/__fixtures__/eventbrite.js
+++ b/app-web/__fixtures__/eventbrite.js
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+
+// event brite sample data
+
+const EVENT_BRITE_EVENT = {
+  internal: {
+    content:
+      '{"name":{"text":"Lunch & Lab - How to Safely Navigate Open Source Licensing in your Projects","html":"Lunch &amp; Lab - How to Safely Navigate Open Source Licensing in your Projects"},"description":{"text":"WHEN? Friday, April 6, 12-1 pm. CSI Lab Commons, 1012 Douglas. 3rd floor. Come hungry. There will be snacks. Everyone welcome.\\nYou have an existing software application and you want to “crowd source” a fix/update. Maybe you have a new application build that will benefit from leveraging existing open source software, or maybe all you have is an idea in need of a solution. Whether the goal is to make existing government-owned software available under an open source license or bring open source code in, this talk will help you understand what you need to know to comply with government policies for success with your project. We will also be sharing some “lessons learned” and field any questions you may have.\\nBio: Lori Kernaghan is an Intellectual Property Manager with the Intellectual Property Program, Ministry of Citizens’ Services. She has 15 years’ experience as an intellectual property professional. Lori joined the BC Government in 2008 and for the past 10 years has been providing ministry and core agency clients across government with a variety of intellectual property management services, including licensing of intellectual property. Lori has worked on a number of key initiatives in the BC Government, including the Open Information and Open Data Policy, the BC Open Source Development Employee Guide (GitHub) and the development of social media guidelines. \\nRecommended (but optional) Pre-Reading: BC Policy Framework For GitHub\\nWhat is the CSI Lab?\\nThe CSI Lab is a creative space where multi-disciplinary teams of public servants can learn new ways of working using technology as an enabler to build a modern public service.","html":"<P><STRONG>WHEN? Friday, April 6, 12-1 pm. CSI Lab Commons, 1012 Douglas. 3rd floor. Come hungry. There will be snacks. Everyone welcome.</STRONG></P>\\n<P>You have an existing software application and you want to “crowd source” a fix/update. Maybe you have a new application build that will benefit from leveraging existing open source software, or maybe all you have is an idea in need of a solution. Whether the goal is to make existing government-owned software available under an open source license or bring open source code in, this talk will help you understand what you need to know to comply with government policies for success with your project. We will also be sharing some “lessons learned” and field any questions you may have.</P>\\n<P><SPAN><STRONG>Bio</STRONG>:</SPAN> Lori Kernaghan is an Intellectual Property Manager with the Intellectual Property Program, Ministry of Citizens’ Services. She has 15 years’ experience as an intellectual property professional. Lori joined the BC Government in 2008 and for the past 10 years has been providing ministry and core agency clients across government with a variety of intellectual property management services, including licensing of intellectual property. Lori has worked on a number of key initiatives in the BC Government, including the Open Information and Open Data Policy, the BC Open Source Development Employee Guide (GitHub) and the development of social media guidelines. </P>\\n<P><SPAN><STRONG>Recommended (but optional) Pre-Reading:</STRONG> </SPAN><A HREF=\\"https://github.com/bcgov/BC-Policy-Framework-For-GitHub\\" TARGET=\\"_blank\\" REL=\\"nofollow noopener noreferrer\\">BC Policy Framework For GitHub</A></P>\\n<P><STRONG>What is the CSI Lab?</STRONG></P>\\n<P>The CSI Lab is a creative space where multi-disciplinary teams of public servants can learn new ways of working using technology as an enabler to build a modern public service.</P>"},"id":"44648171884","url":"https://www.eventbrite.ca/e/lunch-lab-how-to-safely-navigate-open-source-licensing-in-your-projects-tickets-44648171884","start":{"timezone":"America/Vancouver","local":"2018-04-06T12:00:00","utc":"2018-04-06T19:00:00Z"},"end":{"timezone":"America/Vancouver","local":"2018-04-06T13:00:00","utc":"2018-04-06T20:00:00Z"},"organization_id":"228490647317","created":"2018-03-28T18:27:40Z","changed":"2018-04-07T03:48:10Z","published":"2018-03-28T18:29:56Z","capacity":50,"capacity_is_custom":false,"status":"completed","currency":"CAD","listed":false,"shareable":false,"invite_only":false,"online_event":false,"show_remaining":false,"tx_time_limit":480,"hide_start_date":false,"hide_end_date":false,"locale":"en_CA","is_locked":false,"privacy_setting":"unlocked","is_series":false,"is_series_parent":false,"inventory_type":"limited","is_reserved_seating":false,"show_pick_a_seat":false,"show_seatmap_thumbnail":false,"show_colors_in_seatmap_thumbnail":false,"source":"create_2.0","is_free":true,"version":"3.0.0","summary":"WHEN? Friday, April 6, 12-1 pm. CSI Lab Commons, 1012 Douglas. 3rd floor. Come hungry. There will be snacks. Everyone welcome.\\nYou have an e","logo_id":"42845796","organizer_id":"17134258064","venue_id":"23970647","category_id":null,"subcategory_id":null,"format_id":null,"resource_uri":"https://www.eventbriteapi.com/v3/events/44648171884/","is_externally_ticketed":false,"logo":{"crop_mask":{"top_left":{"x":0,"y":0},"width":794,"height":397},"original":{"url":"https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F42845796%2F228490647317%2F1%2Foriginal.jpg?auto=compress&s=a2829f497244deb7ebb5fe91f5c9400d","width":794,"height":1123},"id":"42845796","url":"https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F42845796%2F228490647317%2F1%2Foriginal.jpg?h=200&w=450&auto=compress&rect=0%2C0%2C794%2C397&s=ae5a86a02c4ef24f4be03bdda60d27a1","aspect_ratio":"2","edge_color":null,"edge_color_set":true}}',
+    description: 'DEMO EVENT BRITE',
+    mediaType: 'text/html',
+    type: 'EventbriteEvents',
+  },
+  name: {
+    text: 'DEMO EVENT BRITE DATA - DEVELOPMENT ONLY',
+    html: 'DEMO EVENT BRITE DATA - DEVELOPMENT ONLY',
+  },
+  description: {
+    text: 'DEMO EVENT BRITE DATA - DEVELOPMENT ONLY',
+    html: 'DEMO EVENT BRITE DATA - DEVELOPMENT ONLY',
+  },
+  url:
+    'https://www.eventbrite.ca/e/lunch-lab-how-to-safely-navigate-open-source-licensing-in-your-projects-tickets-44648171884',
+  start: {
+    timezone: 'America/Vancouver',
+    local: '2018-04-06T12:00:00',
+    utc: '2018-04-06T19:00:00Z',
+  },
+  end: {
+    timezone: 'America/Vancouver',
+    local: '2018-04-06T13:00:00',
+    utc: '2018-04-06T20:00:00Z',
+  },
+  organizer_id: '17134258064',
+  organization_id: '228490647317',
+  created: '2018-03-28T18:27:40Z',
+  changed: '2018-04-07T03:48:10Z',
+  published: '2018-03-28T18:29:56Z',
+  privacy_setting: 'unlocked',
+  capacity: 50,
+  category_id: null,
+  currency: 'CAD',
+  capacity_is_custom: false,
+  locale: 'en_CA',
+  shareable: true,
+  logo: {
+    id: 'DEMO',
+    url:
+      'https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F42845796%2F228490647317%2F1%2Foriginal.jpg?h=200&w=450&auto=compress&rect=0%2C0%2C794%2C397&s=ae5a86a02c4ef24f4be03bdda60d27a1',
+    crop_mask: {
+      width: 794,
+      height: 397,
+      top_left: {
+        x: 0,
+        y: 0,
+      },
+    },
+    original: {
+      url:
+        'https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F42845796%2F228490647317%2F1%2Foriginal.jpg?auto=compress&s=a2829f497244deb7ebb5fe91f5c9400d',
+      width: 794,
+      height: 1123,
+      localFile: {
+        id: 'e87c2530-f76c-5e28-bf50-f4e483371cd0',
+      },
+    },
+    aspect_ratio: '2',
+    edge_color: null,
+    edge_color_set: true,
+  },
+  logo_id: 'DEMO@',
+  organization: 'CSI Lab',
+  venue_id: 'DEMO_VENUE',
+  format_id: null,
+  resource_uri: 'https://www.eventbriteapi.com/v3/events/DEMO/',
+  is_externally_ticketed: false,
+  series_id: null,
+  venue: {
+    id: '23970647',
+    address: {
+      address_1: '3rd Floor, 1012 Douglas Street',
+      address_2: null,
+      city: 'Victoria',
+      region: 'BC',
+      postal_code: 'V8W 2C3',
+      country: 'CA',
+      latitude: '48.4242409',
+      longitude: '-123.36581739999997',
+      localized_address_display: '3rd Floor, 1012 Douglas Street, Victoria, BC V8W 2C3',
+      localized_area_display: 'Victoria, BC',
+    },
+    resource_uri: 'https://www.eventbriteapi.com/v3/venues/23970647/',
+    name: '1012 Douglas St',
+    latitude: '48.4242409',
+    longitude: '-123.36581739999997',
+    internal: {
+      type: 'EventbriteVenues',
+      content:
+        '{"address":{"address_1":"3rd Floor, 1012 Douglas Street","address_2":null,"city":"Victoria","region":"BC","postal_code":"V8W 2C3","country":"CA","latitude":"48.4242409","longitude":"-123.36581739999997","localized_address_display":"3rd Floor, 1012 Douglas Street, Victoria, BC V8W 2C3","localized_area_display":"Victoria, BC","localized_multi_line_address_display":["3rd Floor, 1012 Douglas Street","Victoria, BC V8W 2C3"]},"resource_uri":"https://www.eventbriteapi.com/v3/venues/23970647/","id":"23970647","age_restriction":null,"capacity":null,"name":"1012 Douglas St","latitude":"48.4242409","longitude":"-123.36581739999997"}',
+      contentDigest: 'b72d19dba8d990adf5455d65ff6adae8',
+      owner: 'gatsby-source-eventbrite',
+    },
+  },
+};
+
+module.exports = {
+  EVENT_BRITE_EVENT,
+};

--- a/app-web/gatsby-node.js
+++ b/app-web/gatsby-node.js
@@ -47,3 +47,5 @@ exports.createResolvers = ({ createResolvers }) => {
   };
   createResolvers(resolvers);
 };
+
+exports.sourceNodes = require('./gatsby/sourceNodes');

--- a/app-web/gatsby/sourceNodes.js
+++ b/app-web/gatsby/sourceNodes.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+const { EVENT_BRITE_EVENT } = require('../__fixtures__/eventbrite');
+
+module.exports = ({ actions, createNodeId, createContentDigest }) => {
+  const { createNode } = actions;
+
+  if (!process.env.EVENT_BRITE_API_KEY && process.env.NODE_ENV === 'development') {
+    // if there is no event brite api key we stub in the event brite data to prevent page failures
+    // this should be in development mode only
+    const id = createNodeId('EVENT_BRITE_API_KEY');
+
+    createNode({
+      ...EVENT_BRITE_EVENT,
+      id,
+      internal: {
+        ...EVENT_BRITE_EVENT.internal,
+        contentDigest: createContentDigest(EVENT_BRITE_EVENT.internal.content),
+      },
+    });
+  } else {
+    // we  must create a node no matter what so create a placeholder node
+    createNode({
+      id: createNodeId('placeholder'),
+      parent: null,
+      children: [],
+      internal: {
+        type: `MyNodeType`,
+        mediaType: `text/html`,
+        content: 'foo',
+        contentDigest: createContentDigest('foo'),
+      },
+    });
+  }
+};

--- a/app-web/src/templates/TemplatePlaceholder.js
+++ b/app-web/src/templates/TemplatePlaceholder.js
@@ -17,23 +17,74 @@
 //
 
 import React from 'react';
+import styled from '@emotion/styled';
 
 import Layout from '../hoc/Layout';
 
+const Article = styled.article`
+  padding: 40px;
+  max-width: 880px;
+  code {
+    font-size: inherit;
+  }
+  blockquote {
+    padding: 8px;
+    border-radius: 4px;
+    background-color: #f8f8f8;
+    font-size: 15px;
+    text-style: oblique;
+  }
+`;
+
 const TemplatePlaceholder = ({ location: { pathname } }) => (
   <Layout>
-    <h1>This page has been replaced by a temporary placeholder.</h1>
-    <p>
-      For development purposes the page found at {pathname} was not loaded. This message, ofcourse
-      should only be visible in development mode. If you are seeing this message under the URL
-      https://developer.gov.bc.ca then there is a problem that needs attention!
-    </p>
-    <hr />
-    <p>
-      If you are in development mode and are expecting to see a page at {pathname} then this means
-      something in the gatsby config is not set up correctly. Most likely you are missing or have an
-      invalid api key to one of the many gatsby source plugins the Devhub utilizes
-    </p>
+    <Article>
+      <h1>This page has been replaced by a temporary placeholder.</h1>
+      <p>
+        For development purposes the page found at {pathname} was not loaded. This message, ofcourse
+        should only be visible in development mode. If you are seeing this message under the URL
+        <b> https://developer.gov.bc.ca</b> then{' '}
+        <strong>there is a problem that needs attention!</strong>
+      </p>
+      <hr />
+      <p>
+        If you are in development mode and are expecting to see a page at {pathname} then this means
+        something in the gatsby config is not set up correctly. Most likely you are missing or have
+        an invalid api key to one of the many gatsby source plugins the Devhub utilizes
+      </p>
+      <h2>What's going on?</h2>
+      <p>
+        There are a couple of processes that have been kicked off to make this page visible. <br />
+        There are two <code>event</code> templates that exist within the project. One of these is
+        the actual events page and the other one ofcourse, is this page.
+      </p>
+      <p>
+        On build time, we check to see if the appropriate credentials are avaialble for running the
+        events page. When they are not available, the <code>createPages</code> function found at{' '}
+        <code>/gatsby/createPages.js </code>
+        redirects the page create function to point to this placeholder template.
+      </p>
+      <p>
+        In addition, the <code>sourceNodes</code> api is also run on every build and adds a filler{' '}
+        <b>EventbriteEvent</b> graph ql node to prevent failure of the app if the relevant
+        Eventbrite credentials are not available. Although the <i>events</i> template is not used to
+        build a page, it is still evaluated by gatsby as described by
+        <a href="https://github.com/bcgov/devhub-app-web/issues/604"> this Github issue</a>.
+      </p>
+      <h2>Why all this trouble?</h2>
+      <p>
+        The Events feature has some quirks on how data is loaded, these quirks make it difficult to
+        share this feature from workstation to workstation. To circumvent this, a 'placeholder' was
+        introduced to allow the app to run without the feature.
+      </p>
+      <blockquote>
+        If you have any questions please feel free to{' '}
+        <a href="https://github.com/bcgov/devhub-app-web/issues/new/choose">
+          {' '}
+          raise a general issue.
+        </a>
+      </blockquote>
+    </Article>
   </Layout>
 );
 


### PR DESCRIPTION
## Summary
Fixes #604 

When a user tries to stand up the application without the eventbrite api key the app will not run. 

This has been addressed by:
- stubbing a fake eventbriteEvent node to prevent the page query from failing
- replacing the events page with a placeholder explaining whats going on.

