### PR TITLE
Add Alert Banners component documentation

### DIFF
--- a/app-web/topicRegistry/design-system.json
+++ b/app-web/topicRegistry/design-system.json
@@ -15,6 +15,7 @@
             "styles/colours/colourpalette.md",
             "styles/typography/typography.md",
             "styles/Icons/icons.md",
+            "components/alert_banners/README.md",
             "components/beta/README.md",
             "components/header/README.md",
             "components/footer/README.md",


### PR DESCRIPTION
## Summary
This is a content update, adding new [Alert Banners component documentation](https://github.com/bcgov/design-system/tree/master/components/alert_banners) to the Design System `topicRegistry`. 
