### PR TITLE
Add remove service worker pluginn

### DIFF
--- a/app-web/gatsby-config.js
+++ b/app-web/gatsby-config.js
@@ -107,6 +107,11 @@ module.exports = {
   },
   pathPrefix: '/images',
   plugins: [
+    // service worker has been causing very difficult to debug issues
+    // removal of it is necessary for the time being while users have old versions of sw.js
+    // cached on their browser. The date of this removal is around jan 24 2020 and we should aim
+    // to REMOVE this plugin in a month or two so that we can harness the benefits of having a sw
+    'gatsby-plugin-remove-serviceworker',
     {
       resolve: `gatsby-plugin-manifest`,
       options: {

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -15507,6 +15507,11 @@
         "@babel/runtime": "^7.7.6"
       }
     },
+    "gatsby-plugin-remove-serviceworker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz",
+      "integrity": "sha1-n7QzvIvXZuFOHTcRxKxvBR4d/3w="
+    },
     "gatsby-plugin-sharp": {
       "version": "2.3.13",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.3.13.tgz",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -43,6 +43,7 @@
     "gatsby-plugin-postcss": "^2.0.2",
     "gatsby-plugin-prefetch-google-fonts": "^1.4.2",
     "gatsby-plugin-react-helmet": "^3.1.16",
+    "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-plugin-sharp": "^2.0.37",
     "gatsby-plugin-typography": "^2.2.13",
     "gatsby-remark-autolink-headers": "^2.0.12",


### PR DESCRIPTION
## Summary
Some users have been experiencing wildy incosistent 404 issues with the Devhub and it looks like it has been narrowed down to a hard-to-remove and long lived `sw.js` (service worker) file that is not being replaced. 

The removal of the service worker is necessary for these users to be able to experience the site correctly. 

## What are the side effects?
The sw's primary function is to prefetch our page resources to make concurrent server requests snappy. This will be disabled and we will look to add the service worker when a sufficient amount of time has passed (I'm thinking about 2 monthes)

Fixes #1242 