### PR TITLE
Add a alert for user to let then login to view more info

### DIFF
--- a/app-web/__tests__/components/Masthead.test.js
+++ b/app-web/__tests__/components/Masthead.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, cleanup, fireEvent } from 'react-testing-library';
+import Masthead, { TEST_IDS } from '../../src/components/Home/Masthead';
+import { ThemeProvider } from 'emotion-theming';
+import theme from '../../theme';
+import { useAuthenticated } from '../../src/utils/hooks';
+import 'jest-dom/extend-expect';
+
+jest.mock('../../src/utils/hooks');
+describe('Masthead Component', () => {
+  afterEach(cleanup);
+
+  it('It shows an alert window when a search has happened', () => {
+    useAuthenticated.mockReturnValue({ authenticated: false });
+
+    const { queryByTestId, rerender } = render(
+      <ThemeProvider theme={theme}>
+        <Masthead query={'openshift'} searchSourcesLoading={true} resultCount={12} />
+      </ThemeProvider>,
+    );
+    const alert = queryByTestId(TEST_IDS.alertBox);
+    expect(alert).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <Masthead query={'devop'} searchSourcesLoading={true} resultCount={0} />
+      </ThemeProvider>,
+    );
+    expect(alert).toBeInTheDocument();
+
+    const closebtn = alert.querySelector('button');
+    fireEvent.click(closebtn);
+    expect(alert).not.toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <Masthead query={'happy'} searchSourcesLoading={true} resultCount={0} />
+      </ThemeProvider>,
+    );
+
+    expect(alert).not.toBeInTheDocument();
+  });
+
+  it('The alert box does not show when authenticated', () => {
+    useAuthenticated.mockReturnValue({ authenticated: true });
+
+    const { queryByTestId, rerender } = render(
+      <ThemeProvider theme={theme}>
+        <Masthead query={'openshift'} searchSourcesLoading={true} resultCount={12} />
+      </ThemeProvider>,
+    );
+    const alert = queryByTestId(TEST_IDS.alertBox);
+    expect(alert).not.toBeInTheDocument();
+    rerender(
+      <ThemeProvider theme={theme}>
+        <Masthead query={'happy'} searchSourcesLoading={true} resultCount={0} />
+      </ThemeProvider>,
+    );
+
+    expect(alert).not.toBeInTheDocument();
+  });
+});

--- a/app-web/src/components/Home/Masthead.js
+++ b/app-web/src/components/Home/Masthead.js
@@ -15,25 +15,30 @@ limitations under the License.
 
 Created by Patrick Simonian
 */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { navigate } from 'gatsby';
 import styled from '@emotion/styled';
-
+import { Alert } from 'reactstrap';
 import { css } from '@emotion/core';
 import { ChevronLink } from '../UI/Link';
 import { SEARCH } from '../../constants/ui';
 import { EMOTION_BOOTSTRAP_BREAKPOINTS, SPACING } from '../../constants/designTokens';
 import Search from '../Search';
-// localizations
 import AppLogo from '../UI/AppLogo/AppLogo';
 import { SearchSources } from '../Search/SearchSources';
+import { useAuthenticated } from '../../utils/hooks';
+
 const SearchStyled = styled(Search)`
   font-size: 1.25em;
   flex-flow: row wrap;
   > button {
     flex-grow: 1;
   }
+`;
+
+const AlertMessage = styled(Alert)`
+  margin: 10px auto;
 `;
 
 const SearchContainer = styled.div`
@@ -58,8 +63,20 @@ const IconDiv = styled.div`
   display: flex;
   flex-flow: row nowrap;
 `;
+export const TEST_IDS = {
+  alertBox: 'Masthead.show',
+};
 
 export const Masthead = ({ query, resultCount, searchSourcesLoading }) => {
+  const { authenticated } = useAuthenticated();
+  const [isVisible, setVisible] = useState(query !== ''); // show only if user input query to search
+  const [alertHasBeenAcknowledged, setAlertHasBeenAcknowledged] = useState(true);
+
+  const onDismiss = () => {
+    setAlertHasBeenAcknowledged(false);
+    setVisible(false);
+  };
+
   return (
     <Container>
       <AppLogo
@@ -101,6 +118,16 @@ export const Masthead = ({ query, resultCount, searchSourcesLoading }) => {
         />
         <IconDiv>{!searchSourcesLoading && query && resultCount > 0 && <SearchSources />}</IconDiv>
       </SearchContainer>
+      {!authenticated && alertHasBeenAcknowledged && (
+        <AlertMessage
+          color="warning"
+          isOpen={isVisible}
+          toggle={onDismiss}
+          data-testid={TEST_IDS.alertBox}
+        >
+          You can view search results from applications like Rocket.Chat or Github when logged in.
+        </AlertMessage>
+      )}
     </Container>
   );
 };
@@ -108,6 +135,7 @@ export const Masthead = ({ query, resultCount, searchSourcesLoading }) => {
 Masthead.propTypes = {
   query: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
   resultCount: PropTypes.number,
+  searchSourcesLoading: PropTypes.bool,
 };
 
 export default Masthead;

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -329,7 +329,6 @@ export const Index = ({
         query={query}
         searchSourcesLoading={searchSourcesLoading}
         resultCount={totalSearchResults}
-        searchResultsEmpty={resourcesNotFound}
       />
       <Main>
         {windowHasQuery && searchSourcesLoading ? <Loading message="loading" /> : content}


### PR DESCRIPTION
> Added an info box that provides the user with a tip that they can view more search results from github/rocketchat when logged in. Once acknowledged the message does not show up for the remainder of the application lifecycle. 

The alert will not show up again once it is close, and will only show if user is not logged in and search something
#939 
-
-
-
