### PR TITLE
Bug/search results fix

### DIFF
--- a/app-web/__fixtures__/nodes.js
+++ b/app-web/__fixtures__/nodes.js
@@ -29,10 +29,7 @@ export const DESIGN_SYSTEM_SIPHON_NODE_1 = {
   fields: {
     personas: ['Designer'],
     resourceType: 'Components',
-<<<<<<< HEAD
     standAlonePath: '/Design-Node-1',
-=======
->>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: ['/design-system/Z1bGIqu1'],
     image: 'https://github.com/bcgov/design-system/blob/master/components/about/about.md?raw=true',
     title: 'About',
@@ -78,10 +75,7 @@ export const DESIGN_SYSTEM_SIPHON_NODE_2 = {
   fields: {
     personas: ['Developer', 'Designer'],
     resourceType: 'Components',
-<<<<<<< HEAD
     standAlonePath: '/Design-Node-2',
-=======
->>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: ['/design-system/Z1bGIqu2'],
     image: 'https://github.com/bcgov/design-system/blob/master/components/about/about.md?raw=true',
     title: 'About',
@@ -127,10 +121,7 @@ export const DESIGN_SYSTEM_SIPHON_NODE_3 = {
   fields: {
     personas: ['Designer'],
     resourceType: 'Components',
-<<<<<<< HEAD
     standAlonePath: '/Design-Node-3',
-=======
->>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: ['/design-system/Z1bGIqu3'],
     image: 'https://github.com/bcgov/design-system/blob/master/components/about/about.md?raw=true',
     title: 'About',
@@ -461,11 +452,8 @@ export const EVENT_1 = {
   },
   fields: {
     resourceType: 'Events',
-<<<<<<< HEAD
     standAlonePath:
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
-=======
->>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: [
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
     ],
@@ -512,11 +500,8 @@ export const EVENT_2 = {
   },
   fields: {
     resourceType: 'Events',
-<<<<<<< HEAD
     standAlonePath:
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
-=======
->>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: [
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
     ],

--- a/app-web/__fixtures__/nodes.js
+++ b/app-web/__fixtures__/nodes.js
@@ -450,6 +450,7 @@ export const EVENT_1 = {
     },
     id: '45046198392',
   },
+  id: '45046198392',
   fields: {
     resourceType: 'Events',
     standAlonePath:
@@ -498,6 +499,7 @@ export const EVENT_2 = {
     },
     id: '61112980570',
   },
+  id: '61112980570',
   fields: {
     resourceType: 'Events',
     standAlonePath:

--- a/app-web/__fixtures__/nodes.js
+++ b/app-web/__fixtures__/nodes.js
@@ -29,7 +29,10 @@ export const DESIGN_SYSTEM_SIPHON_NODE_1 = {
   fields: {
     personas: ['Designer'],
     resourceType: 'Components',
+<<<<<<< HEAD
     standAlonePath: '/Design-Node-1',
+=======
+>>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: ['/design-system/Z1bGIqu1'],
     image: 'https://github.com/bcgov/design-system/blob/master/components/about/about.md?raw=true',
     title: 'About',
@@ -75,7 +78,10 @@ export const DESIGN_SYSTEM_SIPHON_NODE_2 = {
   fields: {
     personas: ['Developer', 'Designer'],
     resourceType: 'Components',
+<<<<<<< HEAD
     standAlonePath: '/Design-Node-2',
+=======
+>>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: ['/design-system/Z1bGIqu2'],
     image: 'https://github.com/bcgov/design-system/blob/master/components/about/about.md?raw=true',
     title: 'About',
@@ -121,7 +127,10 @@ export const DESIGN_SYSTEM_SIPHON_NODE_3 = {
   fields: {
     personas: ['Designer'],
     resourceType: 'Components',
+<<<<<<< HEAD
     standAlonePath: '/Design-Node-3',
+=======
+>>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: ['/design-system/Z1bGIqu3'],
     image: 'https://github.com/bcgov/design-system/blob/master/components/about/about.md?raw=true',
     title: 'About',
@@ -452,8 +461,11 @@ export const EVENT_1 = {
   },
   fields: {
     resourceType: 'Events',
+<<<<<<< HEAD
     standAlonePath:
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
+=======
+>>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: [
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
     ],
@@ -500,8 +512,11 @@ export const EVENT_2 = {
   },
   fields: {
     resourceType: 'Events',
+<<<<<<< HEAD
     standAlonePath:
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
+=======
+>>>>>>> Doing a similar thing as i did to the home page search to the resourcetype page, removing other resource type results from our search results so the behaviour is correct
     pagePaths: [
       'https://www.eventbrite.ca/e/bc-gov-csi-lab-open-house-networking-event-tickets-45046198392',
     ],
@@ -555,6 +570,9 @@ export const MEETUP_1 = {
         title: 'Product Spotlight: ZenHub',
       },
     },
+    fields: {
+      resourceType: 'Events',
+    },
     start: {
       day: '20',
       daysFromNow: '-2',
@@ -597,6 +615,9 @@ export const MEETUP_2 = {
         image: 'meetup',
         title: 'Product Spotlight: ZenHub',
       },
+    },
+    fields: {
+      resourceType: 'Events',
     },
     start: {
       day: '30',

--- a/app-web/src/hoc/withResourceQuery.js
+++ b/app-web/src/hoc/withResourceQuery.js
@@ -112,6 +112,7 @@ const withResourceQuery = WrappedComponent => () => props => (
                 }
                 id
               }
+              id
               start {
                 day: local(formatString: "DD")
                 month: local(formatString: "MMM")
@@ -140,6 +141,7 @@ const withResourceQuery = WrappedComponent => () => props => (
                   }
                   id
                 }
+                id
                 day: local_date(formatString: "DD")
                 month: local_date(formatString: "MMM")
                 year: local_date(formatString: "YYYY")

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -93,12 +93,8 @@ const getSearchResultTotal = resourcesByType => {
  */
 const removeUnwantedResults = (results, allEventsAndMeetups, currentEventsAndMeetups) => {
   let filteredResults = [];
-  let allIDs = allEventsAndMeetups.flatMap(event => {
-    return event.siphon.id;
-  });
-  let currentIDs = currentEventsAndMeetups.flatMap(event => {
-    return event.siphon.id;
-  });
+  let allIDs = allEventsAndMeetups.map(event => event.siphon.id);
+  let currentIDs = currentEventsAndMeetups.map(event => event.siphon.id);
   // if the result ID is an event and a current one or neither, add to new array
   results.map(result => {
     let currID = result.id;

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -87,9 +87,9 @@ const getSearchResultTotal = resourcesByType => {
  * Unwanted results are things like past events which are returned in our index but we do not want to show
  * having these events in our results can mess up some of our logic later down the line (i.e for no results found)
  * returns results, but without any past events etc
- * @param {array} results
- * @param {array} allEventsAndMeetups
- * @param {array} currentEventsAndMeetups
+ * @param {array} results the search results returned from our index
+ * @param {array} allEventsAndMeetups all the events and meetups on the site
+ * @param {array} currentEventsAndMeetups all the current events and meetups on the site
  */
 const removeUnwantedResults = (results, allEventsAndMeetups, currentEventsAndMeetups) => {
   let filteredResults = [];

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -26,7 +26,7 @@ import { SPACING } from '../constants/designTokens';
 import uniqBy from 'lodash/uniqBy';
 import { formatEvents, formatMeetUps } from '../templates/events';
 import { RESOURCE_TYPES } from '../constants/ui';
-import { getTextAndLink } from '../utils/helpers';
+import { getTextAndLink, removeUnwantedResults } from '../utils/helpers';
 
 const Main = styled.main`
   margin-bottom: ${SPACING['1x']};
@@ -81,30 +81,6 @@ const getSearchResultTotal = resourcesByType => {
     return `${total} Results Found`;
   }
   return `No Results Found`;
-};
-
-/**
- * Unwanted results are things like past events which are returned in our index but we do not want to show
- * having these events in our results can mess up some of our logic later down the line (i.e for no results found)
- * returns results, but without any past events etc
- * @param {array} results the search results returned from our index
- * @param {array} allEventsAndMeetups all the events and meetups on the site
- * @param {array} currentEventsAndMeetups all the current events and meetups on the site
- */
-const removeUnwantedResults = (results, allEventsAndMeetups, currentEventsAndMeetups) => {
-  let filteredResults = [];
-  let allIDs = allEventsAndMeetups.map(event => event.siphon.id);
-  let currentIDs = currentEventsAndMeetups.map(event => event.siphon.id);
-  // if the result ID is an event and a current one or neither, add to new array
-  results.map(result => {
-    let currID = result.id;
-    let isInCurrentEvents = currentIDs.includes(currID);
-    let isInAllEvent = allIDs.includes(currID);
-    if ((isInCurrentEvents && isInAllEvent) || (!isInCurrentEvents && !isInAllEvent)) {
-      filteredResults.push(result);
-    }
-  });
-  return filteredResults;
 };
 
 /**

--- a/app-web/src/templates/resourceType.js
+++ b/app-web/src/templates/resourceType.js
@@ -52,6 +52,28 @@ const getSearchTotal = (resources, resourcesNotFound) => {
   return 'No Results';
 };
 
+/**
+ *
+ * @param {array} results
+ * @param {string} resourceTypeConst
+ */
+const removeOtherResourceTypeResults = (results, resourceTypeConst, resources) => {
+  let filteredResources = resources
+    .filter(resource => resource.fields.resourceType === resourceTypeConst)
+    .map(resource => resource.id);
+  let finalResults = [];
+
+  results.forEach(result => {
+    let currID = result.id;
+    let resultInFilteredResources = filteredResources.includes(currID);
+    if (resultInFilteredResources) {
+      finalResults.push(result);
+    }
+  });
+
+  return finalResults;
+};
+
 // generic template page where all 'resource type' pages are generated from
 export const ResourceType = ({
   data: {
@@ -114,7 +136,9 @@ export const ResourceType = ({
     // diff out resources by id
     resources = intersectionBy(resources, results, 'id');
   }
-
+  if (results) {
+    results = removeOtherResourceTypeResults(results, resourceTypeConst, resources);
+  }
   const resourcesNotFound = !queryIsEmpty && (!results || (results.length === 0 && windowHasQuery));
   // map properties like availableResources and isFilterable to filtergroups based on the current set
   // of resources
@@ -139,7 +163,6 @@ export const ResourceType = ({
 
     resources = filterResources(resources, activeFilters);
   }
-
   const searchResultTotal = getSearchTotal(resources, resourcesNotFound);
   return (
     <Layout>

--- a/app-web/src/templates/resourceType.js
+++ b/app-web/src/templates/resourceType.js
@@ -53,16 +53,17 @@ const getSearchTotal = (resources, resourcesNotFound) => {
 };
 
 /**
- *
- * @param {array} results
- * @param {string} resourceTypeConst
+ * Removes results of the wrong resource type from the search results
+ * @param {array} results the search results returned from our index
+ * @param {string} resourceTypeConst the given resource type for this page
+ * @param {array} resources all the resources on the site
  */
 const removeOtherResourceTypeResults = (results, resourceTypeConst, resources) => {
   let filteredResources = resources
     .filter(resource => resource.fields.resourceType === resourceTypeConst)
     .map(resource => resource.id);
   let finalResults = [];
-
+  //if the result is of the correct resourcetype, add to new array
   results.forEach(result => {
     let currID = result.id;
     let resultInFilteredResources = filteredResources.includes(currID);
@@ -70,7 +71,6 @@ const removeOtherResourceTypeResults = (results, resourceTypeConst, resources) =
       finalResults.push(result);
     }
   });
-
   return finalResults;
 };
 

--- a/app-web/src/templates/resourceType.js
+++ b/app-web/src/templates/resourceType.js
@@ -29,6 +29,7 @@ import {
   filterResources,
   setFilterPropsBasedOnResourceCounts,
   isFilterLonely,
+  removeOtherResourceTypeResults,
 } from '../utils/helpers';
 
 // create a selector instance from the selectResourcesGroupedByType
@@ -43,35 +44,13 @@ const resourcesSelector = selectResourcesGroupedByType();
 const getSearchTotal = (resources, resourcesNotFound) => {
   if (!resourcesNotFound) {
     const total = resources.length;
-    if (total == 1) {
+    if (total === 1) {
       return `${total} Result Found`;
     } else if (total > 1) {
       return `${total} Results Found`;
     }
   }
   return 'No Results';
-};
-
-/**
- * Removes results of the wrong resource type from the search results
- * @param {array} results the search results returned from our index
- * @param {string} resourceTypeConst the given resource type for this page
- * @param {array} resources all the resources on the site
- */
-const removeOtherResourceTypeResults = (results, resourceTypeConst, resources) => {
-  let filteredResources = resources
-    .filter(resource => resource.fields.resourceType === resourceTypeConst)
-    .map(resource => resource.id);
-  let finalResults = [];
-  //if the result is of the correct resourcetype, add to new array
-  results.forEach(result => {
-    let currID = result.id;
-    let resultInFilteredResources = filteredResources.includes(currID);
-    if (resultInFilteredResources) {
-      finalResults.push(result);
-    }
-  });
-  return finalResults;
 };
 
 // generic template page where all 'resource type' pages are generated from

--- a/app-web/src/utils/helpers.js
+++ b/app-web/src/utils/helpers.js
@@ -63,6 +63,37 @@ export const getTextAndLink = (resourceType, resourcesByType) => {
 };
 
 /**
+ * Removes results of the wrong resource type from the search results
+ * @param {array} results the search results returned from our index
+ * @param {string} resourceTypeConst the given resource type for this page
+ * @param {array} resources all the resources on the site
+ */
+export const removeOtherResourceTypeResults = (results, resourceTypeConst, resources) => {
+  let filteredResources = resources
+    .filter(resource => resource.fields.resourceType === resourceTypeConst)
+    .map(resource => resource.id);
+  return results.filter(result => filteredResources.includes(result.id));
+};
+
+/**
+ * Unwanted results are things like past events which are returned in our index but we do not want to show
+ * having these events in our results can mess up some of our logic later down the line (i.e for no results found)
+ * returns results, but without any past events etc
+ * @param {array} results the search results returned from our index
+ * @param {array} allEventsAndMeetups all the events and meetups on the site
+ * @param {array} currentEventsAndMeetups all the current events and meetups on the site
+ */
+export const removeUnwantedResults = (results, allEventsAndMeetups, currentEventsAndMeetups) => {
+  let allIDs = allEventsAndMeetups.map(event => event.siphon.id);
+  let currentIDs = currentEventsAndMeetups.map(event => event.siphon.id);
+  return results.filter(
+    result =>
+      (currentIDs.includes(result.id) && allIDs.includes(result.id)) ||
+      (!currentIDs.includes(result.id) && !allIDs.includes(result.id)),
+  );
+};
+
+/**
  * returns a github username image url
  * @param {String} username
  * @param {Number} size

--- a/app-web/src/utils/helpers.js
+++ b/app-web/src/utils/helpers.js
@@ -84,8 +84,8 @@ export const removeOtherResourceTypeResults = (results, resourceTypeConst, resou
  * @param {array} currentEventsAndMeetups all the current events and meetups on the site
  */
 export const removeUnwantedResults = (results, allEventsAndMeetups, currentEventsAndMeetups) => {
-  let allIDs = allEventsAndMeetups.map(event => event.siphon.id);
-  let currentIDs = currentEventsAndMeetups.map(event => event.siphon.id);
+  let allIDs = allEventsAndMeetups.map(event => event.id);
+  let currentIDs = currentEventsAndMeetups.map(event => event.id);
   return results.filter(
     result =>
       (currentIDs.includes(result.id) && allIDs.includes(result.id)) ||


### PR DESCRIPTION
## Summary
- The issue was that the 'No resources found :(" banner was often not being shown when it should be, this was because things like past events (on the home page search) or results of the wrong resource type (resourceType pages) where coming back in the results
- On each the home and resourceType pages, I created a method to filter out unwanted results so that the logic and later code now returns proper behaviour

