### PR TITLE
Cancel placeholder for search input and update snapshot

### DIFF
--- a/app-web/__tests__/components/__snapshots__/Search.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/Search.test.js.snap
@@ -59,7 +59,6 @@ exports[`Search Bar matches snapshot 1`] = `
     class="Input custom-text"
     data-testid="searchbar-input"
     id="baz"
-    placeholder=""
     type="text"
     value=""
   />

--- a/app-web/__tests__/components/__snapshots__/ToolsMenu.test.js.snap
+++ b/app-web/__tests__/components/__snapshots__/ToolsMenu.test.js.snap
@@ -90,7 +90,6 @@ exports[`Tools Menu renders the tools menu 1`] = `
       data-testid="searchbar-input"
       id="dh-search-input"
       maxlength="40"
-      placeholder=""
       type="text"
       value=""
     />

--- a/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
+++ b/app-web/__tests__/pages/__snapshots__/Index.test.js.snap
@@ -190,7 +190,6 @@ exports[`Home Page When a blank search is entered, cards and alerts dont show bu
         data-testid="searchbar-input"
         id="dh-search-input"
         maxlength="40"
-        placeholder=""
         type="text"
         value=""
       />
@@ -400,7 +399,6 @@ exports[`Home Page it matches snapshot, when there is a search and no results an
         data-testid="searchbar-input"
         id="dh-search-input"
         maxlength="40"
-        placeholder=""
         type="text"
         value=""
       />

--- a/app-web/__tests__/pages/__snapshots__/resourceType.test.js.snap
+++ b/app-web/__tests__/pages/__snapshots__/resourceType.test.js.snap
@@ -419,7 +419,6 @@ exports[`Resource Type Template Page it matches snapshot, when there are no reso
             data-testid="searchbar-input"
             id="dh-search-input"
             maxlength="40"
-            placeholder=""
             type="text"
             value=""
           />

--- a/app-web/src/components/Home/ResourcePreview.js
+++ b/app-web/src/components/Home/ResourcePreview.js
@@ -24,7 +24,7 @@ import { Container, LinkContainer } from './index';
 import Card from '../Cards/Card/Card';
 import Pill from '../UI/Pill';
 import { RESOURCE_TYPES } from '../../constants/ui';
-import { getSearchResultLable } from '../../utils/helpers';
+import { getSearchResultLabel } from '../../utils/helpers';
 import Row from '../Cards/Row';
 import Col from '../Cards/Column';
 
@@ -122,7 +122,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
     setSeeMore(seeMore);
   };
 
-  let resultLabel = getSearchResultLable(resources.length);
+  let resultLabel = getSearchResultLabel(resources.length);
   resultLabel = resources.length !== 0 ? 'All ' + resultLabel : resultLabel;
 
   let pills = [];
@@ -152,7 +152,7 @@ export const ResourcePreview = ({ title, link, resources, filters, amountToShow,
         if (filter.name !== RESOURCE_TYPES.PEOPLE) {
           //formats the text correctly for different cases
 
-          let iconLabel = getSearchResultLable(filter.counter);
+          let iconLabel = getSearchResultLabel(filter.counter);
           //adds informative info for the behavior of the ResourcePills their current state
           let iconInfo =
             filter.name === activeFilter

--- a/app-web/src/components/Search/index.js
+++ b/app-web/src/components/Search/index.js
@@ -49,7 +49,6 @@ export const Search = ({ onSearch, searchOnEnter, inputConfig, query, ...rest })
 
   const search = () => {
     onSearch(terms);
-    setTerms('');
   };
 
   return (

--- a/app-web/src/components/UI/Input/Input.js
+++ b/app-web/src/components/UI/Input/Input.js
@@ -27,7 +27,6 @@ const Input = ({ id, type, label, name, checked, query, ...rest }) => (
     label={label}
     checked={checked}
     className={styles.Input}
-    placeholder={query}
     {...rest}
   />
 );

--- a/app-web/src/utils/helpers.js
+++ b/app-web/src/utils/helpers.js
@@ -61,11 +61,12 @@ export const getTextAndLink = (resourceType, resourcesByType) => {
   return textAndPath;
 };
 
-/** return a combine text result or results depens on how much search results we have
+/** pluralize return string (results) if numOfResults is > 1. And return not search result if
+ * numOfResults === 0 example output: 10 Results / 1 Result / No search Result
  * @param {num} numOfResults
  * @returns {string}
  */
-export const getSearchResultLable = numOfResults => {
+export const getSearchResultLabel = numOfResults => {
   let resultLabel;
   if (numOfResults) {
     resultLabel = `${numOfResults} Result${numOfResults > 1 ? 's' : ''}`;


### PR DESCRIPTION
Instead of using placeholder, we are now using searching query from last time as value after click search(Intimate what other search engine is doing).
