### PR TITLE
Bug: fix regex for babel jest in markdown action

### DIFF
--- a/.github/actions/devhub-markdown-frontmatter-verify/jest.config.js
+++ b/.github/actions/devhub-markdown-frontmatter-verify/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     __PATH_PREFIX__: '',
   },
   transform: {
-    '.(js|jsx)': 'babel-jest',
+    '.(js|jsx)$': 'babel-jest',
   },
   testPathIgnorePatterns: ['/node_modules/', '/.cache/', '/cypress/'],
   moduleFileExtensions: ['js', 'module.css', '.css', 'json']


### PR DESCRIPTION
## Summary
markdown action babel was transforming json files incorrectly. Oops!
