### PR TITLE
Fix Issue where events page breaks if events are private

### DIFF
--- a/app-web/__fixtures__/siphon-fixtures.js
+++ b/app-web/__fixtures__/siphon-fixtures.js
@@ -412,6 +412,12 @@ export const MEETUP_1 = {
       address_1: '3rd Floor 1012 Douglas St.',
       name: '',
     },
+    fields: {
+      location: '3rd Floor 1012 Douglas St.',
+      description: 'test description',
+      name: 'bar',
+      link: 'https://www.meetup.com/DevOps-Commons/events/262271511/',
+    },
     year: '2019',
   },
 };
@@ -445,6 +451,12 @@ export const MEETUP_2 = {
     venue: {
       address_1: '3rd Floor 1012 Douglas St.',
       name: '',
+    },
+    fields: {
+      location: '3rd Floor 1012 Douglas St.',
+      description: 'test description',
+      name: 'foo',
+      link: 'https://www.meetup.com/DevOps-Commons/events/262271511/',
     },
     year: '2019',
   },

--- a/app-web/gatsby-config.js
+++ b/app-web/gatsby-config.js
@@ -44,15 +44,18 @@ module.exports = {
         desc: 'true',
       },
     },
-    {
-      resolve: `gatsby-source-meetup`,
-      options: {
-        key: process.env.MEETUP_API_KEY,
-        groupUrlName: 'bcgov-uxguild',
-        status: 'upcoming,past',
-        desc: 'true',
-      },
-    },
+    // toggling off ux guild events since they are private now
+    // need clarity from Davis Levine if he would like these events to surface
+    // in devhub
+    // {
+    //   resolve: `gatsby-source-meetup`,
+    //   options: {
+    //     key: process.env.MEETUP_API_KEY,
+    //     groupUrlName: 'bcgov-uxguild',
+    //     status: 'upcoming,past',
+    //     desc: 'true',
+    //   },
+    // },
     {
       resolve: `gatsby-source-meetup`,
       options: {
@@ -215,14 +218,14 @@ module.exports = {
       },
     },
     {
-        resolve: 'gatsby-plugin-matomo',
-        options: {
-            siteId: process.env.GATSBY_MATOMO_SITE_ID,
-            matomoUrl: process.env.GATSBY_MATOMO_URL,
-            siteUrl: process.env.GATSBY_MATOMO_SITE_URL,
-            localScript: '/scripts/matomo.js',
-            dev: true
-        }
-    }
+      resolve: 'gatsby-plugin-matomo',
+      options: {
+        siteId: process.env.GATSBY_MATOMO_SITE_ID,
+        matomoUrl: process.env.GATSBY_MATOMO_URL,
+        siteUrl: process.env.GATSBY_MATOMO_SITE_URL,
+        localScript: '/scripts/matomo.js',
+        dev: true,
+      },
+    },
   ].concat(dynamicPlugins.filter(plugin => plugin !== void 0)),
 };

--- a/app-web/gatsby-node.js
+++ b/app-web/gatsby-node.js
@@ -19,5 +19,5 @@ Created by Patrick Simonian
 exports.onCreatePage = require('./gatsby/onCreatePage');
 exports.createPages = require('./gatsby/createPages');
 exports.createResolvers = require('./gatsby/createResolvers');
-
+exports.onCreateNode = require('./gatsby/onCreateNode');
 exports.sourceNodes = require('./gatsby/sourceNodes');

--- a/app-web/gatsby/createResolvers.js
+++ b/app-web/gatsby/createResolvers.js
@@ -67,13 +67,13 @@ module.exports = ({ createResolvers }) => {
         resolve: (source, args, context, info) => {
           return {
             unfurl: {
-              title: source.name,
+              title: source.fields.name,
               image: 'meetup',
-              description: source.description.replace(/<[^>]+>/g, '').replace(/&amp;/g, 'and'),
+              description: source.fields.description,
             },
             resource: {
               type: 'Events',
-              path: source.link,
+              path: source.fields.link,
             },
             id: source.id,
           };

--- a/app-web/gatsby/onCreateNode.js
+++ b/app-web/gatsby/onCreateNode.js
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Created by Patrick Simonian
+*/
+const htmlToFormattedText = require('html-to-formatted-text');
+
+module.exports = ({ node, actions }) => {
+  const { createNodeField } = actions;
+
+  if (node.internal.type === 'MeetupEvent') {
+    // normalize meetup event data
+    createNodeField({ node, name: 'name', value: node.name });
+    createNodeField({
+      node,
+      name: 'description',
+      value: node.description ? htmlToFormattedText(node.description) : '',
+    });
+    createNodeField({
+      node,
+      name: 'link',
+      value: node.link,
+    });
+    createNodeField({
+      node,
+      name: 'location',
+      value: node.venue ? node.venue.address_1 : '',
+    });
+  }
+};

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -11803,6 +11803,14 @@
         "style-to-object": "0.2.2"
       }
     },
+    "html-to-formatted-text": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/html-to-formatted-text/-/html-to-formatted-text-2.7.0.tgz",
+      "integrity": "sha512-dwAWKPVKf9LeNSQ3FBok3Z6PqNtino2o828/O5MMg9NHMBDmUZXAG5omFyptB4ouBasiE0C0B2WUMAs+BVKQAQ==",
+      "requires": {
+        "striptags": "3.1.1"
+      }
+    },
     "html-void-elements": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
@@ -24717,6 +24725,11 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
+    },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
     },
     "style-loader": {
       "version": "0.21.0",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -55,6 +55,7 @@
     "gatsby-transformer-yaml": "^2.1.12",
     "github-markdown-css": "^3.0.1",
     "html-metadata": "^1.7.0",
+    "html-to-formatted-text": "^2.7.0",
     "ignore": "^5.1.1",
     "install": "^0.12.2",
     "js-base64": "^2.4.9",

--- a/app-web/src/components/Event/Logo.js
+++ b/app-web/src/components/Event/Logo.js
@@ -19,7 +19,7 @@ const EventLogo = ({ type }) => (
     render={data => {
       if (type === EVENT_TYPES.eventbrite) {
         return <GatsbyImage fixed={data.eventbrite.childImageSharp.fixed} />;
-      } else if (type === 'meetup') {
+      } else if (type === EVENT_TYPES.meetup) {
         return <GatsbyImage fixed={data.meetup.childImageSharp.fixed} />;
       }
       return null;

--- a/app-web/src/hoc/withResourceQuery.js
+++ b/app-web/src/hoc/withResourceQuery.js
@@ -104,38 +104,12 @@ const withResourceQuery = WrappedComponent => () => props => (
                 year: local_date(formatString: "YYYY")
                 daysFromNow: local_date(difference: "days")
                 status
-                link
-                description
-                venue {
-                  address_1
+                fields {
+                  location
+                  description
+                  link
                 }
               }
-            }
-          }
-        }
-        meetupGroup {
-          childrenMeetupEvent {
-            siphon {
-              unfurl {
-                title
-                description
-                image
-              }
-              resource {
-                type
-                path
-              }
-              id
-            }
-            day: local_date(formatString: "DD")
-            month: local_date(formatString: "MMM")
-            year: local_date(formatString: "YYYY")
-            daysFromNow: local_date(difference: "days")
-            status
-            link
-            description
-            venue {
-              address_1
             }
           }
         }

--- a/app-web/src/pages/collections.js
+++ b/app-web/src/pages/collections.js
@@ -85,14 +85,18 @@ export const CollectionsPage = ({ data }) => {
       return meetups.childrenMeetupEvent;
     })
     .map(meetup => {
-      meetup.start = {
-        day: meetup.day,
-        month: meetup.month,
-        year: meetup.year,
-        daysFromNow: meetup.daysFromNow,
+      return {
+        ...meetup,
+        start: {
+          day: meetup.day,
+          month: meetup.month,
+          year: meetup.year,
+          daysFromNow: meetup.daysFromNow,
+        },
+        venue: {
+          name: meetup.fields.location,
+        },
       };
-      meetup.venue.name = meetup.venue.address_1;
-      return meetup;
     });
   //sort events so they show up soonest to farthest away
   const eventsAndMeetupsSorted = events

--- a/app-web/src/templates/events.js
+++ b/app-web/src/templates/events.js
@@ -58,7 +58,7 @@ const formatMeetUps = meetups => {
       unfurl: meetup.siphon.unfurl,
       resource: meetup.siphon.resource,
       id: meetup.siphon.id,
-      venue: meetup.venue.address_1,
+      venue: meetup.fields.location,
       start: {
         day: meetup.day,
         month: meetup.month,
@@ -201,6 +201,9 @@ export const EventData = graphql`
                 path
               }
               id
+            }
+            fields {
+              location
             }
             day: local_date(formatString: "DD")
             month: local_date(formatString: "MMM")


### PR DESCRIPTION
## Summary
Event pages break if events are private this was because:

- venues do not exist for nodes
- descriptions do not exist for nodes

## Notable Changes <!-- if any -->
- create node fields to normalize these fields
- comment out ux guild gatsby config plugin

Fixes #739 