### PR TITLE
Adding s2i scripts to enable incremental builds

### DIFF
--- a/app-web/.s2i/bin/assemble
+++ b/app-web/.s2i/bin/assemble
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Note this script  was borrowed from https://github.com/sclorg/s2i-nodejs-container/blob/master/10/s2i/bin/save-artifacts since the nodej2 builder image we are using at this moment *does not* support incremental builds.
+
+# Prevent running assemble in builders different than official STI image.
+# The official nodejs:8-onbuild already run npm install and use different
+# application folder.
+[ -d "/usr/src/app" ] && exit 0
+
+set -e
+
+# FIXME: Linking of global modules is disabled for now as it causes npm failures
+#        under RHEL7
+# Global modules good to have
+# npmgl=$(grep "^\s*[^#\s]" ../etc/npm_global_module_list | sort -u)
+# Available global modules; only match top-level npm packages
+#global_modules=$(npm ls -g 2> /dev/null | perl -ne 'print "$1\n" if /^\S+\s(\S+)\@[\d\.-]+/' | sort -u)
+# List all modules in common
+#module_list=$(/usr/bin/comm -12 <(echo "${global_modules}") | tr '\n' ' ')
+# Link the modules
+#npm link $module_list
+
+safeLogging () {
+    if [[ $1 =~ http[s]?://.*@.*$ ]]; then
+        echo $1 | sed 's/^.*@/redacted@/'
+    else
+        echo $1
+    fi
+}
+
+shopt -s dotglob
+if [ -d /tmp/artifacts ] && [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
+    echo "---> Restoring previous build artifacts ..."
+    mv -T --verbose /tmp/artifacts/node_modules "${HOME}/node_modules"
+fi
+
+echo "---> Installing application source ..."
+mv /tmp/src/* ./
+
+if [ ! -z $HTTP_PROXY ]; then
+    echo "---> Setting npm http proxy to" $(safeLogging $HTTP_PROXY)
+	npm config set proxy $HTTP_PROXY
+fi
+
+if [ ! -z $http_proxy ]; then
+    echo "---> Setting npm http proxy to" $(safeLogging $http_proxy)
+	npm config set proxy $http_proxy
+fi
+
+if [ ! -z $HTTPS_PROXY ]; then
+    echo "---> Setting npm https proxy to" $(safeLogging $HTTPS_PROXY)
+	npm config set https-proxy $HTTPS_PROXY
+fi
+
+if [ ! -z $https_proxy ]; then
+    echo "---> Setting npm https proxy to" $(safeLogging $https_proxy)
+	npm config set https-proxy $https_proxy
+fi
+
+# Change the npm registry mirror if provided
+if [ -n "$NPM_MIRROR" ]; then
+	npm config set registry $NPM_MIRROR
+fi
+
+# Set the DEV_MODE to false by default.
+if [ -z "$DEV_MODE" ]; then
+  export DEV_MODE=false
+fi
+
+# If NODE_ENV is not set by the user, then NODE_ENV is determined by whether
+# the container is run in development mode.
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi
+
+if [ "$NODE_ENV" != "production" ]; then
+
+	echo "---> Building your Node application from source"
+	npm install
+
+else
+
+	echo "---> Installing all dependencies"
+	NODE_ENV=development npm install
+
+	#do not fail when there is no build script
+	echo "---> Building in production mode"
+	npm run build --if-present
+
+	echo "---> Pruning the development dependencies"
+	npm prune
+
+	# Clear the npm's cache and tmp directories only if they are not a docker volumes
+	NPM_CACHE=$(npm config get cache)
+	if ! mountpoint $NPM_CACHE; then
+		echo "---> Cleaning the npm cache $NPM_CACHE"
+		#As of npm@5 even the 'npm cache clean --force' does not fully remove the cache directory
+		rm $NPM_CACHE* -rf
+	fi
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
+fi
+
+# Fix source directory permissions
+fix-permissions ./

--- a/app-web/.s2i/bin/save-artifacts
+++ b/app-web/.s2i/bin/save-artifacts
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Note this script  was borrowed from https://github.com/sclorg/s2i-nodejs-container/blob/master/10/s2i/bin/save-artifacts since the nodej2 builder image we are using at this moment *does not* support incremental builds.
+
+if [ -d "${HOME}/node_modules" ] && [ "$(ls "${HOME}/node_modules" 2>/dev/null)" ]; then
+    tar -C "${HOME}" -cf - node_modules
+fi

--- a/app-web/shell-scripts/s2i-build-incremental.sh
+++ b/app-web/shell-scripts/s2i-build-incremental.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# utility script to perform an incremental s2i build locally.  this was created to test/validate the behavour of incremental builds, but is useful for verification of any s2i functionality.
+
+read -n1 -r -p "Welcome to the the DevHub s2i builder.  Note: You must have the s2i binary installed and the Red Hat nodejs builder image from registry.redhat.io in your local docker image cache. Continue? [yY/nN]" key
+
+if [ `echo $key | tr [:upper:] [:lower:]` =  'y' ]; then
+    echo -e "\nBuilding..."
+    #assumes presence of builder image
+    s2i build --scripts-url file://$(pwd)/../.s2i/bin --incremental -E $(pwd)/../.env.production --pull-policy never . registry.redhat.io/rhoar-nodejs/nodejs-10 devhub-app
+else
+    echo -e "\nNot building. Thanks for playing."
+fi
+
+
+

--- a/openshift/templates/bc.yaml
+++ b/openshift/templates/bc.yaml
@@ -41,12 +41,12 @@ objects:
     postCommit: {}
     resources:
       requests:
-        cpu: 4
-        memory: 4Gi ## memory usage is high because jest test use a lot of memory when running
+        cpu: 1
+        memory: 2Gi ## memory usage is high because jest test use a lot of memory when running
         ## we are hoping to move jest tests outside of the assemble script but until we do this will be quite a high request
       limits:
-        cpu: 8
-        memory: 8Gi
+        cpu: 1
+        memory: 4Gi
     source:
       git:
         uri: ${SOURCE_REPOSITORY_URL}

--- a/openshift/templates/bc.yaml
+++ b/openshift/templates/bc.yaml
@@ -41,12 +41,12 @@ objects:
     postCommit: {}
     resources:
       requests:
-        cpu: 2
-        memory: 3Gi ## memory usage is high because jest test use a lot of memory when running
+        cpu: 4
+        memory: 4Gi ## memory usage is high because jest test use a lot of memory when running
         ## we are hoping to move jest tests outside of the assemble script but until we do this will be quite a high request
       limits:
-        cpu: 2
-        memory: 4Gi
+        cpu: 8
+        memory: 8Gi
     source:
       git:
         uri: ${SOURCE_REPOSITORY_URL}

--- a/openshift/templates/bc.yaml
+++ b/openshift/templates/bc.yaml
@@ -41,8 +41,8 @@ objects:
     postCommit: {}
     resources:
       requests:
-        cpu: 1
-        memory: 2Gi ## memory usage is high because jest test use a lot of memory when running
+        cpu: 2
+        memory: 3Gi ## memory usage is high because jest test use a lot of memory when running
         ## we are hoping to move jest tests outside of the assemble script but until we do this will be quite a high request
       limits:
         cpu: 2


### PR DESCRIPTION
The builder image that we are currently using in the cluster does not support incremental builds as-is.  This PR adds s2i scripts that will cause it to support incremental builds, with the goal of speeding up build performance in the cluster.

Also, this PR is adding a utility script to perform s2i build locally.