### PR TITLE
Update Rocket.chat URL to use chat.developer.bc.ca

### DIFF
--- a/.pipeline/lib/deploy.js
+++ b/.pipeline/lib/deploy.js
@@ -64,7 +64,7 @@ module.exports = async settings => {
 
   const chatUrl =
     process.env.CHAT_WEBHOOK_URL ||
-    'https://chat.pathfinder.gov.bc.ca/hooks/ScLeYnDzyKN3hbBob/F84wsFWxmpkguyDN9ZQ8BAyHRrLT3c2yF6DPoNoFbnitqxES';
+    'https://chat.developer.gov.bc.ca/hooks/ScLeYnDzyKN3hbBob/F84wsFWxmpkguyDN9ZQ8BAyHRrLT3c2yF6DPoNoFbnitqxES';
   // The deployment of your cool app goes here ▼▼▼
   objects = oc.processDeploymentTemplate(`${templatesLocalBaseUrl}/dc.yaml`, {
     param: {

--- a/app-web/gatsby-config.js
+++ b/app-web/gatsby-config.js
@@ -35,7 +35,7 @@ const algoliaPlugin = () =>
       }
     : undefined;
 //Commented out since Meetup no longer has an API and has switched to OAUTH, but the plugin we use may be updated
-//more info at https://chat.pathfinder.gov.bc.ca/channel/general?msg=MdAyQzrPRPpQt382o
+//more info at https://chat.developer.gov.bc.ca/channel/general?msg=MdAyQzrPRPpQt382o
 /*const devopsCommonsMeetup = () =>
   process.env.MEETUP_API_KEY
     ? {

--- a/app-web/src/components/Search/SearchGateResults.js
+++ b/app-web/src/components/Search/SearchGateResults.js
@@ -114,7 +114,7 @@ export const SearchGateResults = ({ searchSources }) => {
     },
     [SEARCH_SOURCES.rocketchat]: {
       link: {
-        to: 'https://chat.pathfinder.gov.bc.ca',
+        to: 'https://chat.developer.gov.bc.ca',
         text: 'Go To Rocket.Chat',
       },
       render: renderRocketchat,

--- a/app-web/src/hoc/withResourceQuery.js
+++ b/app-web/src/hoc/withResourceQuery.js
@@ -136,7 +136,7 @@ const withResourceQuery = WrappedComponent => () => props => (
           }
         }
         #Commented out since Meetup no longer has an API and has switched to OAUTH, but the plugin we use may be updated
-        #more info at https://chat.pathfinder.gov.bc.ca/channel/general?msg=MdAyQzrPRPpQt382o
+        #more info at https://chat.developer.gov.bc.ca/channel/general?msg=MdAyQzrPRPpQt382o
         #allMeetupGroup {
         #edges {
         #node {

--- a/app-web/src/templates/events.js
+++ b/app-web/src/templates/events.js
@@ -181,7 +181,7 @@ export const EventData = graphql`
       }
     }
     #Commented out since Meetup no longer has an API and has switched to OAUTH, but the plugin we use may be updated
-    #more info at https://chat.pathfinder.gov.bc.ca/channel/general?msg=MdAyQzrPRPpQt382o
+    #more info at https://chat.developer.gov.bc.ca/channel/general?msg=MdAyQzrPRPpQt382o
     #allMeetupGroup {
     #edges {
     #node {

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -137,7 +137,7 @@ Our current list of topics include:
 
 ### Have an idea for a new Topic?
 
-Please @mention patricksimonian or sheaphillips with your PR or even better, contact the Devhub Team in [Rocket Chat](https://chat.pathfinder.gov.bc.ca)
+Please @mention patricksimonian or sheaphillips with your PR or even better, contact the Devhub Team in [Rocket Chat](https://chat.developer.gov.bc.ca)
 
 
 


### PR DESCRIPTION
## Summary
Updates the Rocket.chat URL to `chat.developer.gov.bc.ca` from `chat.pathfinder.gov.bc.ca` across documentation, commented code, and live code.

## Notable Changes <!-- if any -->
- I've confirmed the new `CHAT_WEBHOOK_URL` fallback URL in `.pipeline/lib/deploy.js` returns the same response as the old URL. (62552dc)
- The commented URL referencing a particular message about the Meetup API works as expected with the new URL. (9740d32)
