### PR TITLE
Only build component if there are changes associated with current Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 pipeline {
     agent none
+    environment {
+        COMPONENT_HOME = '/'
+        BUILD_TRIGGER_EXCLUDES = '^.jenkins/||^matomo/'
+    }
     options {
         disableResume()
     }
@@ -10,12 +14,12 @@ pipeline {
                 script { 
                     // only continue build if changes are relevant to the application 
                     // ie changes that are particualr to configuring the jenkins pipeline should not be included
-                    def filesInThisCommitAsString = sh(script:"git diff --name-only HEAD~1..HEAD | grep -v '^.jenkins/' || echo -n ''", returnStatus: false, returnStdout: true).trim()
+                    def filesInThisCommitAsString = sh(script:"git diff --name-only HEAD~1..HEAD | grep -v '$BUILD_TRIGGER_EXCLUDES' || echo -n ''", returnStatus: false, returnStdout: true).trim()
                     def hasChangesInPath = (filesInThisCommitAsString.length() > 0)
                     echo "${filesInThisCommitAsString}"
                     if (!currentBuild.rawBuild.getCauses()[0].toString().contains('UserIdCause') && !hasChangesInPath){
                         currentBuild.rawBuild.delete()
-                        error("No changes detected in the path /[^.jenkins]/")
+                        error("No changes detected in the component path.")
                     }
                 }
                 echo "Aborting all running jobs ..."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     environment {
         COMPONENT_NAME = 'DevHub web app'
         COMPONENT_HOME = '/'
-        BUILD_TRIGGER_EXCLUDES = '^.jenkins/\|^matomo/'
+        BUILD_TRIGGER_EXCLUDES = "^.jenkins/\|^matomo/"
     }
     options {
         disableResume()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     environment {
         COMPONENT_NAME = 'DevHub web app'
         COMPONENT_HOME = '/'
-        BUILD_TRIGGER_EXCLUDES = "^.jenkins/\|^matomo/"
+        BUILD_TRIGGER_EXCLUDES = "^.jenkins/\\|^matomo/"
     }
     options {
         disableResume()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,9 @@
 pipeline {
     agent none
     environment {
+        COMPONENT_NAME = 'DevHub web app'
         COMPONENT_HOME = '/'
-        BUILD_TRIGGER_EXCLUDES = '^.jenkins/||^matomo/'
+        BUILD_TRIGGER_EXCLUDES = '^.jenkins/\|^matomo/'
     }
     options {
         disableResume()
@@ -12,17 +13,16 @@ pipeline {
             agent { label 'build' }
             steps {
                 script { 
-                    // only continue build if changes are relevant to the application 
-                    // ie changes that are particualr to configuring the jenkins pipeline should not be included
+                    // only continue build if changes are relevant to the devhub
                     def filesInThisCommitAsString = sh(script:"git diff --name-only HEAD~1..HEAD | grep -v '$BUILD_TRIGGER_EXCLUDES' || echo -n ''", returnStatus: false, returnStdout: true).trim()
                     def hasChangesInPath = (filesInThisCommitAsString.length() > 0)
                     echo "${filesInThisCommitAsString}"
                     if (!currentBuild.rawBuild.getCauses()[0].toString().contains('UserIdCause') && !hasChangesInPath){
                         currentBuild.rawBuild.delete()
-                        error("No changes detected in the component path.")
+                        error("No changes detected in the component path for $COMPONENT_NAME.")
                     }
                 }
-                echo "Aborting all running jobs ..."
+                echo "Aborting all running jobs for $COMPONENT_NAME..."
                 script {
                     abortAllPreviousBuildInProgress(currentBuild)
                 }

--- a/matomo/Jenkinsfile
+++ b/matomo/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     environment {
-            COMPONENT_NAME = 'Matomo'
+            COMPONENT_NAME = 'Matomo Analytics'
             COMPONENT_HOME = 'matomo'
             BUILD_TRIGGER_INCLUDES = '^matomo/'
         }

--- a/matomo/Jenkinsfile
+++ b/matomo/Jenkinsfile
@@ -1,5 +1,9 @@
 pipeline {
     agent none
+    environment {
+            COMPONENT_HOME = 'matomo'
+            BUILD_TRIGGER_INCLUDES = '^matomo/'
+        }
     options {
         disableResume()
     }
@@ -8,12 +12,12 @@ pipeline {
             agent { label 'build' }
             steps {
                 script {
-                    def filesInThisCommitAsString = sh(script:"git diff --name-only HEAD~1..HEAD | grep -v '^.jenkins/' || echo -n ''", returnStatus: false, returnStdout: true).trim()
+                    def filesInThisCommitAsString = sh(script:"git diff --name-only HEAD~1..HEAD | grep  '$BUILD_TRIGGER_INCLUDES' || echo -n ''", returnStatus: false, returnStdout: true).trim()
                     def hasChangesInPath = (filesInThisCommitAsString.length() > 0)
                     echo "${filesInThisCommitAsString}"
                     if (!currentBuild.rawBuild.getCauses()[0].toString().contains('UserIdCause') && !hasChangesInPath){
                         currentBuild.rawBuild.delete()
-                        error("No changes detected in the path ('^.jenkins/')")
+                        error("No changes detected in the component path.")
                     }
                 }
                 echo "Aborting all running jobs ..."
@@ -21,14 +25,14 @@ pipeline {
                     abortAllPreviousBuildInProgress(currentBuild)
                 }
                 echo "Building ..."
-                sh "cd matomo/.pipeline && ./npmw ci && ./npmw run build -- --pr=${CHANGE_ID}"
+                sh "cd $COMPONENT_HOME/.pipeline && ./npmw ci && ./npmw run build -- --pr=${CHANGE_ID}"
             }
         }
         stage('Deploy (DEV)') {
             agent { label 'deploy' }
             steps {
                 echo "Deploying ..."
-                sh "cd matomo/.pipeline && ./npmw ci && ./npmw run deploy -- --pr=${CHANGE_ID} --env=dev"
+                sh "cd $COMPONENT_HOME/.pipeline && ./npmw ci && ./npmw run deploy -- --pr=${CHANGE_ID} --env=dev"
             }
         }
         stage('Deploy (PROD)') {
@@ -39,7 +43,7 @@ pipeline {
             }
             steps {
                 echo "Deploying ..."
-                sh "cd matomo/.pipeline && ./npmw ci && ./npmw run deploy -- --pr=${CHANGE_ID} --env=prod"
+                sh "cd $COMPONENT_HOME/.pipeline && ./npmw ci && ./npmw run deploy -- --pr=${CHANGE_ID} --env=prod"
             }
         }
     }

--- a/matomo/Jenkinsfile
+++ b/matomo/Jenkinsfile
@@ -1,6 +1,7 @@
 pipeline {
     agent none
     environment {
+            COMPONENT_NAME = 'Matomo'
             COMPONENT_HOME = 'matomo'
             BUILD_TRIGGER_INCLUDES = '^matomo/'
         }
@@ -17,10 +18,10 @@ pipeline {
                     echo "${filesInThisCommitAsString}"
                     if (!currentBuild.rawBuild.getCauses()[0].toString().contains('UserIdCause') && !hasChangesInPath){
                         currentBuild.rawBuild.delete()
-                        error("No changes detected in the component path.")
+                        error("No changes detected in the component path for $COMPONENT_NAME.")
                     }
                 }
-                echo "Aborting all running jobs ..."
+                echo "Aborting all running jobs for $COMPONENT_NAME..."
                 script {
                     abortAllPreviousBuildInProgress(currentBuild)
                 }


### PR DESCRIPTION
Closes #768.

We should not trigger a build for a component in a repo when changes pushed are not associated with it.

This PR contains modifications to the Jenkinsfiles for both devhub-app and Matomo to stop them from building unless changes to "their" files are contained in a triggering commit.