### PR TITLE
Prevent truncation of text on cards that have whitespace to hold the text

### DIFF
--- a/app-web/__tests__/components/__snapshots__/CardCarousel.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/CardCarousel.test.js.snap
@@ -59,7 +59,7 @@ exports[`Card Carousel matches snapshot 1`] = `
 .emotion-10 {
   padding: 6px 10px;
   height: 100%;
-  overflow: hidden;
+  overflow: overlay;
   height: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -68,6 +68,7 @@ exports[`Card Carousel matches snapshot 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  margin-bottom: 10px;
   -webkit-flex-flow: column nowrap;
   -ms-flex-flow: column nowrap;
   flex-flow: column nowrap;

--- a/app-web/__tests__/components/__snapshots__/CardCarousel.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/CardCarousel.test.js.snap
@@ -103,6 +103,7 @@ exports[`Card Carousel matches snapshot 1`] = `
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-bottom: 0;
+  text-transform: none;
 }
 
 <div

--- a/app-web/__tests__/pages/__snapshots__/resourceType.test.js.snap
+++ b/app-web/__tests__/pages/__snapshots__/resourceType.test.js.snap
@@ -276,6 +276,7 @@ exports[`Resource Type Template Page it matches snapshot, when there are no reso
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-bottom: 0;
+  text-transform: none;
 }
 
 .emotion-22 {

--- a/app-web/__tests__/pages/__snapshots__/resourceType.test.js.snap
+++ b/app-web/__tests__/pages/__snapshots__/resourceType.test.js.snap
@@ -232,7 +232,7 @@ exports[`Resource Type Template Page it matches snapshot, when there are no reso
 .emotion-24 {
   padding: 6px 10px;
   height: 100%;
-  overflow: hidden;
+  overflow: overlay;
   height: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -241,6 +241,7 @@ exports[`Resource Type Template Page it matches snapshot, when there are no reso
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  margin-bottom: 10px;
   -webkit-flex-flow: column nowrap;
   -ms-flex-flow: column nowrap;
   flex-flow: column nowrap;

--- a/app-web/plugins/gatsby-source-github-all/utils/plugins.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/plugins.js
@@ -192,7 +192,11 @@ const markDownUnfurlImagePlugin = (extension, file) => {
 
   const unfurl = file.metadata.unfurl;
   // if the image paramater is relative, it will be correctly mapped to an absolute path
-  if (TypeCheck.isString(unfurl.image) && !validUrl.isWebUri(unfurl.image)) {
+  if (
+    TypeCheck.isString(unfurl.image) &&
+    unfurl.image.trim().length > 0 &&
+    !validUrl.isWebUri(unfurl.image)
+  ) {
     if (path.isAbsolute(unfurl.image)) {
       // if the path is absolute we need to map the path based of the sourcePath to the repo
       // this plus the absolute path cannot just be joined as the github api follows a convention

--- a/app-web/src/components/Cards/Card/Card.js
+++ b/app-web/src/components/Cards/Card/Card.js
@@ -35,9 +35,9 @@ import Aux from '../../../hoc/auxillary';
 import { RESOURCE_TYPES_LIST } from '../../../constants/ui';
 
 const Card = ({ type, title, description, image, link, ...rest }) => {
-  // console.log(theme, type);
   let isExternal = !!validUrl.isWebUri(link);
   // if there is an image it takes priority
+
   let cardBody = <CardDescription tagName="p">{description}</CardDescription>;
 
   if (image && description) {

--- a/app-web/src/components/Cards/Card/Card.js
+++ b/app-web/src/components/Cards/Card/Card.js
@@ -38,23 +38,27 @@ const Card = ({ type, title, description, image, link, ...rest }) => {
   let isExternal = !!validUrl.isWebUri(link);
   // if there is an image it takes priority
 
-  let cardBody = <CardDescription tagName="p">{description}</CardDescription>;
+  let cardBody = (
+    <CardDescription title={description} tagName="p">
+      {description}
+    </CardDescription>
+  );
 
   if (image && description) {
     cardBody = (
       <Aux>
-        <CardDescription clamp={2} tagName="p">
+        <CardDescription title={description} clamp={2} tagName="p">
           {description}
         </CardDescription>
         <CardImageWrapper>
-          <CardImage src={image} />
+          <CardImage src={image} alt={title} />
         </CardImageWrapper>
       </Aux>
     );
   } else if (image) {
     cardBody = (
       <CardImageWrapper>
-        <CardImage src={image} />
+        <CardImage src={image} alt={title} />
       </CardImageWrapper>
     );
   }
@@ -65,7 +69,7 @@ const Card = ({ type, title, description, image, link, ...rest }) => {
         <DecorativeBar type={type} />
         <CardBody>
           <CardHeader type={type} linksToExternal={isExternal} />
-          <CardTitle clamp={image && description ? 2 : 3} tagName="h2">
+          <CardTitle clamp={image && description ? 2 : 3} tagName="h2" title={title}>
             {title}
           </CardTitle>
           {cardBody}

--- a/app-web/src/components/Cards/Card/Card.js
+++ b/app-web/src/components/Cards/Card/Card.js
@@ -38,11 +38,7 @@ const Card = ({ type, title, description, image, link, ...rest }) => {
   // console.log(theme, type);
   let isExternal = !!validUrl.isWebUri(link);
   // if there is an image it takes priority
-  let cardBody = (
-    <CardDescription clamp={3} tagName="p">
-      {description}
-    </CardDescription>
-  );
+  let cardBody = <CardDescription tagName="p">{description}</CardDescription>;
 
   if (image && description) {
     cardBody = (

--- a/app-web/src/components/Cards/Card/index.js
+++ b/app-web/src/components/Cards/Card/index.js
@@ -95,10 +95,11 @@ export const CardImageWrapper = styled.div`
 export const CardBody = styled.div`
   padding: 6px 10px;
   height: 100%;
-  overflow: hidden;
+  overflow: overlay;
   height: 100%;
   display: flex;
   flex: 1 1 auto;
+  margin-bottom: 10px;
   flex-flow: column nowrap;
 `;
 

--- a/app-web/src/components/Cards/Card/index.js
+++ b/app-web/src/components/Cards/Card/index.js
@@ -70,6 +70,7 @@ export const CardDescription = styled(DotDotDot)`
   line-height: 1.4;
   flex: 0 0 auto;
   margin-bottom: 0;
+  text-transform: none;
 `;
 
 // combination of card image and wrapper make images response correctly


### PR DESCRIPTION
## Summary
Cards used to be truncated to two lines for some cards. This was found to be a bug within Siphon.

The bug was addressed and when there is only a description and no image for a card, lines are no longer truncated. 