### PR TITLE
Replace rocket gate apollo client with search gate

### DIFF
--- a/.pipeline/lib/deploy.js
+++ b/.pipeline/lib/deploy.js
@@ -14,7 +14,7 @@ const getParamsByEnv = (env, pr) => {
     SSO_CLIENT_ID_VALUE: 'devhub-web',
     SSO_REALM_NAME_VALUE: 'devhub',
     // for the time being we only have a dev instance, this will change as the api is developed
-    ROCKETGATE_API_URL: 'https://rocketgate.pathfinder.gov.bc.ca/',
+    SEARCHGATE_API_URL: 'https://searchgate.pathfinder.gov.bc.ca/',
   };
   switch (env) {
     case ENVS.PROD:

--- a/app-web/__fixtures__/searchsources.js
+++ b/app-web/__fixtures__/searchsources.js
@@ -19,19 +19,25 @@ Created by Patrick Simonian
 
 export const ROCKET_CHAT = [
   {
-    id: '1', 
-    roomId: '2', author: 'apple', time: '2019-02-12', message: 'apples are clearly superior',
+    type: 'rocketchat',
+    id: '1',
+    typePayload: JSON.stringify({
+      id: '1',
+      roomId: '2',
+      author: 'apple',
+      time: '2019-02-12',
+      message: 'apples are clearly superior',
+    }),
   },
   {
-    id: '2', 
-    roomId: '2', author: 'orange', time: '2019-02-12', message: 'Nice joke apple, are trying to perform some time of standup?',
+    type: 'rocketchat',
+    id: '2',
+    typePayload: JSON.stringify({
+      id: '2',
+      roomId: '2',
+      author: 'apple',
+      time: '2019-02-12',
+      message: 'apples are clearly superior',
+    }),
   },
-  {
-    id: '3', 
-    roomId: '2', author: 'apple', time: '2019-02-12', message: 'Don\'t play coy with me orange, you know I\'m telling the truth',
-  },
-  {
-    id: '4', 
-    roomId: '2', author: 'orange', time: '2019-02-12', message: 'I ain\'t never hurd of people curing scurvy with apples yo. Hook line and sinker dawg.',
-  },
-]
+];

--- a/app-web/__tests__/pages/Index.test.js
+++ b/app-web/__tests__/pages/Index.test.js
@@ -18,7 +18,7 @@ import {
   SELECT_TOPICS_WITH_RESOURCES_GROUPED_BY_TYPE,
   SELECT_RESOURCES_GROUPED_BY_TYPE,
 } from '../../__fixtures__/selector-fixtures';
-import { useSearch, useAuthenticated, useRCSearch } from '../../src/utils/hooks';
+import { useSearch, useAuthenticated, useSearchGate } from '../../src/utils/hooks';
 import { TEST_IDS as TOPIC_TEST_IDS } from '../../src/components/Home/TopicsContainer';
 import { TEST_IDS as RESOURCE_PREVIEW_TEST_IDS } from '../../src/components/Home/ResourcePreview';
 import {
@@ -43,7 +43,7 @@ jest.mock('../../src/utils/helpers.js');
 
 getFirstNonExternalResource.mockReturnValue('foo');
 getTextAndLink.mockReturnValue({ to: '/documentation?q=mobile', text: 'two results found' });
-useRCSearch.mockReturnValue({ results: [], loading: false });
+useSearchGate.mockReturnValue({ results: [], loading: false });
 useAuthenticated.mockReturnValue(false);
 buildFeaturedTopic.mockReturnValue({ node: FEATURED_TOPIC });
 buildPopularTopic.mockReturnValue({ node: POPULAR_TOPIC });
@@ -212,7 +212,7 @@ describe('Home Page', () => {
   test('shows rocket chat results when authenticated', () => {
     queryString.parse.mockReturnValue({ q: 'foo' });
     useSearch.mockReturnValue([]);
-    useRCSearch.mockReturnValue({ results: ROCKET_CHAT, loading: false });
+    useSearchGate.mockReturnValue({ results: ROCKET_CHAT, loading: false });
     useAuthenticated.mockReturnValue(true);
 
     const { queryByTestId, rerender } = render(

--- a/app-web/__tests__/utils/search.test.js
+++ b/app-web/__tests__/utils/search.test.js
@@ -44,8 +44,8 @@ describe('Search Helpers', () => {
 
   test('getSearchSourcesTotal return the correct total', () => {
     const sources = {
-      sourceA: { results: [1, 2, 3] },
-      sourceB: { results: [2, 4, 5, 7] },
+      sourceA: [1, 2, 3],
+      sourceB: [2, 4, 5, 7],
     };
 
     const expected = 7;

--- a/app-web/src/config.js
+++ b/app-web/src/config.js
@@ -3,5 +3,5 @@ export default {
   ssoRealmName: '{{.Env.SSO_REALM_NAME}}',
   ssoClientId: '{{.Env.SSO_CLIENT_ID}}',
   ssoBaseUrl: '{{.Env.SSO_BASE_URL}}',
-  rocketgateApiUrl: '{{.Env.ROCKETGATE_API_URL}}',
+  searchgateApiUrl: '{{.Env.SEARCHGATE_API_URL}}',
 };

--- a/app-web/src/constants/api.js
+++ b/app-web/src/constants/api.js
@@ -5,5 +5,5 @@ import config from '../config';
 export const SSO_REALM_NAME = process.env.GATSBY_SSO_REALM_NAME || config.ssoRealmName;
 export const SSO_CLIENT_ID = process.env.GATSBY_SSO_CLIENT_ID || config.ssoClientId;
 export const SSO_BASE_URL = process.env.GATSBY_SSO_BASE_URL || config.ssoBaseUrl;
-export const ROCKETGATE_API_URL = process.env.GATSBY_ROCKETGATE_API_URL || config.rocketgateApiUrl;
+export const SEARCHGATE_API_URL = process.env.GATSBY_SEARCHGATE_API_URL || config.searchgateApiUrl;
 export const GITHUB_URL = 'https://www.github.com';

--- a/app-web/src/constants/runtimeGraphqlQueries.js
+++ b/app-web/src/constants/runtimeGraphqlQueries.js
@@ -17,15 +17,12 @@ Created by Patrick Simonian
 */
 import gql from 'graphql-tag';
 
-export const ROCKET_GATE_QUERY = gql`
+export const SEARCHGATE_QUERY = gql`
   query DevHubQuery($queryString: String!) {
     search(searchString: $queryString) {
-      message
-      author
-      time
-      roomId
-      url
       id
+      type
+      typePayload
     }
   }
 `;

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import queryString from 'query-string';
 import isNull from 'lodash/isNull';
+import groupBy from 'lodash/groupBy';
 import styled from '@emotion/styled';
 import { Alert } from 'reactstrap';
 import { withApollo } from 'react-apollo';
@@ -14,7 +15,7 @@ import { ResourcePreview, Masthead, TopicsContainer } from '../components/Home';
 import withResourceQuery from '../hoc/withResourceQuery';
 import Aux from '../hoc/auxillary';
 
-import { useSearch, useAuthenticated, useRCSearch } from '../utils/hooks';
+import { useSearch, useAuthenticated, useSearchGate } from '../utils/hooks';
 import {
   selectTopicsWithResourcesGroupedByType,
   selectResourcesGroupedByType,
@@ -160,9 +161,13 @@ export const Index = ({
   const { authenticated } = useAuthenticated();
   // get rocket chat search results if authenticated
   // TODO will activate once ui component is available
-  const searchSourceResults = {
-    rocketchat: useRCSearch(authenticated, query, client),
-  };
+
+  const searchGate = useSearchGate(authenticated, query, client);
+
+  let searchSourceResults = {};
+  if (searchGate.results) {
+    searchSourceResults = groupBy(searchGate.results, 'type');
+  }
 
   //set search filter to false if the user isnt authenticated, so RC icon will show appropriately
   if (!authenticated) {
@@ -250,11 +255,15 @@ export const Index = ({
       <Aux>
         {getTopicPreviews(dynamicTopics.concat(topics), windowHasQuery && !queryIsEmpty)}
         {siphonResources}
-        {!isEmpty(rocketchat.results) && rocketchat.results.length > 0 && (
+        {!isEmpty(rocketchat) && rocketchat.length > 0 && (
           <DynamicSearchResults
-            results={searchSourceResults.rocketchat.results}
+            results={rocketchat}
             sourceType={SEARCH_SOURCES.rocketchat}
-            renderItem={r => <RocketChatItem {...r} data-testid={r.id} />}
+            renderItem={r => {
+              const chatItem = JSON.parse(r.typePayload);
+
+              return <RocketChatItem {...chatItem} data-testid={chatItem.id} />;
+            }}
             link={{
               to: 'https://chat.pathfinder.gov.bc.ca',
               text: 'Go To Rocket.Chat',
@@ -267,7 +276,7 @@ export const Index = ({
 
   // dynamic sources all load at different times, this function returns false when all have completed loading
   const searchSourcesLoading = areSearchSourcesStillLoading(searchSourceResults);
-  if (!!searchSourceResults.rocketchat.results) {
+  if (!!searchSourceResults.rocketchat) {
     totalSearchResults += getSearchSourcesResultTotal(searchSourceResults);
   }
 

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -21,11 +21,7 @@ import {
   selectResourcesGroupedByType,
 } from '../utils/selectors';
 
-import {
-  isQueryEmpty,
-  getSearchSourcesResultTotal,
-  areSearchSourcesStillLoading,
-} from '../utils/search';
+import { isQueryEmpty } from '../utils/search';
 import { SEARCH_QUERY_PARAM, SEARCH_SOURCES } from '../constants/search';
 import { SPACING } from '../constants/designTokens';
 import uniqBy from 'lodash/uniqBy';
@@ -275,9 +271,9 @@ export const Index = ({
   }
 
   // dynamic sources all load at different times, this function returns false when all have completed loading
-  const searchSourcesLoading = areSearchSourcesStillLoading(searchSourceResults);
+  const searchSourcesLoading = searchGate.loading;
   if (!!searchSourceResults.rocketchat) {
-    totalSearchResults += getSearchSourcesResultTotal(searchSourceResults);
+    totalSearchResults += searchSourceResults.rocketchat.length;
   }
 
   return (

--- a/app-web/src/utils/hooks.js
+++ b/app-web/src/utils/hooks.js
@@ -23,7 +23,7 @@ import { SEARCH_FIELD_NAMES, SEARCH_FIELD_MAPPING } from '../constants/search';
 import isEmpty from 'lodash/isEmpty';
 import AuthContext from '../AuthContext';
 import { useQuery } from '@apollo/react-hooks';
-import { ROCKET_GATE_QUERY } from '../constants/runtimeGraphqlQueries';
+import { SEARCHGATE_QUERY } from '../constants/runtimeGraphqlQueries';
 
 //TODO, why in a function?
 function deepCompareEquals(a, b) {
@@ -139,8 +139,8 @@ export const useAuthenticated = () => {
  * @param {Client} client the apollo client to query
  * @returns {Object} {loading, results: <Array>}
  */
-export const useRCSearch = (authenticated, queryString, client) => {
-  const { data, loading } = useQuery(ROCKET_GATE_QUERY, {
+export const useSearchGate = (authenticated, queryString, client) => {
+  const { data, loading } = useQuery(SEARCHGATE_QUERY, {
     variables: {
       queryString,
     },
@@ -148,6 +148,7 @@ export const useRCSearch = (authenticated, queryString, client) => {
   });
   const [results, setResults] = useState([]);
   const [_loading, setLoading] = useState(true);
+
   useEffect(() => {
     setLoading(loading);
     if (!authenticated || !queryString) {
@@ -162,5 +163,6 @@ export const useRCSearch = (authenticated, queryString, client) => {
     //Reminder - Ask patrick about this
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, useDeepCompareMemoize([_loading, loading, authenticated, queryString, results]));
+
   return { results, loading: _loading };
 };

--- a/app-web/src/utils/hooks.js
+++ b/app-web/src/utils/hooks.js
@@ -151,7 +151,9 @@ export const useSearchGate = (authenticated, queryString, client) => {
 
   useEffect(() => {
     setLoading(loading);
-    if (!authenticated || !queryString) {
+    // if (!authenticated && !queryString) {
+    // TODO remove line 156 and replace with above before push
+    if (!queryString) {
       setResults([]);
     } else if (!_loading) {
       setResults(data.search);

--- a/app-web/src/utils/search.js
+++ b/app-web/src/utils/search.js
@@ -69,13 +69,12 @@ export const isQueryEmpty = query => {
 /**
  * takes in a hash of search sources and returns the total count based on if they are toggled or not
  * @param {Object} searchSources map of search sources
- * @param {Object} searchSources.rocketchat map of search sources
- * @param {Array} searchSources.rocketchat.results map of search sources
+ * @param {Array} searchSources.rocketchat map of search sources
  * @returns {Number} total number of search sources
  */
 export const getSearchSourcesResultTotal = searchSources => {
   return Object.keys(searchSources).reduce((total, source) => {
-    total += searchSources[source].results.length;
+    total += searchSources[source].length;
     return total;
   }, 0);
 };

--- a/app-web/src/utils/search.js
+++ b/app-web/src/utils/search.js
@@ -78,12 +78,3 @@ export const getSearchSourcesResultTotal = searchSources => {
     return total;
   }, 0);
 };
-
-/**
- * multiple search sources can resolve at different times,
- * this method returns true if atleast n sources are still loading
- * @param {Object} searchSources
- * @returns {Boolean}
- */
-export const areSearchSourcesStillLoading = searchSources =>
-  Object.keys(searchSources).filter(source => searchSources[source].loading).length > 0;

--- a/app-web/wrapWithProvider.js
+++ b/app-web/wrapWithProvider.js
@@ -24,13 +24,13 @@ import { ApolloClient, InMemoryCache } from 'apollo-boost';
 import { ApolloProvider } from 'react-apollo';
 import { createHttpLink } from 'apollo-link-http';
 import fetch from 'unfetch';
-import { ROCKETGATE_API_URL } from './src/constants/api';
+import { SEARCHGATE_API_URL } from './src/constants/api';
 
 const cache = new InMemoryCache();
 //this needs to be an enviroment variable later on......
 export const client = new ApolloClient({
   link: createHttpLink({
-    uri: ROCKETGATE_API_URL,
+    uri: SEARCHGATE_API_URL,
     fetch: fetch,
   }),
   cache,

--- a/openshift/templates/dc.yaml
+++ b/openshift/templates/dc.yaml
@@ -95,8 +95,8 @@ objects:
               cpu: '300m'
               memory: '75Mi'
           env:
-          - name: ROCKETGATE_API_URL
-            value: ${ROCKETGATE_API_URL}
+          - name: SEARCHGATE_API_URL
+            value: ${SEARCHGATE_API_URL}
           - name: SSO_BASE_URL
             value: ${SSO_BASE_URL_VALUE}
           - name: SSO_REALM_NAME
@@ -184,8 +184,8 @@ parameters:
   required: false
   value: ''
 - description: Then end point for connecting to the apollo graphql api gateway 
-  displayName: Rocketgate Graphql Api Url
-  name: ROCKETGATE_API_URL
+  displayName: Searchgate Graphql Api Url
+  name: SEARCHGATE_API_URL
   required: false
   value: ''
 - description: A base url of sso in the env


### PR DESCRIPTION
## Summary
As described by issue #907, we are leveraging search gate to perform our runtime graphql searches. This returns payloads from different search sources in a standard schema. 

This pr integrates search gate and modifies any infra code that referenced Rocketgate with Search gate

Reference repositories for the two can be found here
https://github.com/bcgov/searchgate
https://github.com/bcgov/rocketgate

fixes #907 