### PR TITLE
Fixing journey map view

### DIFF
--- a/app-web/src/components/Journey/SubwayLine.js
+++ b/app-web/src/components/Journey/SubwayLine.js
@@ -26,9 +26,12 @@ const Subway = styled.div`
   display: flex;
   position: relative;
   align-items: center;
-  padding: 130px 60px;
+  padding: 100px 60px;
   min-width: 615px;
   justify-content: space-between;
+  ${EMOTION_BOOTSTRAP_BREAKPOINTS.md} {
+    padding: 130px 60px;
+  }
 `;
 
 const Line = styled.div`


### PR DESCRIPTION
## Summary

The padding in mobile view was a bit too much. The padding was reduced for mobile views but kept the same for larger screens :fire:

Fixes #1115 