### PR TITLE
Rocket Chat search now based on an authenticated user

### DIFF
--- a/app-web/__tests__/pages/Index.test.js
+++ b/app-web/__tests__/pages/Index.test.js
@@ -11,7 +11,7 @@ import {
   SELECT_TOPICS_WITH_RESOURCES_GROUPED_BY_TYPE,
   SELECT_RESOURCES_GROUPED_BY_TYPE,
 } from '../../__fixtures__/selector-fixtures';
-import { useSearch } from '../../src/utils/hooks';
+import { useSearch, useAuthenticated, useRCSearch } from '../../src/utils/hooks';
 import { TEST_IDS as TOPIC_TEST_IDS } from '../../src/components/Home/TopicsContainer';
 import { TEST_IDS as RESOURCE_PREVIEW_TEST_IDS } from '../../src/components/Home/ResourcePreview';
 import {
@@ -33,6 +33,8 @@ jest.mock('../../src/utils/helpers.js');
 
 getFirstNonExternalResource.mockReturnValue('foo');
 getTextAndLink.mockReturnValue({ to: '/documentation?q=mobile', text: 'two results found' });
+useRCSearch.mockReturnValue([]);
+useAuthenticated.mockReturnValue(false);
 
 describe('Home Page', () => {
   // mock out non redux selectors
@@ -53,6 +55,7 @@ describe('Home Page', () => {
   const meetups = MEETUP_NODES.map(c => ({ node: c }));
   const githubRaw = GITHUB_RAW_NODES.map(c => ({ node: c }));
   const props = {
+    client: {},
     data: {
       allDevhubSiphon: {
         edges: nodes,
@@ -167,7 +170,7 @@ describe('Home Page', () => {
   test('when there is no search, topics are visible', () => {
     queryString.parse.mockReturnValue({});
     useSearch.mockReturnValue([]);
-
+    useAuthenticated.mockReturnValue(false);
     const { getByTestId } = render(
       <ThemeProvider theme={theme}>
         <ApolloProvider client={client}>

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, {useContext, useState} from 'react';
 import queryString from 'query-string';
 import intersectionBy from 'lodash/intersectionBy';
 import isNull from 'lodash/isNull';
 import styled from '@emotion/styled';
 
 import { Alert } from 'reactstrap';
-
+import {  withApollo } from 'react-apollo';
 import { MAIN_NAV_ROUTES } from '../constants/routes';
 import { flattenGatsbyGraphQL } from '../utils/dataHelpers';
 import { SEARCH } from '../messages';
@@ -15,7 +15,7 @@ import { ResourcePreview, Masthead, TopicsContainer } from '../components/Home';
 import withResourceQuery from '../hoc/withResourceQuery';
 import Aux from '../hoc/auxillary';
 
-import { useSearch } from '../utils/hooks';
+import { useSearch, useAuthenticated, useRCSearch } from '../utils/hooks';
 import {
   selectTopicsWithResourcesGroupedByType,
   selectResourcesGroupedByType,
@@ -27,6 +27,9 @@ import uniqBy from 'lodash/uniqBy';
 import { formatEvents, formatMeetUps } from '../templates/events';
 import { RESOURCE_TYPES } from '../constants/ui';
 import { getTextAndLink, removeUnwantedResults } from '../utils/helpers';
+import { useQuery, useApolloClient } from '@apollo/react-hooks';
+import { ROCKET_GATE_QUERY } from '../constants/runtimeGraphqlQueries';
+import AuthContext from '../AuthContext';
 
 
 const Main = styled.main`
@@ -127,6 +130,7 @@ export const TEST_IDS = {
 };
 
 export const Index = ({
+  client,
   data: {
     allDevhubTopic,
     allDevhubSiphon,
@@ -147,6 +151,10 @@ export const Index = ({
   } else {
     query = '';
   }
+  const { authenticated } = useAuthenticated();
+  // get rocket chat search results if authenticated
+  // TODO will activate once ui component is available
+  // const rcResults = useRCSearch(authenticated, query, client);
 
   results = useSearch(query, index);
 
@@ -213,4 +221,4 @@ export const Index = ({
   );
 };
 
-export default withResourceQuery(Index)();
+export default withResourceQuery(withApollo(Index))();

--- a/app-web/src/utils/hooks.js
+++ b/app-web/src/utils/hooks.js
@@ -13,14 +13,33 @@ Created by Patrick Simonian
 */
 // custom react hooks
 // notes on custom hooks https://reactjs.org/docs/hooks-custom.html
-import { useState, useEffect } from 'react';
-import { useQuery } from '@apollo/react-hooks';
+import { useState, useEffect, useRef, useContext } from 'react';
+import moment from 'moment';
 import { Index as ElasticLunr } from 'elasticlunr';
 import isEqual from 'lodash/isEqual';
 import { createIam } from '../auth';
 import { isLocalHost } from './helpers';
 import { SEARCH_FIELD_NAMES, SEARCH_FIELD_MAPPING } from '../constants/search';
+import isEmpty from 'lodash/isEmpty';
+import AuthContext from '../AuthContext';
+import { useQuery } from '@apollo/react-hooks';
 import { ROCKET_GATE_QUERY } from '../constants/runtimeGraphqlQueries';
+
+function deepCompareEquals(a, b) {
+  return isEqual(a, b);
+}
+
+export function useDeepCompareMemoize(value) {
+  const ref = useRef() 
+  // it can be done by using useMemo as well
+  // but useRef is rather cleaner and easier
+
+  if (!deepCompareEquals(value, ref.current)) {
+    ref.current = value
+  }
+
+  return ref.current
+}
 /**
  * custom react hook to perform a search
  * @param {String | Array} query the query param from the url q=
@@ -79,16 +98,62 @@ export const useImplicitAuth = () => {
   const [user, setUser] = useState({});
   useEffect(() => {
     const implicitAuthManager = createIam();
-
+    
     implicitAuthManager.registerHooks({
       onAuthenticateSuccess: () => setUser(implicitAuthManager.getAuthDataFromLocal()),
       onAuthenticateFail: () => setUser({}),
       onAuthLocalStorageCleared: () => setUser({}),
     });
-
+    
     if (!isLocalHost()) {
       implicitAuthManager.handleOnPageLoad();
     }
   }, []);
   return user;
 };
+
+
+// returns if user is authenticated and the id token
+export const useAuthenticated = () => {
+  const [authenticated, setAuthenticated] = useState({authenticated: false, idToken: null});
+  const { auth } = useContext(AuthContext);
+  useEffect(() => {
+
+    if(!isEmpty(auth)) {
+      const now = new Date();
+      const { exp } = auth.idToken.data;
+      // jwt times are in seconds, multiply by 1000 to convert into a date object
+      const expDate = new Date(exp * 1000);
+      // parse out auth.id_token and see if its still valid 
+      if(moment(now).isBefore(moment(expDate))) {
+        setAuthenticated({authenticated: true, token: auth.idToken.bearer});
+      }
+    }
+  }, []);
+  return authenticated;
+}
+
+/**
+ * hook that performs a rocket chat search against the rocket gate apollo api
+ * @param {Boolean} authenticated
+ * @param {String} queryString the search string
+ * @param {Client} client the apollo client to query
+ */
+export const useRCSearch = (authenticated, queryString, client) => {
+
+  const {data, loading} = useQuery(ROCKET_GATE_QUERY, {variables: {
+    queryString
+  }, client});
+  const [results, setResults] = useState([]);
+  useEffect(() => {
+    if(!authenticated || !queryString) {
+      setResults([]);
+    } else {
+      setResults(data.search);
+    }
+    return () => {
+      setResults([]);
+    };
+  }, useDeepCompareMemoize([loading, authenticated, queryString, results]));
+  return results;
+}


### PR DESCRIPTION
## Summary
Added a few re-usable react hooks for searching rocket gate

- added a `useAuthenticated` which validates the authorization token
- added a `useRCSearch` hook to perform searches and return data in a memoized fashion