### PR TITLE
Added ExchangeLabOps markdown file to the dev hub docs page

### DIFF
--- a/app-web/topicRegistry/community-contributed.json
+++ b/app-web/topicRegistry/community-contributed.json
@@ -137,6 +137,15 @@
         }
     },
     {
+      "sourceType":"github",
+      "resourceType": "Documentation",
+      "sourceProperties":{
+      "url":"https://github.com/bcgov/ExchangeLabOps/tree/master/Resident-Teams",
+      "repo":"ExchangeLabOps",
+      "owner":"bcgov"
+      }
+    },
+    {
         "sourceType":"web",
         "sourceProperties":{
             "url":"https://apistore.nrs.gov.bc.ca/store/apis/info?version=v1&name=dms-api&provider=admin",

--- a/app-web/topicRegistry/community-contributed.json
+++ b/app-web/topicRegistry/community-contributed.json
@@ -142,7 +142,10 @@
       "sourceProperties":{
       "url":"https://github.com/bcgov/ExchangeLabOps/tree/master/Resident-Teams",
       "repo":"ExchangeLabOps",
-      "owner":"bcgov"
+      "owner":"bcgov",
+      "files": [
+        "README.md"
+      ]
       }
     },
     {

--- a/app-web/topicRegistry/community-contributed.json
+++ b/app-web/topicRegistry/community-contributed.json
@@ -144,7 +144,7 @@
       "repo":"ExchangeLabOps",
       "owner":"bcgov",
       "files": [
-        "blob/master/Resident-Teams/README.md"
+        "Resident-Teams/README.md"
       ]
       }
     },

--- a/app-web/topicRegistry/community-contributed.json
+++ b/app-web/topicRegistry/community-contributed.json
@@ -140,11 +140,11 @@
       "sourceType":"github",
       "resourceType": "Documentation",
       "sourceProperties":{
-      "url":"https://github.com/bcgov/ExchangeLabOps/tree/master/Resident-Teams",
+      "url":"https://github.com/bcgov/ExchangeLabOps",
       "repo":"ExchangeLabOps",
       "owner":"bcgov",
       "files": [
-        "README.md"
+        "blob/master/Resident-Teams/README.md"
       ]
       }
     },


### PR DESCRIPTION
## Summary
This should add the page, https://bcgov.github.io/ExchangeLabOps/Resident-Teams/README.html, to the Dev hub app.  I was not sure how to run the dev hub web app locally, so this change was *not* tested.

## Notable Changes <!-- if any -->
-
-
-
