### PR TITLE
Imp/618 integrate ids into siphon

### DIFF
--- a/app-web/plugins/gatsby-source-github-all/__tests__/__snapshots__/sourceNodes.test.js.snap
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/__snapshots__/sourceNodes.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gatsby source github all plugin createSiphonNode returns data 1`] = `
+Object {
+  "_metadata": Object {
+    "position": "1.1.1",
+  },
+  "attributes": Object {
+    "labels": "component",
+    "personas": undefined,
+  },
+  "children": Array [],
+  "collection": Object {
+    "name": "foo",
+    "type": "curated",
+  },
+  "devhubId": "file-stub-id",
+  "fileName": "test.md",
+  "fileType": "Markdown",
+  "id": "123",
+  "internal": Object {
+    "content": "content",
+    "contentDigest": null,
+    "mediaType": "application/test",
+    "type": "DevhubSiphon",
+  },
+  "name": "test",
+  "owner": "Billy Bob",
+  "parent": "foo",
+  "path": "/test.md",
+  "resource": Object {
+    "originalSource": "https://github.com/awesomeOrg/awesomeRepo/blob/master/public/manifest.json",
+    "path": undefined,
+    "type": undefined,
+  },
+  "source": Object {
+    "_properties": Object {
+      "branch": "master",
+      "owner": "bar",
+      "repo": "foo",
+    },
+    "displayName": "something",
+    "name": "something/something",
+    "sourcePath": undefined,
+    "type": undefined,
+  },
+  "unfurl": undefined,
+}
+`;

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -160,6 +160,7 @@ describe('gatsby source github all plugin', () => {
           name: 'foo',
           type: COLLECTION_TYPES.CURATED,
         },
+        id: 'file-stub-id',
         name: 'test',
         source: 'something/something',
         sourceName: 'something',
@@ -197,60 +198,9 @@ describe('gatsby source github all plugin', () => {
       },
     };
 
-    const expected = {
-      id: '123',
-      children: [],
-      fileName: 'test.md',
-      fileType: 'Markdown',
-      name: 'test',
-      owner: 'Billy Bob',
-      parent: 'foo',
-      path: '/test.md',
-      collection: {
-        name: 'foo',
-        type: COLLECTION_TYPES.CURATED,
-      },
-      attributes: {
-        labels: 'component',
-        personas: undefined,
-      },
-      source: {
-        name: 'something/something',
-        displayName: 'something',
-        sourcePath: undefined,
-        type: undefined,
-        _properties: {
-          branch: 'master',
-          repo: 'foo',
-          owner: 'bar',
-        },
-      },
-      unfurl: undefined,
-      resource: {
-        originalSource:
-          'https://github.com/awesomeOrg/awesomeRepo/blob/master/public/manifest.json',
-        type: undefined,
-        path: undefined,
-      },
-      internal: {
-        contentDigest: null, // hashstring called here
-        // Optional media type (https://en.wikipedia.org/wiki/Media_type) to indicate
-        // to transformer plugins this node has data they can further process.
-        mediaType: 'application/test',
-        // A globally unique node type chosen by the plugin owner.
-        type: GRAPHQL_NODE_TYPE.SIPHON,
-        // Optional field exposing the raw content for this node
-        // that transformer plugins can take and further process.
-        content: 'content',
-      },
-      _metadata: {
-        position: '1.1.1',
-      },
-    };
-
     hashString.mockReturnValue(null);
 
-    expect(createSiphonNode(file, '123', 'foo')).toEqual(expected);
+    expect(createSiphonNode(file, '123', 'foo')).toMatchSnapshot();
   });
 
   test('createCollectionNode returns an object', () => {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -41,7 +41,12 @@ const {
 } = require('./utils/constants');
 const { createSiphonNode, createCollectionNode } = require('./utils/createNode');
 const Store = require('./utils/Store');
-const { getRegistry, checkRegistry } = require('./utils/registryHelpers');
+const {
+  getRegistry,
+  checkRegistry,
+  expandRegistry,
+  applyInferredIdToSources,
+} = require('./utils/registryHelpers');
 /**
  * maps root level attributes to a child 'source'
  * this only happens for collections that are set in the registry
@@ -338,8 +343,11 @@ const sourceNodes = async ({ getNodes, actions, createNodeId }, { tokens, source
   try {
     // check registry prior to fetching data
     checkRegistry(registry);
+    // expand and collapsed github source configs (translates files [...] into seperate github sources with file: '...')
+    const expandedReg = expandRegistry(registry);
+    const regWithIds = applyInferredIdToSources(expandedReg);
     // map of over registry and create a queue of collections to fetch
-    const fetchQueue = await getFetchQueue(registry, tokens);
+    const fetchQueue = await getFetchQueue(regWithIds, tokens);
     const collections = await Promise.all(
       fetchQueue.map(async collection =>
         processCollection(collection, createNodeId, createNode, createParentChildLink, tokens),

--- a/app-web/plugins/gatsby-source-github-all/utils/createNode.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/createNode.js
@@ -67,6 +67,7 @@ const createSiphonNode = (data, id, collectionId) => ({
   children: [],
   fileName: data.metadata.fileName,
   fileType: data.metadata.fileType,
+  devhubId: data.metadata.id,
   name: data.metadata.name,
   owner: data.metadata.owner,
   parent: collectionId,

--- a/app-web/plugins/gatsby-source-github-all/utils/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/helpers.js
@@ -156,21 +156,15 @@ const validateAgainstSchema = (obj, schema) => {
   Object.keys(schema).every(key => {
     const schemaItem = schema[key];
     let isValid = true;
-    if (schemaItem.required) {
-      if (isFunction(schemaItem.validate)) {
-        isValid = schemaItem.validate(obj);
-      } else {
-        isValid =
-          Object.prototype.hasOwnProperty.call(obj, key) &&
-          TypeCheck.isA(schemaItem.type, obj[key]);
-      }
+    // is there a validator function
+    if (isFunction(schemaItem.validate)) {
+      isValid = schemaItem.validate(obj);
+    } else if (schemaItem.required) {
+      isValid =
+        Object.prototype.hasOwnProperty.call(obj, key) && TypeCheck.isA(schemaItem.type, obj[key]);
       // does this source property have it anyways?
     } else if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      if (isFunction(schemaItem.validate)) {
-        isValid = schemaItem.validate(obj);
-      } else {
-        isValid = TypeCheck.isA(schemaItem.type, obj[key]);
-      }
+      isValid = TypeCheck.isA(schemaItem.type, obj[key]);
     }
 
     if (!isValid) {

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/helpers.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/helpers.js
@@ -185,6 +185,7 @@ const applyBaseMetadata = (
   globalPersonas,
   collection,
   sourceProperties,
+  id,
 ) => {
   const extension = getExtensionFromName(file.name);
   return {
@@ -208,6 +209,7 @@ const applyBaseMetadata = (
       globalPersonas,
       collection,
       sourceProperties,
+      id,
     },
   };
 };

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/github/index.js
@@ -57,7 +57,7 @@ const validateSourceGithub = source =>
  * @returns {Array} The array of files
  */
 const fetchSourceGithub = async (
-  { sourceType, resourceType, name, sourceProperties, attributes, collection, metadata },
+  { sourceType, resourceType, name, sourceProperties, attributes, collection, id },
   token,
 ) => {
   const { repo, owner, branch, url } = sourceProperties;
@@ -98,6 +98,7 @@ const fetchSourceGithub = async (
         personas,
         collection,
         { branch: 'master', ...sourceProperties }, // by default no branch means master, we are setting it explicitly so it exists in ql schema
+        id,
       ),
     )
     .map(async f => {

--- a/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/sources/web/index.js
@@ -48,7 +48,7 @@ const fetchSourceWeb = async ({
   sourceProperties,
   attributes,
   collection,
-  metadata,
+  id,
 }) => {
   const { url } = sourceProperties;
 
@@ -59,6 +59,7 @@ const fetchSourceWeb = async ({
     const siphonData = {
       metadata: {
         unfurl,
+        id,
         resourceType,
         sourceType,
         name,


### PR DESCRIPTION
## Summary
This is the final pr for getting id's into siphon nodes. ID's are implicitly set by norms based on the source type.

For source type **web** the id is the **url** since this is guaranteed to be unique.

For source type **github** the is a combination of the **repo** and the **path to the file** `'${repo}-${file}'` since this is also guaranteed to be unique as well.

Fixes #618 
