### PR TITLE
Deprecate DevhubTopic Node

### DIFF
--- a/app-web/__tests__/gatsby/validators.test.js
+++ b/app-web/__tests__/gatsby/validators.test.js
@@ -1,6 +1,5 @@
 import {
   isMarkdownRemark,
-  isDevhubTopic,
   isDevhubSiphon,
   isEventbriteEvents,
   isGithubRaw,
@@ -17,9 +16,6 @@ describe('Validators', () => {
     test('they return true when valid', () => {
       expect(isMarkdownRemark(node('MarkdownRemark'))).toBe(true);
       expect(isMarkdownRemark(node('MarkdownRemark2'))).toBe(false);
-
-      expect(isDevhubTopic(node('DevhubTopic'))).toBe(true);
-      expect(isDevhubTopic(node('DevhubTopic2'))).toBe(false);
 
       expect(isDevhubSiphon(node('DevhubSiphon'))).toBe(true);
       expect(isDevhubSiphon(node('DevhubSiphon2'))).toBe(false);

--- a/app-web/__tests__/pages/Index.test.js
+++ b/app-web/__tests__/pages/Index.test.js
@@ -80,7 +80,7 @@ describe('Home Page', () => {
       allGithubRaw: {
         edges: githubRaw,
       },
-      allDevhubTopic: {
+      allTopicRegistryJson: {
         edges: topics,
       },
       allEventbriteEvents: {

--- a/app-web/__tests__/pages/topics.test.js
+++ b/app-web/__tests__/pages/topics.test.js
@@ -25,7 +25,7 @@ describe('Topics Container', () => {
       allDevhubSiphon: {
         edges: nodes,
       },
-      allDevhubTopic: {
+      allTopicRegistryJson: {
         edges: topics,
       },
       allEventbriteEvents: {

--- a/app-web/__tests__/utils/__snapshots__/selectors.test.js.snap
+++ b/app-web/__tests__/utils/__snapshots__/selectors.test.js.snap
@@ -262,6 +262,7 @@ Array [
           },
           "id": "8257de0d-811b-58dd-9fae-661f13d5a11b",
           "name": "README.md",
+          "path": "/Design-System/bar",
         },
       ],
       "Documentation": Array [
@@ -296,6 +297,7 @@ Array [
           },
           "id": "8257de0d-811b-58dd-9fae-661f13d5a11b",
           "name": "README.md",
+          "path": "/Design-System/foo",
         },
       ],
       "Events": Array [],
@@ -544,6 +546,7 @@ Array [
           },
           "id": "8257de0d-811b-58dd-9fae-661f13d5a11b",
           "name": "README.md",
+          "path": "/Devhub/bar",
         },
       ],
       "Documentation": Array [
@@ -578,6 +581,7 @@ Array [
           },
           "id": "8257de0d-811b-58dd-9fae-661f13d5a11b",
           "name": "README.md",
+          "path": "/Devhub/foo",
         },
       ],
       "Events": Array [],

--- a/app-web/gatsby-config.js
+++ b/app-web/gatsby-config.js
@@ -99,11 +99,11 @@ module.exports = {
     title: 'DevHub',
   },
   mapping: {
-    'GithubRaw.fields.topics': 'DevhubTopic.name',
-    'DevhubSiphon.fields.topics': 'DevhubTopic.name',
-    // 'DevhubTopic.fields.content': 'MarkdownRemark.fields.id', // topic page content mapping
-    'DevhubTopic.fields.githubRaw': 'GithubRaw.id',
-    'journeyRegistryJson.name': 'MarkdownRemark.frontmatter.id',
+    'GithubRaw.fields.topics': 'TopicRegistryJson.name',
+    'DevhubSiphon.fields.topics': 'TopicRegistryJson.name',
+    // 'devhubRegistryJson.fields.content': 'MarkdownRemark.fields.id', // topic page content mapping
+    // 'TopicRegistryJson.fields.githubRaw': 'GithubRaw.id',
+    // 'JourneyRegistryJson.name': 'MarkdownRemark.frontmatter.id',
   },
   pathPrefix: '/images',
   plugins: [

--- a/app-web/gatsby/createPages.js
+++ b/app-web/gatsby/createPages.js
@@ -49,7 +49,7 @@ const resolvePath = path => resolve(__dirname, path);
 const createResourceInTopicsPages = (node, createPage) => {
   node.fields.pagePaths.forEach((path, ind) => {
     const topic = node.fields.topics[ind];
-    const template = getTemplate(topic._metadata.template, topic._metadata.templateFile);
+    const template = getTemplate(topic.fields.template);
 
     createPage({
       path: `${path}`,
@@ -205,9 +205,8 @@ const createResourceTopicsPages = async (createPage, graphql) => {
               pagePaths
               topics {
                 id
-                _metadata {
+                fields {
                   template
-                  templateFile
                 }
               }
             }

--- a/app-web/gatsby/createResolvers.js
+++ b/app-web/gatsby/createResolvers.js
@@ -61,7 +61,7 @@ module.exports = ({ createResolvers }) => {
         },
       },
     },
-    DevhubTopic: {
+    TopicRegistryJson: {
       connectsWith: {
         // a list of nodes only really needs pointers to the page paths and a title for a link
         type: '[ConnectedNode]',

--- a/app-web/gatsby/createSchemaCustomization.js
+++ b/app-web/gatsby/createSchemaCustomization.js
@@ -22,6 +22,7 @@ module.exports = ({ actions }) => {
       tags: [String]
       path: String
       resourceType: String
+      standAlonePath: String
     }
     type ConnectedStopNode {
       fields: ConnectedNodeFieldSet

--- a/app-web/gatsby/onCreateNode.js
+++ b/app-web/gatsby/onCreateNode.js
@@ -22,7 +22,6 @@ const visit = require('unist-util-visit');
 const remark = require('remark');
 const { RESOURCE_TYPES, PERSONAS_LIST } = require('../src/constants/ui');
 const {
-  isDevhubTopic,
   isDevhubSiphon,
   isMarkdownRemark,
   isGithubRaw,
@@ -69,21 +68,15 @@ module.exports = ({ node, actions, getNode, getNodes }) => {
     createNodeField({ node, name: 'slug', value: slugify(node.name) });
   }
 
-  if (isDevhubTopic(node)) {
+  if (isTopicRegistryJson(node)) {
     // add a content field that the markdown topics will map too
     createNodeField({ node, name: 'content', value: node.name });
     // to help with page path creation, we adapt a slug from the collection/topic name
     // because collections/topics are held within this repo they SHOULD be unique
     createNodeField({ node, name: 'slug', value: slugify(node.name) });
-
-    const ghRawNodes = getNodes().filter(isGithubRaw);
-
-    // bind gh raw nodes that match this topic
-    const nodesThatHaveTopic = ghRawNodes
-      .filter(n => n.___boundProperties.topics.includes(node.name))
-      .map(n => n.id);
-
-    createNodeField({ node, name: 'githubRaw', value: nodesThatHaveTopic });
+    createNodeField({ node, name: 'title', value: node.name });
+    createNodeField({ node, name: 'description', value: node.description });
+    createNodeField({ node, name: 'template', value: node.template ? node.template : 'default' });
   }
 
   if (isDevhubSiphon(node)) {

--- a/app-web/gatsby/utils/validators.js
+++ b/app-web/gatsby/utils/validators.js
@@ -22,7 +22,6 @@ const { RESOURCE_TYPES_LIST } = require('../../src/constants/ui');
 const isGithubRaw = node => node.internal.type === 'GithubRaw';
 const isMarkdownRemark = node => node.internal.type === 'MarkdownRemark';
 const isDevhubSiphon = node => node.internal.type === 'DevhubSiphon';
-const isDevhubTopic = node => node.internal.type === 'DevhubTopic';
 const isMeetupEvent = node => node.internal.type === 'MeetupEvent';
 const isEventbriteEvents = node => node.internal.type === 'EventbriteEvents';
 const isTopicRegistryJson = node => node.internal.type === 'TopicRegistryJson';
@@ -98,7 +97,6 @@ module.exports = {
   isMarkdownRemark,
   isMarkdownRemarkFrontmatter,
   isDevhubSiphon,
-  isDevhubTopic,
   isEventbriteEvents,
   isTopicRegistryJson,
   isJourneyRegistryJson,

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.itest.js
@@ -50,7 +50,6 @@ describe('Integration Tests Source Nodes', () => {
 
     const createNodeId = jest.fn(() => 1);
     const getNodes = jest.fn(() => GRAPHQL_NODES_WITH_REGISTRY);
-    const topics = await sourceNodes({ actions, createNodeId, getNodes }, CONFIG_OPTIONS);
-    expect(topics).toBeDefined();
+    await sourceNodes({ actions, createNodeId, getNodes }, CONFIG_OPTIONS);
   });
 });

--- a/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/sourceNodes.test.js
@@ -388,7 +388,9 @@ describe('gatsby source github all plugin', () => {
     expect(node.id).toBeDefined();
   });
 
-  test('returns a topic object', async () => {
+  // eslint-disable-next-line no-console
+  console.log('skipping SourceNodes.topicObject test, this feature is deprecated');
+  test.skip('returns a topic object', async () => {
     const createNodeId = jest.fn(() => 1);
     const createNode = jest.fn(node => node);
     const createParentChildLink = jest.fn();
@@ -440,7 +442,8 @@ describe('gatsby source github all plugin', () => {
     // fetch from source returns a single web source node
     // in total only 1 resource was returned from all sources fetched for the fixtured topic
     // therefor the createparent child link should only be called once
-    expect(createParentChildLink).toHaveBeenCalledTimes(1);
+    // expect(createParentChildLink).toHaveBeenCalledTimes(1);
+    // TOPICS NO LONGER CREATED BY THIS PLUGIN !
   });
 
   test('getContentForTopic returns data', async () => {

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -17,7 +17,7 @@
 //
 // Created by Patrick Simonian on 2018-10-12.
 //
-const { isArray, isString, every, flatten, isEmpty, isPlainObject } = require('lodash');
+const { isArray, isString, every, isPlainObject } = require('lodash');
 const slugify = require('slugify');
 const {
   hashString,
@@ -39,7 +39,7 @@ const {
   TOPIC_TEMPLATES_LIST,
   TOPIC_SOURCE,
 } = require('./utils/constants');
-const { createSiphonNode, createTopicNode } = require('./utils/createNode');
+const { createSiphonNode } = require('./utils/createNode');
 const Store = require('./utils/Store');
 const {
   getRegistry,
@@ -297,27 +297,27 @@ const processTopic = async (topic, createNodeId, createNode, createParentChildLi
   // id for topic node
   const id = createNodeId(hash);
   // fetch all sources
-  const sourceNodes = await Promise.all(
+  await Promise.all(
     topic.sources.map(source => processSource(source, createNodeId, createNode, tokens, id)),
   );
 
-  let topicContent;
-  // fetch a github file if has topic source
-  if (!isEmpty(topic.topicSource)) {
-    topicContent = await getContentForTopic(topic.topicSource, tokens, topic.name);
-  }
-  // flatten source nodes to get a list of all the resources
-  const resources = flatten(sourceNodes, true);
-  // create a hash map of all resources: resource paths original source against the path created
-  // for a gatsby page
-  topic.sourceLocations = resources.map(r => [r.resource.originalSource, r.resource.path]);
+  // let topicContent;
+  // // fetch a github file if has topic source
+  // if (!isEmpty(topic.topicSource)) {
+  //   topicContent = await getContentForTopic(topic.topicSource, tokens, topic.name);
+  // }
+  // // flatten source nodes to get a list of all the resources
+  // const resources = flatten(sourceNodes, true);
+  // // create a hash map of all resources: resource paths original source against the path created
+  // // for a gatsby page
+  // topic.sourceLocations = resources.map(r => [r.resource.originalSource, r.resource.path]);
 
-  const topicNode = createTopicNode(topic, id, topicContent);
+  // const topicNode = createTopicNode(topic, id, topicContent);
 
-  await createNode(topicNode);
-  resources.forEach(r => createParentChildLink({ parent: topicNode, child: r }));
-  // establish a parent child link between all resources and the topic node
-  return topicNode;
+  // await createNode(topicNode);
+  // resources.forEach(r => createParentChildLink({ parent: topicNode, child: r }));
+  // // establish a parent child link between all resources and the topic node
+  // return topicNode;
 };
 
 /**
@@ -340,13 +340,11 @@ const sourceNodes = async ({ getNodes, actions, createNodeId }, { tokens, source
     const regWithIds = applyInferredIdToSources(expandedReg);
     // map of over registry and create a queue of topics to fetch
     const fetchQueue = await getFetchQueue(regWithIds, tokens);
-    const topics = await Promise.all(
+    await Promise.all(
       fetchQueue.map(async topic =>
         processTopic(topic, createNodeId, createNode, createParentChildLink, tokens),
       ),
     );
-
-    return topics;
   } catch (e) {
     // failed to retrieve files or some other type of failure
     // eslint-disable-next-line

--- a/app-web/src/hoc/Layout.js
+++ b/app-web/src/hoc/Layout.js
@@ -79,6 +79,8 @@ export const query = graphql`
       resourceType
       title
       description
+      standAlonePath
+      path
     }
     id
   }

--- a/app-web/src/hoc/withResourceQuery.js
+++ b/app-web/src/hoc/withResourceQuery.js
@@ -83,47 +83,14 @@ const withResourceQuery = WrappedComponent => () => props => (
             }
           }
         }
-        allDevhubTopic {
+        allTopicRegistryJson {
           edges {
             node {
               id
               name
               description
-              fields {
-                githubRaw {
-                  id
-                  fields {
-                    resourceType
-                    title
-                    description
-                    image
-                    slug
-                  }
-                }
-              }
               connectsWith {
                 ...DevhubNodeConnection
-              }
-              childrenDevhubSiphon {
-                id
-                resource {
-                  type
-                  path
-                }
-                _metadata {
-                  position
-                }
-                unfurl {
-                  title
-                  description
-                  image
-                }
-                fields {
-                  resourceType
-                  pagePaths
-                  title
-                  description
-                }
               }
             }
           }

--- a/app-web/src/pages/index.js
+++ b/app-web/src/pages/index.js
@@ -153,7 +153,7 @@ export const TEST_IDS = {
 export const Index = ({
   client,
   data: {
-    allDevhubTopic,
+    allTopicRegistryJson,
     allDevhubSiphon,
     allEventbriteEvents,
     allMarkdownRemark,
@@ -228,7 +228,7 @@ export const Index = ({
     (!results || (results.length === 0 && windowHasQuery)) &&
     isEmpty(searchSourceResults);
 
-  const topics = flattenGatsbyGraphQL(allDevhubTopic.edges);
+  const topics = flattenGatsbyGraphQL(allTopicRegistryJson.edges);
   const journeys = flattenGatsbyGraphQL(allJourneyRegistryJson.edges);
   const githubRaw = flattenGatsbyGraphQL(allGithubRaw.edges);
   const devhubSiphon = flattenGatsbyGraphQL(allDevhubSiphon.edges);

--- a/app-web/src/pages/topics.js
+++ b/app-web/src/pages/topics.js
@@ -26,7 +26,7 @@ import Layout from '../hoc/Layout';
 import { getFirstNonExternalResource } from '../utils/helpers';
 
 export const TopicsPage = ({ data }) => {
-  let topics = flattenGatsbyGraphQL(data.allDevhubTopic.edges);
+  let topics = flattenGatsbyGraphQL(data.allTopicRegistryJson.edges);
   // resources are grouped by type, 'ungroup' them so we can find the first available
   // non external link to use as the entry page for the topic card
   return (

--- a/app-web/src/templates/SourceGithub_default.js
+++ b/app-web/src/templates/SourceGithub_default.js
@@ -125,11 +125,11 @@ export const devhubSiphonMarkdown = graphql`
         pagePaths
       }
     }
-    topic: devhubTopic(id: { eq: $topicId }) {
+    topic: topicRegistryJson(id: { eq: $topicId }) {
       name
       description
     }
-    nav: devhubTopic(id: { eq: $topicId }) {
+    nav: topicRegistryJson(id: { eq: $topicId }) {
       items: connectsWith {
         ...DevhubNodeConnection
       }

--- a/app-web/src/templates/SourceGithub_overview.js
+++ b/app-web/src/templates/SourceGithub_overview.js
@@ -122,11 +122,11 @@ export const githubRawMarkdown = graphql`
         pagePaths
       }
     }
-    topic: devhubTopic(id: { eq: $topicId }) {
+    topic: topicRegistryJson(id: { eq: $topicId }) {
       name
       description
     }
-    nav: devhubTopic(id: { eq: $topicId }) {
+    nav: topicRegistryJson(id: { eq: $topicId }) {
       items: connectsWith {
         ...DevhubNodeConnection
       }

--- a/app-web/src/templates/events.js
+++ b/app-web/src/templates/events.js
@@ -67,7 +67,7 @@ export const formatMeetUps = meetups => {
   });
 };
 
-export const EventsPage = ({ data: { allEventbriteEvents, allDevhubTopic } }) => {
+export const EventsPage = ({ data: { allEventbriteEvents, allTopicRegistryJson } }) => {
   const events = flattenGatsbyGraphQL(allEventbriteEvents.edges);
   /*const meetUps = formatMeetUps(
     flattenGatsbyGraphQL(allMeetupGroup.edges).flatMap(meetups => {
@@ -78,12 +78,12 @@ export const EventsPage = ({ data: { allEventbriteEvents, allDevhubTopic } }) =>
   const currentEvents = formatEvents(events.filter(e => e.start.daysFromNow <= 0));
   //const currentMeetups = meetUps.filter(e => e.start.daysFromNow <= 0);
   //Get all the cards on the site
-  const cards = flattenGatsbyGraphQL(allDevhubTopic.edges);
+  const cards = flattenGatsbyGraphQL(allTopicRegistryJson.edges);
   //filter to just get the cards for the Community and Events topic
   const communityCards = cards
     .filter(e => e.name === TOPICS.COMMUNITY_AND_EVENTS)
-    .flatMap(e => e.childrenDevhubSiphon)
-    .filter(e => e.resource.type === RESOURCE_TYPES.EVENTS);
+    .flatMap(e => e.connectsWith)
+    .filter(e => e.fields.resourceType === RESOURCE_TYPES.EVENTS);
   //sort all the info so that event show up from soonest to farthest away
   const currentEventsMeetUpsAndCards = communityCards.concat(
     currentEvents.sort((a, b) => b.start.daysFromNow - a.start.daysFromNow),
@@ -217,40 +217,14 @@ export const EventData = graphql`
     # }
     # }
     # }
-    allDevhubTopic {
+    allTopicRegistryJson {
       edges {
         node {
           id
           name
           description
-          resources: childrenDevhubSiphon {
-            id
-          }
-          childrenDevhubSiphon {
-            id
-            resource {
-              type
-              path
-            }
-            fields {
-              standAlonePath
-            }
-            _metadata {
-              position
-            }
-            unfurl {
-              title
-              description
-              image
-            }
-            fields {
-              resourceType
-              standAlonePath
-              pagePaths
-              image
-              title
-              description
-            }
+          connectsWith {
+            ...DevhubNodeConnection
           }
         }
       }

--- a/app-web/src/utils/selectors.js
+++ b/app-web/src/utils/selectors.js
@@ -55,7 +55,7 @@ export const selectTopicsWithResourcesGroupedByType = () =>
         // so that all topics have all resource type groups
         const selector = selectResourcesGroupedByType();
 
-        const groups = selector(topic.fields.githubRaw);
+        const groups = selector(topic.connectsWith);
         return {
           ...topic,
           resources: groups,


### PR DESCRIPTION
## Summary
The DevhubTopic node is one of the last remaining remnants of the monolithic plugin for devhub siphon
## Notable Changes <!-- if any -->
- removed dehubtopic and leveraged the topic registry file just the same as the journey registry. 
- updated tests
- improved site performance? 
