### PR TITLE
Add OCPStorageServices.md link

### DIFF
--- a/app-web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/app-web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -69,7 +69,8 @@
             "docs/OCP/RequestUserAccess.md",
             "docs/OCP/RequestGitHubUserAccess.md",
             "docs/HowTo/GrantUsersAccessToProject.md",
-            "docs/OCP/Networking.md"
+            "docs/OCP/Networking.md",
+            "docs/OCP/OCPStorageServices.md"
           ]
         }
       },


### PR DESCRIPTION
## Summary
Adds an OCP Storage Services page for Platform storage documentation and links.

## Notable Changes
- new line in getting-started-on-devops-platform.json to add to index
