### PR TITLE
Add SecOps docs to index

### DIFF
--- a/app-web/registry/information-and-application-security.json
+++ b/app-web/registry/information-and-application-security.json
@@ -32,17 +32,6 @@
         }
       },
       {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/BC-Policy-Framework-For-GitHub",
-          "owner": "bcgov",
-          "repo": "BC-Policy-Framework-For-GitHub",
-          "files": [
-            "BC-Open-Source-Development-Employee-Guide/Security.md"
-          ]
-        }
-      },
-      {
         "sourceType": "web",
         "sourceProperties": {
           "title": "BC Gov Digital Security",
@@ -61,7 +50,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/BCDevOps/platform-services/tree/master/security/aporeto/docs",
+          "url": "https://github.com/BCDevOps/platform-services",
           "owner": "BCDevOps",
           "repo": "platform-services",
           "files": [

--- a/app-web/registry/information-and-application-security.json
+++ b/app-web/registry/information-and-application-security.json
@@ -65,10 +65,10 @@
           "owner": "BCDevOps",
           "repo": "platform-services",
           "files": [
-            "README.md",
-            "QuickStart.md",
-            "ExternalNetworks.md",
-            "CustomPolicy.md"
+            "security/aporeto/docs/README.md",
+            "security/aporeto/docs/QuickStart.md",
+            "security/aporeto/docs/ExternalNetworks.md",
+            "security/aporeto/docs/CustomPolicy.md"
           ]
         }
       }

--- a/app-web/registry/information-and-application-security.json
+++ b/app-web/registry/information-and-application-security.json
@@ -32,6 +32,17 @@
         }
       },
       {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "https://github.com/bcgov/BC-Policy-Framework-For-GitHub",
+          "owner": "bcgov",
+          "repo": "BC-Policy-Framework-For-GitHub",
+          "files": [
+            "BC-Open-Source-Development-Employee-Guide/Security.md"
+          ]
+        }
+      },
+      {
         "sourceType": "web",
         "sourceProperties": {
           "title": "BC Gov Digital Security",
@@ -45,6 +56,20 @@
           "title": "Cloud Native Application Security",
           "description": "Application Security in a Cloud Native World.",
           "url": "https://raw.githubusercontent.com/bcgov/devhub-resources/master/resources/security/BCGov-DevSecOps-Project.pdf"
+        }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "https://github.com/BCDevOps/platform-services/tree/master/security/aporeto/docs",
+          "owner": "BCDevOps",
+          "repo": "platform-services",
+          "files": [
+            "README.md",
+            "QuickStart.md",
+            "ExternalNetworks.md",
+            "CustomPolicy.md"
+          ]
         }
       }
     ]


### PR DESCRIPTION
## Summary
Add the Platform Services documentation for teams to use to create secure, Zero Trust, networks.

## Notable Changes

- Add to information and application security index.