### PR TITLE
Update nr repo name in registry

### DIFF
--- a/app-web/topicRegistry/community-contributed.json
+++ b/app-web/topicRegistry/community-contributed.json
@@ -154,8 +154,8 @@
             "generation"
         ],
         "sourceProperties":{
-            "url":"https://github.com/bcgov/nr-document-generation-showcase",
-            "repo":"nr-document-generation-showcase",
+            "url":"https://github.com/bcgov/document-generation-showcase",
+            "repo":"document-generation-showcase",
             "owner":"bcgov",
             "files":[
                 "docs/overview.md",


### PR DESCRIPTION
## Summary
The repo `nr-document-generation-showcase` was changed to `document-generation-showcase` which was causing failures to build. 

@sheaphillips should we make the devhub fault tolerant to this type of issue?
