### PR TITLE
Make dynamic topic page client side loading

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,10 +2,12 @@
 root /var/www/html
 log stdout
 errors stdout
+
 rewrite {
-  if  {path} not_match ^\/0.0.0.0
-  to  {path} {path}/ /?_url={uri}
+  re ^\/topic(\/\w+)+
+  to /topic/index.html
 }
+
 templates {
   ext   .js
 }

--- a/app-web/gatsby/onCreatePage.js
+++ b/app-web/gatsby/onCreatePage.js
@@ -16,21 +16,13 @@ limitations under the License.
 Created by Patrick Simonian
 */
 
-// const { FILTER_BASE_ROUTE } = require('../src/constants/routes');
-// the above declaration is to identify the actual constants where FILTER_BASE_ROUTE
-// should be coming from. At this time, there is no babel transpilation of this file or gatsby-node.js
-// and so requiring from an es6+ file (such as src/constants/routes) will fail.
-// until the time this issue is resolved, we are declaring the filter base route here in the interim.
-const FILTER_BASE_ROUTE = '/resources';
-
 module.exports = async ({ page, actions }) => {
   const { createPage } = actions;
-  const re = new RegExp(`^${FILTER_BASE_ROUTE}`);
   // check if page that's being created matches the filter base routes
   // which is intended for client side loading only
   // https://github.com/gatsbyjs/gatsby/blob/v1/docs/docs/building-apps-with-gatsby.md#client-only-routes--user-authentication
-  if (page.path.match(re)) {
-    page.matchPath = `${FILTER_BASE_ROUTE}/:resource_type`;
+  if (page.path.match(/^\/topic/)) {
+    page.matchPath = `/topic/:topicType/:resource`;
     createPage(page);
   }
 };

--- a/app-web/gatsby/onCreatePage.js
+++ b/app-web/gatsby/onCreatePage.js
@@ -21,8 +21,10 @@ module.exports = async ({ page, actions }) => {
   // check if page that's being created matches the filter base routes
   // which is intended for client side loading only
   // https://github.com/gatsbyjs/gatsby/blob/v1/docs/docs/building-apps-with-gatsby.md#client-only-routes--user-authentication
-  if (page.path.match(/^\/topic/)) {
-    page.matchPath = `/topic/:topicType/:resource`;
+  // only match /topic/ not /topics/
+
+  if (page.path.match(/^\/topic(?!s)/)) {
+    page.matchPath = `/topic/*`;
     createPage(page);
   }
 };

--- a/app-web/src/pages/topic.js
+++ b/app-web/src/pages/topic.js
@@ -31,6 +31,9 @@ import {
 import withResourceQuery from '../hoc/withResourceQuery';
 
 export const TopicPage = ({ data, location, ...rest }) => {
+  // props contains '*' as a property which matches our pageMatch property as assigned from
+  // gatsby/onCreatePage.js
+  // this would amount to /:topicType/:resource
   const [topicType, resource] = rest['*'].split('/');
 
   const [menuToggled, setMenuToggled] = useState(false);

--- a/app-web/src/pages/topic.js
+++ b/app-web/src/pages/topic.js
@@ -30,7 +30,9 @@ import {
 } from '../components/GithubTemplate/common';
 import withResourceQuery from '../hoc/withResourceQuery';
 
-export const TopicPage = ({ data, location, topicType, resource, ...rest }) => {
+export const TopicPage = ({ data, location, ...rest }) => {
+  const [topicType, resource] = rest['*'].split('/');
+
   const [menuToggled, setMenuToggled] = useState(false);
   const entryPages = {
     [DYNAMIC_TOPIC_PATHS.featured]: <Featured />,
@@ -51,6 +53,7 @@ export const TopicPage = ({ data, location, topicType, resource, ...rest }) => {
   let resourceComponent = null;
   let topicMetadata = {};
   let topicObj = {};
+
   if (!DYNAMIC_TOPIC_PATHS[topicType]) {
     return navigateFn('404');
   }

--- a/app-web/src/pages/topic.js
+++ b/app-web/src/pages/topic.js
@@ -30,7 +30,7 @@ import {
 } from '../components/GithubTemplate/common';
 import withResourceQuery from '../hoc/withResourceQuery';
 
-export const TopicPage = ({ data, location }) => {
+export const TopicPage = ({ data, location, topicType, resource, ...rest }) => {
   const [menuToggled, setMenuToggled] = useState(false);
   const entryPages = {
     [DYNAMIC_TOPIC_PATHS.featured]: <Featured />,
@@ -41,7 +41,7 @@ export const TopicPage = ({ data, location }) => {
   const navigateFn = global.window ? navigate : () => null;
   const query = queryString.parse(location.search);
   const nodes = flattenGatsbyGraphQL(data.allGithubRaw.edges);
-  const [topic, topicType, resource] = location.pathname.replace(/^\/|\/$/, '').split('/');
+  // const [topic, topicType, resource] = location.pathname.replace(/^\/|\/$/, '').split('/');
   // // if ?viewResource=0 then auto navigate to the given resource with that index
   // // this is in place so that topic entry pages can provide a means to link to a given resource from within the topic
   const shouldAutoNavigate = query.viewResource && isInteger(query.viewResource / 1);
@@ -136,7 +136,7 @@ export const TopicPage = ({ data, location }) => {
         <SidePanel>{navigationComponent}</SidePanel>
         <SideDrawerToggleButton onClick={() => setMenuToggled(true)}>
           <FontAwesomeIcon icon={faBars} style={{ color: '#026' }} />{' '}
-          <span>{topic.name} Content</span>
+          <span>{topicMetadata.name} Content</span>
         </SideDrawerToggleButton>
         {resourceComponent}
       </Main>

--- a/app-web/src/pages/topic.js
+++ b/app-web/src/pages/topic.js
@@ -132,6 +132,8 @@ export const TopicPage = ({ data, location, ...rest }) => {
           />
         </MarkdownBody>
       );
+    } else {
+      navigateFn('404');
     }
   }
 

--- a/openshift/templates/caddyfile.configmap.yaml
+++ b/openshift/templates/caddyfile.configmap.yaml
@@ -21,6 +21,12 @@ objects:
         if  {path} not_match ^\/0.0.0.0
         to  {path} {path}/ /?_url={uri}
       }
+      
+      rewrite {
+        regexp ^\/topic\/\w+(\/\w+){0,}
+        to {path} {path}/ /topic/
+      }
+
       templates {
         ext   .js
       }

--- a/openshift/templates/caddyfile.configmap.yaml
+++ b/openshift/templates/caddyfile.configmap.yaml
@@ -19,7 +19,7 @@ objects:
       errors stdout
       
       rewrite {
-        regexp ^\/topic\/\w+(\/\w+){0,}
+        regexp ^\/topic(\/[\w|\-|\_|~|\.]+)+
         to {path} {path}/ /topic/
       }
 

--- a/openshift/templates/caddyfile.configmap.yaml
+++ b/openshift/templates/caddyfile.configmap.yaml
@@ -17,10 +17,6 @@ objects:
       root /var/www/html
       log stdout
       errors stdout
-      rewrite {
-        if  {path} not_match ^\/0.0.0.0
-        to  {path} {path}/ /?_url={uri}
-      }
       
       rewrite {
         regexp ^\/topic\/\w+(\/\w+){0,}

--- a/openshift/templates/dc.yaml
+++ b/openshift/templates/dc.yaml
@@ -13,10 +13,6 @@ objects:
       root /var/www/html
       log stdout
       errors stdout
-      rewrite {
-        if  {path} not_match ^\/0.0.0.0
-        to  {path} {path}/ /?_url={uri}
-      }
       
       rewrite {
         regexp ^\/topic\/\w+(\/\w+){0,}

--- a/openshift/templates/dc.yaml
+++ b/openshift/templates/dc.yaml
@@ -17,11 +17,16 @@ objects:
         if  {path} not_match ^\/0.0.0.0
         to  {path} {path}/ /?_url={uri}
       }
+      
+      rewrite {
+        regexp ^\/topic\/\w+(\/\w+){0,}
+        to {path} {path}/ /topic/
+      }
 
       templates {
         ext   .js
       }
-      gzip
+
       # gatsby_cache_control
       # https://www.gatsbyjs.org/docs/caching/
       header / {

--- a/openshift/templates/dc.yaml
+++ b/openshift/templates/dc.yaml
@@ -13,9 +13,9 @@ objects:
       root /var/www/html
       log stdout
       errors stdout
-      
+
       rewrite {
-        regexp ^\/topic\/\w+(\/\w+){0,}
+        regexp ^\/topic(\/[\w|\-|\_|~|\.]+)+
         to {path} {path}/ /topic/
       }
 


### PR DESCRIPTION
## Summary

I found out that the dynamic topic page was not truly client side loading. This has been enabled so that page paths from `/topic/:topicType/:resource` can be parameterized. 

The reason for this change is an effort to fix the unknown css bug that affects the popular page on refresh. 

Fixes #1089 