### PR TITLE
install updated version of iam

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Cache node modules
       uses: actions/cache@v1
       with:
-        path: node_modules
+        path: app-web/node_modules
         key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.OS }}-build-${{ env.cache-name }}-

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -1171,9 +1171,9 @@
       }
     },
     "@bcgov/common-web-utils": {
-      "version": "1.0.6-1",
-      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-1.0.6-1.tgz",
-      "integrity": "sha512-An90j3MKMcUpHYroZDFshNufT2AW26h82U1a64RDigLEk2sDAVo1I2z1DATc8PVxRrfGopnTqoxIw+OpMIFR4w==",
+      "version": "1.0.6-2",
+      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-1.0.6-2.tgz",
+      "integrity": "sha512-571ArK2TmvkK3I5/8Mp/pC/yORr3GdI7SXexknVCtrqgaXMRe2LT1cAaNP1byZyhdHGzr6Yj+R1k2eB1z23e6g==",
       "requires": {
         "hash.js": "^1.1.7",
         "jwt-decode": "^2.2.0",

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -1171,9 +1171,9 @@
       }
     },
     "@bcgov/common-web-utils": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-1.0.5.tgz",
-      "integrity": "sha512-hTKyypj8pZ0HyHLYjEz+wVDnELcM70eqElmPHydnlm7KAkDy0LRbMV1q2vrAJPTq3IHNog4IzVIGYZz3hbnwXQ==",
+      "version": "1.0.6-0",
+      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-1.0.6-0.tgz",
+      "integrity": "sha512-6PP+SAEYZGRHvpEA4i61m5RwNQB6ku37pZKqxxF5Uq82GFbjN+u/+FB7SN+ljdcO10H+xd3CtgPq8qcLrHIzmg==",
       "requires": {
         "hash.js": "^1.1.7",
         "jwt-decode": "^2.2.0",

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -1171,9 +1171,9 @@
       }
     },
     "@bcgov/common-web-utils": {
-      "version": "1.0.6-0",
-      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-1.0.6-0.tgz",
-      "integrity": "sha512-6PP+SAEYZGRHvpEA4i61m5RwNQB6ku37pZKqxxF5Uq82GFbjN+u/+FB7SN+ljdcO10H+xd3CtgPq8qcLrHIzmg==",
+      "version": "1.0.6-1",
+      "resolved": "https://registry.npmjs.org/@bcgov/common-web-utils/-/common-web-utils-1.0.6-1.tgz",
+      "integrity": "sha512-An90j3MKMcUpHYroZDFshNufT2AW26h82U1a64RDigLEk2sDAVo1I2z1DATc8PVxRrfGopnTqoxIw+OpMIFR4w==",
       "requires": {
         "hash.js": "^1.1.7",
         "jwt-decode": "^2.2.0",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@apollo/react-hooks": "0.1.0-beta.11",
-    "@bcgov/common-web-utils": "^1.0.6-1",
+    "@bcgov/common-web-utils": "^1.0.6-2",
     "@brainhubeu/react-carousel": "^1.10.17",
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.11",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@apollo/react-hooks": "0.1.0-beta.11",
-    "@bcgov/common-web-utils": "^1.0.6-0",
+    "@bcgov/common-web-utils": "^1.0.6-1",
     "@brainhubeu/react-carousel": "^1.10.17",
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.11",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@apollo/react-hooks": "0.1.0-beta.11",
-    "@bcgov/common-web-utils": "^1.0.5",
+    "@bcgov/common-web-utils": "^1.0.6-0",
     "@brainhubeu/react-carousel": "^1.10.17",
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.11",


### PR DESCRIPTION
## Summary
The infinite redirect issue is happening in Safari. I believe this is because safari seems to strip hash fragments occasionally 🤔 

the latest version of `@bcgov/common-web-utils` counts redirects and bases logic on that count instead of implicitly through existance of certain hash fragments. 