### PR TITLE
Changed Github/Rocketchat Icon Button titles

### DIFF
--- a/app-web/src/components/Search/SearchSources.js
+++ b/app-web/src/components/Search/SearchSources.js
@@ -55,7 +55,7 @@ export const SearchSources = ({ searchSourcesLoading }) => {
           <SearchSourcesButton
             searchType={element}
             style={iconProps.style}
-            title={'Login or wait to view ' + element + ' search results'}
+            title={'Login in to view search results from ' + element}
           ></SearchSourcesButton>
         </StyledDiv>
       )}


### PR DESCRIPTION
Fixes issue #1248 

Changed the title of the github/rocketchat buttons to show correct text when hovered over