### PR TITLE
fix bug where create issue link wouldn't work on dynamic pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,4 +117,4 @@ app-web/registry/registry.json
 
 # root level package json (for now)
 package-lock.json
-cypress/videos
+app-web/cypress/videos

--- a/app-web/cypress/integration/DynamicTopic/index.spec.js
+++ b/app-web/cypress/integration/DynamicTopic/index.spec.js
@@ -1,0 +1,14 @@
+describe('Dynamic Topic Specs', () => {
+  describe('Arriving on the popular page', () => {
+    it('has a github issue link at the bottom of the first page', () => {
+      cy.visit('/');
+      cy.getByTestId('topic-Popular').click();
+      cy.log('checking url matches');
+      cy.url().should('contain', '/topic/popular');
+      cy.log('finding create issue link');
+      cy.getByTestId('actions-issue')
+        .should('have.attr', 'href')
+        .and('match', /https:\/\/(www\.)?github.com\/bcgov\/\w+/);
+    });
+  });
+});

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -15968,9 +15968,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/app-web/src/components/GithubTemplate/Actions/Actions.js
+++ b/app-web/src/components/GithubTemplate/Actions/Actions.js
@@ -28,7 +28,7 @@ const LI = styled.li`
   }
 `;
 
-export const IDS = {
+export const TEST_IDS = {
   issue: 'actions-issue',
 };
 
@@ -36,7 +36,7 @@ const Actions = ({ repo, owner, pageTitle, originalSource, devhubPath }) => (
   <Container>
     <LI>
       <Link
-        id={IDS.issue}
+        data-testid={TEST_IDS.issue}
         to={getCannedIssueMessage(repo, owner, pageTitle, originalSource, devhubPath)}
         aria-label="create an issue for this page on github"
       >

--- a/app-web/src/components/TopicPreview/TopicPreview.js
+++ b/app-web/src/components/TopicPreview/TopicPreview.js
@@ -82,7 +82,9 @@ const TopicPreview = ({ title, description, link, resources, ...rest }) => (
     <TopicPreviewContainer>
       <CardHeader resourceType={TOPICS} />
       <TopicTitle clamp={2}>
-        <TitleLink to={link.to}>{title}</TitleLink>
+        <TitleLink to={link.to} data-testid={`topic-${title}`}>
+          {title}
+        </TitleLink>
       </TopicTitle>
       {description && <TopicDescription clamp={3}>{description}</TopicDescription>}
       <CardCarousel resources={resources} />

--- a/app-web/src/pages/topic.js
+++ b/app-web/src/pages/topic.js
@@ -106,7 +106,8 @@ export const TopicPage = ({ data, location }) => {
         components: { 'component-preview': previewWithNode },
       }).Compiler;
 
-      const [owner, repo] = node.html_url.replace('https://github.com/').split('/');
+      const [owner, repo] = node.html_url.replace('https://github.com/', '').split('/');
+
       resourceComponent = (
         <MarkdownBody>
           {' '}


### PR DESCRIPTION
## Summary

Popular and Featured Topic pages would have a buggy 'create issue' link that would lead to a 404 page on github.  This has been resolved and some cypress tests were added to assert this. 
