### PR TITLE
chore: deprecate siphon getting github resources

### DIFF
--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -16641,9 +16641,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -22935,7 +22935,7 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
             "string-width": "^2.1.1",
@@ -22945,12 +22945,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -23186,11 +23186,6 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
           "version": "0.2.0",
@@ -23440,14 +23435,6 @@
           "resolved": false,
           "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
         },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
         "flush-write-stream": {
           "version": "1.0.3",
           "resolved": false,
@@ -23661,11 +23648,6 @@
             }
           }
         },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-        },
         "get-stream": {
           "version": "4.1.0",
           "resolved": false,
@@ -23801,8 +23783,7 @@
         },
         "https-proxy-agent": {
           "version": "2.2.2",
-          "resolved": false,
-          "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+          "resolved": "",
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -23887,9 +23868,9 @@
           }
         },
         "invert-kv": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
         },
         "ip": {
           "version": "1.1.5",
@@ -24076,11 +24057,11 @@
           "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
         },
         "lcid": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "^2.0.0"
           }
         },
         "libcipm": {
@@ -24267,15 +24248,6 @@
             "yargs": "^11.0.0"
           }
         },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
         "lock-verify": {
           "version": "2.1.0",
           "resolved": false,
@@ -24410,11 +24382,13 @@
           "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
         },
         "mem": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
           }
         },
         "mime-db": {
@@ -24431,9 +24405,9 @@
           }
         },
         "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "minimatch": {
           "version": "3.0.4",
@@ -24772,13 +24746,41 @@
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-locale": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "6.0.5",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+              "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            }
           }
         },
         "os-tmpdir": {
@@ -24799,27 +24801,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "package-json": {
           "version": "4.0.1",
@@ -25207,16 +25188,6 @@
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
           }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "resolve-from": {
           "version": "4.0.0",
@@ -25825,11 +25796,6 @@
             "isexe": "^2.0.0"
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-        },
         "wide-align": {
           "version": "1.1.2",
           "resolved": false,
@@ -25864,27 +25830,6 @@
           "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "requires": {
             "errno": "~0.1.7"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
           }
         },
         "wrappy": {
@@ -25923,15 +25868,15 @@
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         },
         "yargs": {
-          "version": "11.0.0",
-          "resolved": false,
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
+          "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
             "find-up": "^2.1.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.1.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
@@ -25943,14 +25888,14 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
               "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
             "camelcase": "^4.1.0"

--- a/app-web/plugins/gatsby-source-github-all/__tests__/fetchSource.test.js
+++ b/app-web/plugins/gatsby-source-github-all/__tests__/fetchSource.test.js
@@ -34,11 +34,6 @@ describe('Fetch Source Routine', () => {
     expect(fetchFromSource(invalidSource.sourceType, invalidSource, sourceOptions)).toEqual([]);
   });
 
-  test('fetch from source calls getFilesFromRepo if source type is github', () => {
-    fetchFromSource(GITHUB_SOURCE.sourceType, GITHUB_SOURCE, sourceOptions);
-    expect(fetchSourceGithub).toHaveBeenCalled();
-  });
-
   test('validateSourceGithub calls validatesourceGithub if source type is github', () => {
     validateSourceRegistry(GITHUB_SOURCE);
     expect(validateSourceGithub).toHaveBeenCalled();

--- a/app-web/plugins/gatsby-source-github-all/sourceNodes.js
+++ b/app-web/plugins/gatsby-source-github-all/sourceNodes.js
@@ -300,24 +300,10 @@ const processTopic = async (topic, createNodeId, createNode, createParentChildLi
   await Promise.all(
     topic.sources.map(source => processSource(source, createNodeId, createNode, tokens, id)),
   );
-
-  // let topicContent;
-  // // fetch a github file if has topic source
-  // if (!isEmpty(topic.topicSource)) {
-  //   topicContent = await getContentForTopic(topic.topicSource, tokens, topic.name);
-  // }
-  // // flatten source nodes to get a list of all the resources
-  // const resources = flatten(sourceNodes, true);
-  // // create a hash map of all resources: resource paths original source against the path created
-  // // for a gatsby page
-  // topic.sourceLocations = resources.map(r => [r.resource.originalSource, r.resource.path]);
-
-  // const topicNode = createTopicNode(topic, id, topicContent);
-
-  // await createNode(topicNode);
-  // resources.forEach(r => createParentChildLink({ parent: topicNode, child: r }));
-  // // establish a parent child link between all resources and the topic node
-  // return topicNode;
+  // process topic no longer creates DevhubTopic Nodes !
+  // this was removed to make this plugin less monolithic
+  // there was code right below this that processed the topic and created a node for it
+  // check out the github commits previous to this one to view
 };
 
 /**

--- a/app-web/plugins/gatsby-source-github-all/utils/fetchSource.js
+++ b/app-web/plugins/gatsby-source-github-all/utils/fetchSource.js
@@ -17,7 +17,7 @@ Created by Patrick Simonian
 */
 
 const { SOURCE_TYPES } = require('./constants');
-const { fetchSourceGithub, validateSourceGithub } = require('./sources/github');
+const { validateSourceGithub } = require('./sources/github');
 const { fetchSourceWeb, validateSourceWeb } = require('./sources/web');
 /**
  * maps to a fetch function for that sourceType,
@@ -26,10 +26,10 @@ const { fetchSourceWeb, validateSourceWeb } = require('./sources/web');
  * @param {Object} source  // source object as found in source regsitry
  * @param {Object} tokens // relevant API tokens needed to fetch from sources
  */
-const fetchFromSource = (sourceType, source, { GITHUB_API_TOKEN }) => {
+const fetchFromSource = (sourceType, source) => {
   switch (sourceType) {
-    case SOURCE_TYPES.GITHUB:
-      return fetchSourceGithub(source, GITHUB_API_TOKEN);
+    // this code used to fetch github sources, this has been removed in  favor of
+    // gatsby-source-github-raw
     case SOURCE_TYPES.WEB:
       return fetchSourceWeb(source);
     default:

--- a/app-web/src/hoc/withResourceQuery.js
+++ b/app-web/src/hoc/withResourceQuery.js
@@ -201,10 +201,7 @@ const withResourceQuery = WrappedComponent => () => props => (
                 type
               }
               source {
-                displayName
-                sourcePath
                 type
-                name
               }
               resource {
                 path
@@ -216,11 +213,6 @@ const withResourceQuery = WrappedComponent => () => props => (
                 type
                 image
                 author
-              }
-              childMarkdownRemark {
-                frontmatter {
-                  pageOnly
-                }
               }
             }
           }


### PR DESCRIPTION
## Summary
the dev hub siphon source plugin was still getting GitHub resources. This code has been removed. This will greatly reduce the search index size. 


