### PR TITLE
Sort search results by relevance, and show result count by resource type with interaction

### DIFF
--- a/app-web/__tests__/components/ResourcePreview.test.js
+++ b/app-web/__tests__/components/ResourcePreview.test.js
@@ -30,6 +30,7 @@ describe('Resource Preview Component', () => {
       text: 'bar',
     },
     resources: SIPHON_NODES,
+    amountToShow: 6,
   };
 
   beforeEach(() => {

--- a/app-web/__tests__/components/__snapshots__/ResourcePreview.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/ResourcePreview.test.js.snap
@@ -4,15 +4,11 @@ exports[`Resource Preview Component it matches snapshot 1`] = `
 <Container
   data-testid="resource-preview-container"
 >
-  <Title>
-    <StyledLink
-      activeClassName=""
-      activeStyle={Object {}}
-      to="/"
-    >
+  <PreviewHeader>
+    <h2>
       foo
-    </StyledLink>
-  </Title>
+    </h2>
+  </PreviewHeader>
   <ResourceContainer>
     <CardWrapper
       key="3"

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -18,13 +18,14 @@ Created by Patrick Simonian
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import css from '@emotion/css';
 
 import { EMOTION_BOOTSTRAP_BREAKPOINTS } from '../../constants/designTokens';
 import { ChevronLink } from '../UI/Link';
 import { Container, LinkContainer } from './index';
 import Card from '../Cards/Card/Card';
 import Pill from '../UI/Pill';
-import css from '@emotion/css';
+import { RESOURCE_TYPES } from '../../constants/ui';
 
 export const CardWrapper = styled.div`
   margin: 6px 9px;
@@ -131,13 +132,24 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
   //These pills are interactive and filter results when clicked
   if (filters) {
     //No people resource type Icon rn
+    pills = pills.concat(
+      //Add first pill to the start of the list
+      <ResourcePill
+        otherIcon={'search'}
+        label={'All Results'}
+        title={'Click to view all results'}
+        key={'All Results'}
+        variant="filled"
+        deletable={false}
+        css={'All' === activeFilter ? toggled : ''}
+        onClick={() => showAllResults()}
+      />,
+    );
     pills = filters.map(filter => {
-      if (filter.name !== 'People') {
+      if (filter.name !== RESOURCE_TYPES.PEOPLE) {
         //formats the text correctly for different cases
         let iconLabel =
-          filter.counter > 1 || filter.counter === 0
-            ? `${filter.counter} Results`
-            : `${filter.counter} Result`;
+          filter.counter !== 1 ? `${filter.counter} Results` : `${filter.counter} Result`;
         //adds informative info for the behavior of the ResourcePills their current state
         let iconInfo =
           filter.name === activeFilter
@@ -159,19 +171,6 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
       }
       return '';
     });
-    //Add final pill to the start of the list
-    pills.unshift(
-      <ResourcePill
-        otherIcon={'search'}
-        label={'All Results'}
-        title={'Click to view all results'}
-        key={'All Results'}
-        variant="filled"
-        deletable={false}
-        css={'All' === activeFilter ? toggled : ''}
-        onClick={() => showAllResults()}
-      />,
-    );
   }
 
   return (

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -89,7 +89,11 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
         return (
           <Pill
             resourceType={filter.name}
-            label={`${filter.counter} Result(s)`} //make a bit of logic for this perhaps
+            label={
+              filter.counter > 1 || filter.counter === 0
+                ? `${filter.counter} Results`
+                : `${filter.counter} Result`
+            } //make a bit of logic for this perhaps
             variant="filled"
             deletable={false}
             key={filter.name}
@@ -121,7 +125,9 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
         ))}
       </ResourceContainer>
       <LinkContainer>
-        {seeMoreResults && <SeeMoreP onClick={() => setCount()}>See More Results</SeeMoreP>}
+        {seeMoreResults && resources.length > 6 && (
+          <SeeMoreP onClick={() => setCount()}>See More Results</SeeMoreP>
+        )}
         {link && <ChevronLink to={link.to}>{link.text}</ChevronLink>}
       </LinkContainer>
     </Container>

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -108,18 +108,12 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
 
   //This filters what results we are showing based on the given filter coming from user interaction with the ResourcePills
   const resourceFilter = filter => {
-    if (filter.name === activeFilter) {
-      //bring back the full set of search result and reset the filter
-      updateResources(resources);
-      updateFilter('');
-    } else {
-      //filter the results based on given filter, update the resources and active filter
-      let filteredResources = resources.filter(
-        resource => resource.fields.resourceType === filter.name,
-      );
-      updateResources(filteredResources);
-      updateFilter(filter.name);
-    }
+    //filter the results based on given filter, update the resources and active filter
+    let filteredResources = resources.filter(
+      resource => resource.fields.resourceType === filter.name,
+    );
+    updateResources(filteredResources);
+    updateFilter(filter.name);
     //reset the amount of resources to show
     updateCount(amountToShow);
   };

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -66,16 +66,6 @@ const SeeMoreP = styled.p`
   }
 `;
 
-const ResourcePill = styled(Pill)`
-  :hover {
-    background: white;
-    border-width: 1px;
-    border-style: solid;
-    border-color: #e0e0e0;
-    top: -3px;
-  }
-`;
-
 const toggled = css`
   background: white;
   border-width: 1px;
@@ -95,6 +85,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
   let [resourcesToShow, updateResources] = useState(resources);
   let [activeFilter, updateFilter] = useState('');
 
+  //sets the amount of resources to show, allowing users to 'see more'
   const setCount = () => {
     updateCount(showCount + 6);
     updateSeeMore(true);
@@ -103,6 +94,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     }
   };
 
+  //This filters what results we are showing based on the given filter coming from user interaction with the resourceIcons
   const resourceFilter = filter => {
     let filteredResources = resources.filter(
       resource => resource.fields.resourceType === filter.name,
@@ -111,13 +103,16 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     updateFilter(filter.name);
     updateCount(amountToShow);
   };
+
   let resourceIcons;
+  //Filters will be mapped into pills displaying result count for that particular resourcetype
+  //These pills are interactive and filter results when clicked
   if (filters) {
     //No people resource type Icon rn
     resourceIcons = filters.map(filter => {
       if (filter.name !== 'People') {
         return (
-          <ResourcePill
+          <Pill
             resourceType={filter.name}
             label={
               filter.counter > 1 || filter.counter === 0

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -127,7 +127,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     updateSeeMore(seeMore);
   };
 
-  let pills;
+  let pills = [];
   //Filters will be mapped into pills displaying result count for that particular resourcetype
   //These pills are interactive and filter results when clicked
   if (filters) {
@@ -145,32 +145,34 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
         onClick={() => showAllResults()}
       />,
     );
-    pills = filters.map(filter => {
-      if (filter.name !== RESOURCE_TYPES.PEOPLE) {
-        //formats the text correctly for different cases
-        let iconLabel =
-          filter.counter !== 1 ? `${filter.counter} Results` : `${filter.counter} Result`;
-        //adds informative info for the behavior of the ResourcePills their current state
-        let iconInfo =
-          filter.name === activeFilter
-            ? 'Click to view all results again'
-            : `Click to view only ${filter.name} results`;
+    pills = pills.concat(
+      filters.map(filter => {
+        if (filter.name !== RESOURCE_TYPES.PEOPLE) {
+          //formats the text correctly for different cases
+          let iconLabel =
+            filter.counter !== 1 ? `${filter.counter} Results` : `${filter.counter} Result`;
+          //adds informative info for the behavior of the ResourcePills their current state
+          let iconInfo =
+            filter.name === activeFilter
+              ? 'Click to view all results again'
+              : `Click to view only ${filter.name} results`;
 
-        return (
-          <ResourcePill
-            resourceType={filter.name}
-            label={iconLabel}
-            variant="filled"
-            deletable={false}
-            key={filter.name}
-            css={filter.name === activeFilter ? toggled : ''}
-            onClick={filter.counter === 0 ? undefined : () => resourceFilter(filter)}
-            title={iconInfo}
-          />
-        );
-      }
-      return '';
-    });
+          return (
+            <ResourcePill
+              resourceType={filter.name}
+              label={iconLabel}
+              variant="filled"
+              deletable={false}
+              key={filter.name}
+              css={filter.name === activeFilter ? toggled : ''}
+              onClick={filter.counter === 0 ? undefined : () => resourceFilter(filter)}
+              title={iconInfo}
+            />
+          );
+        }
+        return '';
+      }),
+    );
   }
 
   return (

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -71,6 +71,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow 
             label={`${filter.counter} Result(s)`}
             variant="filled"
             deletable={false}
+            key={filter}
           />
         );
       }

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -66,6 +66,16 @@ const SeeMoreP = styled.p`
   }
 `;
 
+const ResourcePill = styled(Pill)`
+  :hover {
+    background: white;
+    border-width: 1px;
+    border-style: solid;
+    border-color: #e0e0e0;
+    top: -3px;
+  }
+`;
+
 const toggled = css`
   background: white;
   border-width: 1px;
@@ -99,8 +109,14 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     let filteredResources = resources.filter(
       resource => resource.fields.resourceType === filter.name,
     );
-    updateResources(filteredResources);
-    updateFilter(filter.name);
+    if (filter.name === activeFilter) {
+      updateResources(resources);
+      updateFilter('');
+    } else {
+      updateResources(filteredResources);
+      updateFilter(filter.name);
+    }
+
     updateCount(amountToShow);
   };
 
@@ -112,7 +128,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     resourceIcons = filters.map(filter => {
       if (filter.name !== 'People') {
         return (
-          <Pill
+          <ResourcePill
             resourceType={filter.name}
             label={
               filter.counter > 1 || filter.counter === 0

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -15,7 +15,7 @@ limitations under the License.
 
 Created by Patrick Simonian
 */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
@@ -53,13 +53,34 @@ const PreviewHeader = styled.div`
   }
 `;
 
+const SeeMoreP = styled.p`
+  text-decoration: underline;
+  color: #1a5a96;
+  font-weight: 400;
+  text-transform: capitalize;
+  padding: 0 4px;
+  margin: 0 2px;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
 // used by react-testing-library dom querying
 export const TEST_IDS = {
   container: 'resource-preview-container',
 };
 
 // this is a wrapper component that encapsulates cards for topics or other sizes
-export const ResourcePreview = ({ title, link, resources, filters, amountToShow }) => {
+export const ResourcePreview = ({ title, link, resources, filters, amountToShow, seeMore }) => {
+  let [showCount, updateCount] = useState(amountToShow);
+  let [seeMoreResults, updateSeeMore] = useState(seeMore);
+  const setCount = () => {
+    if (showCount + 6 >= resources.length) {
+      updateSeeMore(false);
+    }
+    updateCount(showCount + 6);
+  };
+
   let resourceIcons;
   if (filters) {
     //No people resource type Icon rn
@@ -68,10 +89,10 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow 
         return (
           <Pill
             resourceType={filter.name}
-            label={`${filter.counter} Result(s)`}
+            label={`${filter.counter} Result(s)`} //make a bit of logic for this perhaps
             variant="filled"
             deletable={false}
-            key={filter}
+            key={filter.name}
           />
         );
       }
@@ -86,7 +107,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow 
         {resourceIcons}
       </PreviewHeader>
       <ResourceContainer>
-        {resources.slice(0, amountToShow).map(r => (
+        {resources.slice(0, showCount).map(r => (
           <CardWrapper key={r.id}>
             <Card
               type={r.fields.resourceType}
@@ -99,7 +120,10 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow 
           </CardWrapper>
         ))}
       </ResourceContainer>
-      <LinkContainer>{link && <ChevronLink to={link.to}>{link.text}</ChevronLink>}</LinkContainer>
+      <LinkContainer>
+        {seeMoreResults && <SeeMoreP onClick={() => setCount()}>See More Results</SeeMoreP>}
+        {link && <ChevronLink to={link.to}>{link.text}</ChevronLink>}
+      </LinkContainer>
     </Container>
   );
 };
@@ -112,6 +136,7 @@ ResourcePreview.propTypes = {
   }),
   filters: PropTypes.array,
   amountToShow: PropTypes.number.isRequired,
+  seeMore: PropTypes.bool,
   resources: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -60,20 +60,23 @@ export const TEST_IDS = {
 
 // this is a wrapper component that encapsulates cards for topics or other sizes
 export const ResourcePreview = ({ title, link, resources, filters, amountToShow }) => {
-  //No people resource type Icon rn
-  let resourceIcons = filters.map(filter => {
-    if (filter.name !== 'People') {
-      return (
-        <Pill
-          resourceType={filter.name}
-          label={`${filter.counter} Result(s)`}
-          variant="filled"
-          deletable={false}
-        />
-      );
-    }
-    return '';
-  });
+  let resourceIcons;
+  if (filters) {
+    //No people resource type Icon rn
+    resourceIcons = filters.map(filter => {
+      if (filter.name !== 'People') {
+        return (
+          <Pill
+            resourceType={filter.name}
+            label={`${filter.counter} Result(s)`}
+            variant="filled"
+            deletable={false}
+          />
+        );
+      }
+      return '';
+    });
+  }
 
   return (
     <Container data-testid={TEST_IDS.container}>
@@ -106,6 +109,8 @@ ResourcePreview.propTypes = {
     text: PropTypes.string.isRequired,
     to: PropTypes.string.isRequired,
   }),
+  filters: PropTypes.array,
+  amountToShow: PropTypes.number.isRequired,
   resources: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -91,19 +91,19 @@ export const TEST_IDS = {
 
 // this is a wrapper component that encapsulates cards for topics or other sizes
 export const ResourcePreview = ({ title, link, resources, filters, amountToShow, seeMore }) => {
-  let [showCount, updateCount] = useState(amountToShow);
-  let [seeMoreResults, updateSeeMore] = useState(seeMore);
-  let [resourcesToShow, updateResources] = useState(resources);
-  let [activeFilter, updateFilter] = useState('All');
+  let [showCount, setCount] = useState(amountToShow);
+  let [seeMoreResults, setSeeMore] = useState(seeMore);
+  let [resourcesToShow, setResources] = useState(resources);
+  let [activeFilter, setFilter] = useState('All');
 
   //sets the amount of resources to show, allowing users to 'see more' if its appropriate
-  const setCount = () => {
+  const updateCount = () => {
     //show 6 more results
-    updateCount(showCount + 6);
-    updateSeeMore(true);
+    setCount(showCount + 6);
+    setSeeMore(true);
     if (showCount >= resourcesToShow.length) {
       //hide the 'see more results' when there isnt more to show
-      updateSeeMore(false);
+      setSeeMore(false);
     }
   };
 
@@ -113,18 +113,18 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     let filteredResources = resources.filter(
       resource => resource.fields.resourceType === filter.name,
     );
-    updateResources(filteredResources);
-    updateFilter(filter.name);
+    setResources(filteredResources);
+    setFilter(filter.name);
     //reset the amount of resources to show
-    updateCount(amountToShow);
+    setCount(amountToShow);
   };
 
   //when 'All Results' pill is toggled, reset our variables to initial states and show all results
   const showAllResults = () => {
-    updateResources(resources);
-    updateFilter('All');
-    updateCount(amountToShow);
-    updateSeeMore(seeMore);
+    setResources(resources);
+    setFilter('All');
+    setCount(amountToShow);
+    setSeeMore(seeMore);
   };
 
   let pills = [];
@@ -197,7 +197,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
       </ResourceContainer>
       <LinkContainer>
         {seeMoreResults && resourcesToShow.length > showCount && (
-          <SeeMoreP onClick={() => setCount()}>See More Results</SeeMoreP>
+          <SeeMoreP onClick={() => updateCount()}>See More Results</SeeMoreP>
         )}
         {link && <ChevronLink to={link.to}>{link.text}</ChevronLink>}
       </LinkContainer>

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -21,8 +21,9 @@ import styled from '@emotion/styled';
 
 import { EMOTION_BOOTSTRAP_BREAKPOINTS } from '../../constants/designTokens';
 import { ChevronLink } from '../UI/Link';
-import { Container, Title, StyledLink, LinkContainer } from './index';
+import { Container, LinkContainer } from './index';
 import Card from '../Cards/Card/Card';
+import Pill from '../UI/Pill';
 
 export const CardWrapper = styled.div`
   margin: 6px 9px;
@@ -38,36 +39,66 @@ export const ResourceContainer = styled.div`
   }
 `;
 
+const PreviewHeader = styled.div`
+  padding: 10px 4px;
+  display: flex;
+  flex-flow: row wrap;
+  border-bottom: 1px solid #ccc;
+  h2 {
+    font-weight: 400;
+    text-transform: capitalize;
+    padding: 0 20px 0 0;
+    margin: 0 2px;
+    margin-top: 5px;
+  }
+`;
+
 // used by react-testing-library dom querying
 export const TEST_IDS = {
   container: 'resource-preview-container',
 };
 
 // this is a wrapper component that encapsulates cards for topics or other sizes
-export const ResourcePreview = ({ title, link, resources }) => (
-  <Container data-testid={TEST_IDS.container}>
-    <Title>
-      <StyledLink to={link.to}>{title}</StyledLink>
-    </Title>
-    <ResourceContainer>
-      {resources.slice(0, 6).map(r => (
-        <CardWrapper key={r.id}>
-          <Card
-            type={r.fields.resourceType}
-            title={r.fields.title}
-            description={r.fields.description}
-            image={r.fields.image}
-            link={r.fields.standAlonePath}
-            event={r}
-          />
-        </CardWrapper>
-      ))}
-    </ResourceContainer>
-    <LinkContainer>
-      <ChevronLink to={link.to}>{link.text}</ChevronLink>
-    </LinkContainer>
-  </Container>
-);
+export const ResourcePreview = ({ title, link, resources, filters, amountToShow }) => {
+  //No people resource type Icon rn
+  let resourceIcons = filters.map(filter => {
+    if (filter.name !== 'People') {
+      return (
+        <Pill
+          resourceType={filter.name}
+          label={`${filter.counter} Result(s)`}
+          variant="filled"
+          deletable={false}
+        />
+      );
+    }
+    return '';
+  });
+
+  return (
+    <Container data-testid={TEST_IDS.container}>
+      <PreviewHeader>
+        <h2>{title}</h2>
+        {resourceIcons}
+      </PreviewHeader>
+      <ResourceContainer>
+        {resources.slice(0, amountToShow).map(r => (
+          <CardWrapper key={r.id}>
+            <Card
+              type={r.fields.resourceType}
+              title={r.fields.title}
+              description={r.fields.description}
+              image={r.fields.image}
+              link={r.fields.standAlonePath}
+              event={r}
+            />
+          </CardWrapper>
+        ))}
+      </ResourceContainer>
+      <LinkContainer>{link && <ChevronLink to={link.to}>{link.text}</ChevronLink>}</LinkContainer>
+    </Container>
+  );
+};
 
 ResourcePreview.propTypes = {
   title: PropTypes.string.isRequired,

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -95,28 +95,32 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
   let [resourcesToShow, updateResources] = useState(resources);
   let [activeFilter, updateFilter] = useState('');
 
-  //sets the amount of resources to show, allowing users to 'see more'
+  //sets the amount of resources to show, allowing users to 'see more' if its appropriate
   const setCount = () => {
+    //show 6 more results
     updateCount(showCount + 6);
     updateSeeMore(true);
     if (showCount >= resourcesToShow.length) {
+      //hide the 'see more results' when there isnt more to show
       updateSeeMore(false);
     }
   };
 
-  //This filters what results we are showing based on the given filter coming from user interaction with the resourceIcons
+  //This filters what results we are showing based on the given filter coming from user interaction with the ResourcePills
   const resourceFilter = filter => {
-    let filteredResources = resources.filter(
-      resource => resource.fields.resourceType === filter.name,
-    );
     if (filter.name === activeFilter) {
+      //bring back the full set of search result and reset the filter
       updateResources(resources);
       updateFilter('');
     } else {
+      //filter the results based on given filter, update the resources and active filter
+      let filteredResources = resources.filter(
+        resource => resource.fields.resourceType === filter.name,
+      );
       updateResources(filteredResources);
       updateFilter(filter.name);
     }
-
+    //reset the amount of resources to show
     updateCount(amountToShow);
   };
 
@@ -127,19 +131,27 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     //No people resource type Icon rn
     resourceIcons = filters.map(filter => {
       if (filter.name !== 'People') {
+        //formats the text correctly for different cases
+        let iconLabel =
+          filter.counter > 1 || filter.counter === 0
+            ? `${filter.counter} Results`
+            : `${filter.counter} Result`;
+        //adds informative info for the behavior of the ResourcePills their current state
+        let iconInfo =
+          filter.name === activeFilter
+            ? 'Click to view all results again'
+            : `Click to view only ${filter.name} results`;
+
         return (
           <ResourcePill
             resourceType={filter.name}
-            label={
-              filter.counter > 1 || filter.counter === 0
-                ? `${filter.counter} Results`
-                : `${filter.counter} Result`
-            }
+            label={iconLabel}
             variant="filled"
             deletable={false}
             key={filter.name}
             css={filter.name === activeFilter ? toggled : ''}
             onClick={filter.counter === 0 ? undefined : () => resourceFilter(filter)}
+            title={iconInfo}
           />
         );
       }

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -93,7 +93,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
   let [showCount, updateCount] = useState(amountToShow);
   let [seeMoreResults, updateSeeMore] = useState(seeMore);
   let [resourcesToShow, updateResources] = useState(resources);
-  let [activeFilter, updateFilter] = useState('');
+  let [activeFilter, updateFilter] = useState('All');
 
   //sets the amount of resources to show, allowing users to 'see more' if its appropriate
   const setCount = () => {
@@ -124,12 +124,20 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     updateCount(amountToShow);
   };
 
-  let resourceIcons;
+  //when 'All Results' pill is toggled, reset our variables to initial states and show all results
+  const showAllResults = () => {
+    updateResources(resources);
+    updateFilter('All');
+    updateCount(amountToShow);
+    updateSeeMore(seeMore);
+  };
+
+  let pills;
   //Filters will be mapped into pills displaying result count for that particular resourcetype
   //These pills are interactive and filter results when clicked
   if (filters) {
     //No people resource type Icon rn
-    resourceIcons = filters.map(filter => {
+    pills = filters.map(filter => {
       if (filter.name !== 'People') {
         //formats the text correctly for different cases
         let iconLabel =
@@ -157,13 +165,26 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
       }
       return '';
     });
+    //Add final pill to the start of the list
+    pills.unshift(
+      <ResourcePill
+        otherIcon={'search'}
+        label={'All Results'}
+        title={'Click to view all results'}
+        key={'All Results'}
+        variant="filled"
+        deletable={false}
+        css={'All' === activeFilter ? toggled : ''}
+        onClick={() => showAllResults()}
+      />,
+    );
   }
 
   return (
     <Container data-testid={TEST_IDS.container}>
       <PreviewHeader>
         <h2>{title}</h2>
-        {resourceIcons}
+        {pills}
       </PreviewHeader>
       <ResourceContainer>
         {resourcesToShow.slice(0, showCount).map(r => (

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -24,6 +24,7 @@ import { ChevronLink } from '../UI/Link';
 import { Container, LinkContainer } from './index';
 import Card from '../Cards/Card/Card';
 import Pill from '../UI/Pill';
+import css from '@emotion/css';
 
 export const CardWrapper = styled.div`
   margin: 6px 9px;
@@ -65,6 +66,23 @@ const SeeMoreP = styled.p`
   }
 `;
 
+const ResourcePill = styled(Pill)`
+  :hover {
+    background: white;
+    border-width: 1px;
+    border-style: solid;
+    border-color: #e0e0e0;
+    top: -3px;
+  }
+`;
+
+const toggled = css`
+  background: white;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #e0e0e0;
+`;
+
 // used by react-testing-library dom querying
 export const TEST_IDS = {
   container: 'resource-preview-container',
@@ -74,29 +92,43 @@ export const TEST_IDS = {
 export const ResourcePreview = ({ title, link, resources, filters, amountToShow, seeMore }) => {
   let [showCount, updateCount] = useState(amountToShow);
   let [seeMoreResults, updateSeeMore] = useState(seeMore);
+  let [resourcesToShow, updateResources] = useState(resources);
+  let [activeFilter, updateFilter] = useState('');
+
   const setCount = () => {
-    if (showCount + 6 >= resources.length) {
+    updateCount(showCount + 6);
+    updateSeeMore(true);
+    if (showCount >= resourcesToShow.length) {
       updateSeeMore(false);
     }
-    updateCount(showCount + 6);
   };
 
+  const resourceFilter = filter => {
+    let filteredResources = resources.filter(
+      resource => resource.fields.resourceType === filter.name,
+    );
+    updateResources(filteredResources);
+    updateFilter(filter.name);
+    updateCount(amountToShow);
+  };
   let resourceIcons;
   if (filters) {
     //No people resource type Icon rn
     resourceIcons = filters.map(filter => {
       if (filter.name !== 'People') {
         return (
-          <Pill
+          <ResourcePill
             resourceType={filter.name}
             label={
               filter.counter > 1 || filter.counter === 0
                 ? `${filter.counter} Results`
                 : `${filter.counter} Result`
-            } //make a bit of logic for this perhaps
+            }
             variant="filled"
             deletable={false}
             key={filter.name}
+            css={filter.name === activeFilter ? toggled : ''}
+            onClick={filter.counter === 0 ? undefined : () => resourceFilter(filter)}
           />
         );
       }
@@ -111,7 +143,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
         {resourceIcons}
       </PreviewHeader>
       <ResourceContainer>
-        {resources.slice(0, showCount).map(r => (
+        {resourcesToShow.slice(0, showCount).map(r => (
           <CardWrapper key={r.id}>
             <Card
               type={r.fields.resourceType}
@@ -125,7 +157,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
         ))}
       </ResourceContainer>
       <LinkContainer>
-        {seeMoreResults && resources.length > 6 && (
+        {seeMoreResults && resourcesToShow.length > showCount && (
           <SeeMoreP onClick={() => setCount()}>See More Results</SeeMoreP>
         )}
         {link && <ChevronLink to={link.to}>{link.text}</ChevronLink>}

--- a/app-web/src/components/Search/SearchPills.js
+++ b/app-web/src/components/Search/SearchPills.js
@@ -62,12 +62,7 @@ export const SearchPills = ({ onDelete, query, searchResultTotal, showClear, onC
   }
 
   resultpill = [
-    <SearchPill
-      key={shortid.generate()}
-      label={resultLabel}
-      onDelete={onDelete}
-      variant="filled"
-    />,
+    <Pill key={shortid.generate()} label={resultLabel} variant="filled" deletable={false} />,
   ];
 
   const clearPill =

--- a/app-web/src/components/Search/SearchSources.js
+++ b/app-web/src/components/Search/SearchSources.js
@@ -26,7 +26,12 @@ export const SearchSources = ({ rocketchat }) => {
   return (
     <SearchSourcesContainer data-testid={TEST_IDS.container}>
       <Link to={'#rocketChat'}>
-        {authenticated && <RCButton {...rcProps} title="toggle rocket chat search results" />}
+        {authenticated && (
+          <RCButton {...rcProps} title="Click to jump to rocket chat search results" />
+        )}
+        {!authenticated && (
+          <RCButton {...rcProps} title="Login to view rocket chat search results" />
+        )}
       </Link>
     </SearchSourcesContainer>
   );

--- a/app-web/src/components/Search/SearchSources.js
+++ b/app-web/src/components/Search/SearchSources.js
@@ -26,9 +26,7 @@ export const SearchSources = ({ rocketchat }) => {
   return (
     <SearchSourcesContainer data-testid={TEST_IDS.container}>
       <Link to={'#rocketChat'}>
-        {authenticated && (
-          <RCButton {...rcProps} title="Click to jump to rocket chat search results" />
-        )}
+        {authenticated && <RCButton title="Click to jump to rocket chat search results" />}
         {!authenticated && (
           <RCButton {...rcProps} title="Login to view rocket chat search results" />
         )}

--- a/app-web/src/components/UI/Pill/index.js
+++ b/app-web/src/components/UI/Pill/index.js
@@ -6,6 +6,7 @@ import {
   faLayerGroup,
   faUser,
   faTag,
+  faSearch,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styled from '@emotion/styled';
@@ -89,6 +90,8 @@ export const Pill = ({
     specialIcon = faTag;
   } else if (otherIcon === 'persona') {
     specialIcon = faUser;
+  } else if (otherIcon === 'search') {
+    specialIcon = faSearch;
   }
 
   if (variant === variants.filled) {

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -83,7 +83,7 @@ const getSearchResultTotal = results => {
  * @param {string} queryExists the search query
  * @param {Array} results the list of searched resources
  */
-const getResourcePreviews = (resources, queryExists, results = []) => {
+const getResourcePreviews = (resources, queryExists, results = [], title) => {
   const resourcesSelector = selectResourcesGroupedByType();
   let resourcesToShow = [];
   if (!isNull(results) && results.length > 0) {
@@ -112,11 +112,12 @@ const getResourcePreviews = (resources, queryExists, results = []) => {
 
   return (
     <ResourcePreview
-      key={'DevHub Resources'}
-      title={'DevHub Resources'}
+      key={'Internal Results'}
+      title={title}
       resources={resourcesToShow}
       filters={resourceIconsWithCounter}
-      amountToShow={21}
+      amountToShow={18}
+      seeMore={true}
     />
   );
 };
@@ -194,6 +195,7 @@ export const Index = ({
       .concat(markdownRemark),
     windowHasQuery && !queryIsEmpty,
     results,
+    'Devhub Resources',
   );
 
   let totalSearchResults = 0;

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -195,7 +195,7 @@ export const Index = ({
       .concat(markdownRemark),
     windowHasQuery && !queryIsEmpty,
     results,
-    'Devhub Resources',
+    'DevHub Resources',
   );
 
   let totalSearchResults = 0;


### PR DESCRIPTION
## Summary
- Search results are no longer grouped by resource type but now by relevance. The resource type metadata can be seen above the results with their respecting result counts
- When clicked, the resource type pills now filter the results being shown according to the given resource type
- click on = filter, click off = all results back
- RocketChat Icon can now be seen even if not logged in, but when the user isnt logged in - it is faded

