### PR TITLE
Convert anchor links for search sources (github/rocketchat) to a programmatic scroll

### DIFF
--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -27592,9 +27592,9 @@
       }
     },
     "react-scroll": {
-      "version": "1.7.12",
-      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.12.tgz",
-      "integrity": "sha512-hvi3MixtYQC1FADODqWx6MSYaShBbsq7ElQBny/pmzrGtF4ubGLuDOGpzP3mvJjWZ66Cepujt4PBjysYV3itwg==",
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.14.tgz",
+      "integrity": "sha512-zQ2/8+TaEBctA9RSQspP5GWMffA6g7u+AB9gMWB42btZZTBcGEyomvxnm52UVVELjqXOpD9U1/tHhVTNXyntbQ==",
       "requires": {
         "lodash.throttle": "^4.1.1",
         "prop-types": "^15.5.8"
@@ -32334,11 +32334,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "uri-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uri-parser/-/uri-parser-1.0.1.tgz",
-      "integrity": "sha512-TRjjM2M83RD9jIIYttNj7ghUQTKSov+WXZbQIMM8DxY1R1QdJEGWNKKMYCxyeOw1p9re2nQ85usM6dPTVtox1g=="
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -33550,15 +33545,6 @@
       "integrity": "sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==",
       "requires": {
         "js-yaml": "^3.5.2"
-      }
-    },
-    "yamljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
       }
     },
     "yargs": {

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -92,7 +92,7 @@
     "react-helmet": "^5.2.1",
     "react-image": "^2.1.1",
     "react-pose": "^4.0.7",
-    "react-scroll": "^1.7.10",
+    "react-scroll": "^1.7.14",
     "react-select": "^2.4.3",
     "react-strap": "0.0.1",
     "react-toggled": "^1.2.7",
@@ -110,10 +110,7 @@
     "typography": "^0.16.19",
     "unfetch": "^4.1.0",
     "unist-util-visit": "^1.4.1",
-    "uri-parser": "^1.0.1",
-    "url-parse": "^1.4.7",
-    "valid-url": "^1.0.9",
-    "yamljs": "^0.3.0"
+    "valid-url": "^1.0.9"
   },
   "scripts": {
     "build": "npx --node-arg '-r esm' gatsby build",

--- a/app-web/src/components/DynamicSearchResults/index.js
+++ b/app-web/src/components/DynamicSearchResults/index.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { Title, LinkContainer } from '../Home';
 import { ChevronLink } from '../UI/Link';
 import { SEARCH_SOURCE_CONFIG, SEARCH_SOURCES } from '../../constants/search';
-
+import { Element } from 'react-scroll';
 import documizeLogo from '../../assets/images/documize_logo.png';
 import githubLogo from '../../assets/images/github_logo.png';
 import rocketchatLogo from '../../assets/images/rocketchat_logo.svg';
@@ -22,35 +22,37 @@ const Container = styled.div`
   }
 `;
 
-export const DynamicSearchResults = ({ numResults, sourceType, link, children, ...rest }) => {
-  const contentMapping = {
-    [SEARCH_SOURCES.documize]: {
-      name: 'From Documize',
-      logo: documizeLogo,
-      id: 'documize',
-    },
-    [SEARCH_SOURCES.rocketchat]: {
-      name: 'From Rocket.Chat',
-      logo: rocketchatLogo,
-      id: 'rocketChat',
-    },
-    [SEARCH_SOURCES.github]: {
-      name: 'From Github',
-      logo: githubLogo,
-      id: 'github',
-    },
-  };
+export const SEARCH_SOURCE_CONTENT = {
+  [SEARCH_SOURCES.documize]: {
+    name: 'From Documize',
+    logo: documizeLogo,
+    id: 'documize',
+  },
+  [SEARCH_SOURCES.rocketchat]: {
+    name: 'From Rocket.Chat',
+    logo: rocketchatLogo,
+    id: 'rocketChat',
+  },
+  [SEARCH_SOURCES.github]: {
+    name: 'From Github',
+    logo: githubLogo,
+    id: 'github',
+  },
+};
 
-  const content = contentMapping[sourceType];
+export const DynamicSearchResults = ({ numResults, sourceType, link, children, ...rest }) => {
+  const content = SEARCH_SOURCE_CONTENT[sourceType];
   const settings = SEARCH_SOURCE_CONFIG[sourceType]
     ? SEARCH_SOURCE_CONFIG[sourceType]
     : SEARCH_SOURCE_CONFIG.default;
 
   return (
     <Container {...rest}>
-      <Title id={content.id}>
-        {content.name} <img src={content.logo} alt={content.name} />
-      </Title>
+      <Element name={content.id}>
+        <Title id={content.id}>
+          {content.name} <img src={content.logo} alt={content.name} />
+        </Title>
+      </Element>
 
       {numResults > settings.maxResults && (
         <small>

--- a/app-web/src/components/Search/SearchSources.js
+++ b/app-web/src/components/Search/SearchSources.js
@@ -2,7 +2,13 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { RCButton, GithubButton } from '../UI/Button/Button';
 import { useAuthenticated } from '../../utils/hooks';
-import { Link } from '../UI/Link';
+import { Link } from 'react-scroll';
+import { SEARCH_SOURCE_CONTENT } from '../DynamicSearchResults';
+import { SEARCH_SOURCES } from '../../constants/search';
+
+const StyledLink = styled(Link)`
+  margin: 0 5px;
+`;
 
 export const SearchSourcesContainer = styled.div`
   display: flex;
@@ -30,19 +36,21 @@ export const SearchSources = () => {
     };
   }
 
+  const scrollOffset = -125;
+
   return (
     <SearchSourcesContainer data-testid={TEST_IDS.container}>
       {authenticated ? (
-        <Link to={'#rocketChat'}>
+        <StyledLink to={SEARCH_SOURCE_CONTENT[SEARCH_SOURCES.rocketchat].id} offset={scrollOffset}>
           <RCButton title="Click to jump to rocket chat search results" />
-        </Link>
+        </StyledLink>
       ) : (
         <RCButton {...iconProps} title="Login to view rocket chat search results" />
       )}
       {authenticated ? (
-        <Link to={'#github'}>
+        <StyledLink to={SEARCH_SOURCE_CONTENT[SEARCH_SOURCES.github].id} offset={scrollOffset}>
           <GithubButton title="Click to jump to Github search results" />
-        </Link>
+        </StyledLink>
       ) : (
         <GithubButton {...iconProps} title="Login to view Github search results" />
       )}


### PR DESCRIPTION
## Summary
Based off of issue #899, we found it necessary to change the anchor links to the containers that contained external search results to a programmatic scroll.

## Notable Changes <!-- if any -->
- Integrated React Scroll
- Removed some old packages that weren't being used

Fixes #899 #941 
