### PR TITLE
Fix topic cards to include images

### DIFF
--- a/app-web/src/pages/topics.js
+++ b/app-web/src/pages/topics.js
@@ -130,6 +130,11 @@ export const TopicsQuery = graphql`
           description
           connectsWith {
             ...DevhubNodeConnection
+            fields {
+              image {
+                ...cardFixedImage
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
Fixes issue #1323. 

Fix issue where images would not show on the cards on the topics page.

Edit the topic graphql query to include image field.
