### PR TITLE
fix up github raw resolver to link multiple topics

### DIFF
--- a/app-web/__tests__/utils/getFilesFromRegistry.test.js
+++ b/app-web/__tests__/utils/getFilesFromRegistry.test.js
@@ -40,6 +40,15 @@ describe('getFilesFromRegistry', () => {
               file: 'README.md',
             },
           },
+          {
+            sourceType: 'github',
+            sourceProperties: {
+              url: 'https://github.com/bcgov/Agile-Delivery-Process',
+              owner: 'bcgov',
+              repo: 'Agile-Delivery-Process',
+              files: ['README.md'],
+            },
+          },
         ],
       },
     },
@@ -51,7 +60,7 @@ describe('getFilesFromRegistry', () => {
     const expected = [
       {
         url: 'https://github.com/bcgov/Agile-Delivery-Process/blob/master/README.md',
-        topics: ['Registry Item 1'],
+        topics: ['Registry Item 1', 'Registry Item 2'],
       },
       {
         url: 'https://github.com/bcgov/Agile-Delivery-Process/blob/master/foo.md',

--- a/app-web/gatsby/utils/githubRaw.js
+++ b/app-web/gatsby/utils/githubRaw.js
@@ -55,6 +55,7 @@ const getFilesFromRegistry = getNodes => {
     return [flatten(urls), topic];
   });
   // map out urls to their respective topics since this is 1 to many relationship
+  // ends up with structure that is similar to this => {url1: [topicA, topicB]}
   resolvedGitSources.forEach(([urls, topic]) => {
     urls.forEach(u => {
       if (Object.prototype.hasOwnProperty.call(sourceToTopicMap, u)) {
@@ -64,8 +65,8 @@ const getFilesFromRegistry = getNodes => {
       }
     });
   });
-  // convert into the files array required by the gatsby github raw plugin
-  // [[url1, url2], topic] => [{url: url1, topic}, {url: url2, topic}]
+  // convert sourceToTopicMap to an array in the expected structure for the github raw plugin
+  // {url1: [topicA, topicB]} => [{url: url1, topics: [topicA, topicB]}]
   return Object.keys(sourceToTopicMap).map(url => ({ url, topics: sourceToTopicMap[url] }));
 };
 


### PR DESCRIPTION
## Summary
The resolver used to only allow one topic from the registry to be bound the github raw node, now it correctly handles multiple topics
