### PR TITLE
fix an issue where the rc logo would not anchor in safari

### DIFF
--- a/app-web/src/components/Search/SearchSources.js
+++ b/app-web/src/components/Search/SearchSources.js
@@ -25,9 +25,9 @@ export const SearchSources = ({ rocketchat }) => {
   }
   return (
     <SearchSourcesContainer data-testid={TEST_IDS.container}>
-      <Link to={'#rocketChat'}>
+      <a href="#rocketChat">
         {authenticated && <RCButton {...rcProps} title="toggle rocket chat search results" />}
-      </Link>
+      </a>
     </SearchSourcesContainer>
   );
 };


### PR DESCRIPTION
This does not fix issue #899. Unfortunately, I am unable to do discern what the root cause is at this stage. My guess is that if the URL already matches the contents of the anchor tag's href attribute, clicking on the anchor tag does not work as expected (it doesn't scroll to the anchored element)
