### PR TITLE
Clearing up front page cards, without disturbing search functionality

### DIFF
--- a/app-web/__tests__/pages/Index.test.js
+++ b/app-web/__tests__/pages/Index.test.js
@@ -89,7 +89,7 @@ describe('Home Page', () => {
     expect(Alert).toBeInTheDocument();
   });
 
-  test('when there is an empty search the alert box does not show and all results show instead', () => {
+  test('when there is an empty search the alert box does not show and neither do cards', () => {
     queryString.parse.mockReturnValue({});
     const { container, rerender, queryByTestId, queryAllByTestId } = render(
       <ThemeProvider theme={theme}>
@@ -116,7 +116,8 @@ describe('Home Page', () => {
     expect(Alert).not.toBeInTheDocument();
 
     expect(queryByTestId(COLLECTION_TEST_IDS.container)).toBeInTheDocument();
-    expect(queryAllByTestId(RESOURCE_PREVIEW_TEST_IDS.container).length).toBeGreaterThan(0);
+    expect(queryAllByTestId(RESOURCE_PREVIEW_TEST_IDS.container).length).toBe(0);
+    //The above changed to "toBe(0)" from "toBeGreaterThan(0)" as previews are no longer shown on the home page (unless a valid search has been made)
   });
 
   test('when searching, collections disappear if there are results', () => {
@@ -132,17 +133,16 @@ describe('Home Page', () => {
     expect(queryAllByTestId(RESOURCE_PREVIEW_TEST_IDS.container).length).toBeGreaterThan(0);
   });
 
-  test('when there is no search, collections are visible and cards are visible', () => {
+  test('when there is no search, collections are visible', () => {
     queryString.parse.mockReturnValue({});
     useSearch.mockReturnValue([]);
 
-    const { getByTestId, getAllByTestId } = render(
+    const { getByTestId } = render(
       <ThemeProvider theme={theme}>
         <Index {...props} />
       </ThemeProvider>,
     );
 
     expect(getByTestId(COLLECTION_TEST_IDS.container)).toBeInTheDocument();
-    expect(getAllByTestId(RESOURCE_PREVIEW_TEST_IDS.container).length).toBeGreaterThan(0);
   });
 });

--- a/app-web/__tests__/pages/Index.test.js
+++ b/app-web/__tests__/pages/Index.test.js
@@ -89,7 +89,7 @@ describe('Home Page', () => {
     expect(Alert).toBeInTheDocument();
   });
 
-  test('when there is an empty search the alert box does not show and neither do cards', () => {
+  test('When a blank search is entered, cards and alerts dont show but topics/collections do', () => {
     queryString.parse.mockReturnValue({});
     const { container, rerender, queryByTestId, queryAllByTestId } = render(
       <ThemeProvider theme={theme}>

--- a/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
+++ b/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Home Page it matches snapshot, when there is a search and no results an alert box shows up 1`] = `
+exports[`Home Page When a blank search is entered, cards and alerts dont show but topics/collections do 1`] = `
 .emotion-13 {
   background-color: #fafafa;
   text-align: center;
@@ -178,7 +178,7 @@ exports[`Home Page it matches snapshot, when there is a search and no results an
 </div>
 `;
 
-exports[`Home Page when there is an empty search the alert box does not show and neither do cards 1`] = `
+exports[`Home Page it matches snapshot, when there is a search and no results an alert box shows up 1`] = `
 .emotion-13 {
   background-color: #fafafa;
   text-align: center;

--- a/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
+++ b/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
@@ -178,7 +178,7 @@ exports[`Home Page it matches snapshot, when there is a search and no results an
 </div>
 `;
 
-exports[`Home Page when there is an empty search the alert box does not show and all results show instead 1`] = `
+exports[`Home Page when there is an empty search the alert box does not show and neither do cards 1`] = `
 .emotion-13 {
   background-color: #fafafa;
   text-align: center;

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -136,7 +136,16 @@ export const Index = ({
   const siphonResources = getResourcePreviews(flattenGatsbyGraphQL(allDevhubSiphon.edges), results);
 
   const resourcesNotFound = !queryIsEmpty && (!results || (results.length === 0 && windowHasQuery));
-  if (resourcesNotFound) {
+  if (queryIsEmpty) {
+    content = (
+      <Aux>
+        {getCollectionPreviews(
+          flattenGatsbyGraphQL(allDevhubCollection.edges),
+          windowHasQuery && !queryIsEmpty,
+        )}
+      </Aux>
+    );
+  } else if (resourcesNotFound) {
     content = (
       <Alert style={{ margin: '10px auto' }} color="info" data-testid={TEST_IDS.alert}>
         {SEARCH.results.empty.defaultMessage}


### PR DESCRIPTION
## Summary
Changed the logic in the Index.js file (within pages folder) so that the cards are not shown by default on home page, while still maintaining the search functionality. Then updated the test files to match the new behaviour, and updated snapshots according.

close #649 
