### PR TITLE
adding new topic 'Data and APIs'

### DIFF
--- a/app-web/registry/data-and-apis.json
+++ b/app-web/registry/data-and-apis.json
@@ -10,14 +10,7 @@
           "owner": "bcgov",
           "repo": "api-guidelines",
           "files": [
-            "government-of-british-columbia-api-guidelines.md#api-performance-management",
-            "government-of-british-columbia-api-guidelines.md#api-design",
-            "government-of-british-columbia-api-guidelines.md#api-security",
-            "government-of-british-columbia-api-guidelines.md#api-encoding-and-metadata",
-            "government-of-british-columbia-api-guidelines.md#api-documentation",
-            "government-of-british-columbia-api-guidelines.md#api-consumption",
-            "government-of-british-columbia-api-guidelines.md#api-lifecycle-management",
-            "government-of-british-columbia-api-guidelines.md#api-performance-management"
+            "government-of-british-columbia-api-guidelines.md"
           ]
         }
       },

--- a/app-web/registry/data-and-apis.json
+++ b/app-web/registry/data-and-apis.json
@@ -1,0 +1,70 @@
+{
+  "name": "Data and APIs",
+  "description": "Privince provided Data and API Services",
+  "sourceProperties": {
+    "sources": [
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "https://github.com/bcgov/api-guidelines",
+          "owner": "bcgov",
+          "repo": "api-guidelines",
+          "files": [
+            "government-of-british-columbia-api-guidelines.md#api-performance-management",
+            "government-of-british-columbia-api-guidelines.md#api-design",
+            "government-of-british-columbia-api-guidelines.md#api-security",
+            "government-of-british-columbia-api-guidelines.md#api-encoding-and-metadata",
+            "government-of-british-columbia-api-guidelines.md#api-documentation",
+            "government-of-british-columbia-api-guidelines.md#api-consumption",
+            "government-of-british-columbia-api-guidelines.md#api-lifecycle-management",
+            "government-of-british-columbia-api-guidelines.md#api-performance-management"
+          ]
+        }
+      },
+      {
+        "sourceType": "web",
+        "sourceProperties": {
+          "url": "https://catalogue.data.gov.bc.ca/group/bc-government-api-registry",
+          "author": "bcgov",
+          "title": "BC Government API Registry",
+          "description": "The Province of British Columbia API Registry",
+          "image": "https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg"
+        }
+      },      
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "https://github.com/bcgov/api-specs",
+          "author": "bcgov",
+          "repo": "api-specs",
+          "image": "https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg",
+          "files": [
+            "README.md"
+          ]          
+        }
+      },
+      {
+        "sourceType": "web",
+        "sourceProperties": {
+          "url": "https://catalogue.data.gov.bc.ca/",
+          "author": "bcgov",
+          "title": "the B.C. Data Catalogue",
+          "description": "The BC Data catalogue helps users to find, understand and explore data. The catalogue also provides contact information so that data users can contact Data Custodians for additional information if required.",
+          "image": "https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg"
+        }
+      }      
+    ]
+  },
+  "attributes": {
+    "labels": [
+      "Documentation",
+      "Repository"
+    ],
+    "personas": [
+      "Designer",
+      "Developer",
+      "Product Owner"
+    ]
+  },
+  "resourceType": "Documentation"
+}

--- a/app-web/registry/data-and-apis.json
+++ b/app-web/registry/data-and-apis.json
@@ -25,7 +25,7 @@
         "sourceType": "web",
         "sourceProperties": {
           "url": "https://catalogue.data.gov.bc.ca/group/bc-government-api-registry",
-          "author": "bcgov",
+          "owner": "bcgov",
           "title": "BC Government API Registry",
           "description": "The Province of British Columbia API Registry",
           "image": "https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg"
@@ -35,7 +35,7 @@
         "sourceType": "github",
         "sourceProperties": {
           "url": "https://github.com/bcgov/api-specs",
-          "author": "bcgov",
+          "owner": "bcgov",
           "repo": "api-specs",
           "image": "https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg",
           "files": [
@@ -47,7 +47,7 @@
         "sourceType": "web",
         "sourceProperties": {
           "url": "https://catalogue.data.gov.bc.ca/",
-          "author": "bcgov",
+          "owner": "bcgov",
           "title": "the B.C. Data Catalogue",
           "description": "The BC Data catalogue helps users to find, understand and explore data. The catalogue also provides contact information so that data users can contact Data Custodians for additional information if required.",
           "image": "https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg"

--- a/app-web/registry/featured-cards.json
+++ b/app-web/registry/featured-cards.json
@@ -10,19 +10,7 @@
               "title": "Mobile Signing",
               "url": "https://signing-web-devhub-prod.pathfinder.gov.bc.ca"
             }
-          },
-          {
-            "sourceType": "github",
-            "resourceType": "Documentation",
-            "sourceProperties": {
-              "url": "https://github.com/bcgov/api-guidelines",
-              "owner": "bcgov",
-              "repo": "api-guidelines",
-              "files": [
-                "government-of-british-columbia-api-guidelines.md"
-              ]
-            }
-          },        
+          },       
           {
             "sourceType": "github",
             "resourceType": "Documentation",

--- a/app-web/registry/featured-cards.json
+++ b/app-web/registry/featured-cards.json
@@ -15,6 +15,18 @@
             "sourceType": "github",
             "resourceType": "Documentation",
             "sourceProperties": {
+              "url": "https://github.com/bcgov/api-guidelines",
+              "owner": "bcgov",
+              "repo": "api-guidelines",
+              "files": [
+                "government-of-british-columbia-api-guidelines.md"
+              ]
+            }
+          },        
+          {
+            "sourceType": "github",
+            "resourceType": "Documentation",
+            "sourceProperties": {
               "url": "https://github.com/bcgov/devhub-resources/",
               "owner": "bcgov",
               "repo": "devhub-resources",


### PR DESCRIPTION
## Summary
https://github.com/bcgov/devhub-app-web/issues/700

## Notable Changes <!-- if any -->
- adding new topic 'Data and APIs'
- including github repos for api-guidelines
- including github repos for api-specs
- including link to BC Data Catalogue
- including link to BC Government API Registry
