### PR TITLE
Add browser support guidance doc to Design System topicRegistry

### DIFF
--- a/app-web/topicRegistry/design-system.json
+++ b/app-web/topicRegistry/design-system.json
@@ -30,6 +30,7 @@
             "components/dropdown/README.md",
             "components/text_input/README.md",
             "components/textarea/README.md",
+            "components/about/browser_support_guidance.md",
             "components/about/component_workflow.md",
             "components/about/propose_a_component.md",
             "components/about/prototyping_tools.md"


### PR DESCRIPTION
## Summary
This is a content update, adding new [browser support guidance documentation](https://github.com/bcgov/design-system/blob/master/components/about/browser_support_guidance.md) to the Design System `topicRegistry`.
