### PR TITLE
Add sysdig-teams topic

### DIFF
--- a/app-web/topicRegistry/developer-tools.json
+++ b/app-web/topicRegistry/developer-tools.json
@@ -32,6 +32,17 @@
       {
         "sourceType": "github",
         "sourceProperties": {
+          "url": "https://github.com/BCDevOps/platform-services",
+          "owner": "BCDevOps",
+          "repo": "platform-services",
+          "files": [
+            "monitoring/sysdig/docs/sysdigteam_user_guide.md"
+          ]
+        }
+      }, 
+      {
+        "sourceType": "github",
+        "sourceProperties": {
           "url": "https://github.com/bcgov/devhub-resources",
           "owner": "bcgov",
           "repo": "devhub-resources",


### PR DESCRIPTION
## Summary
This adds the sysdigteams topic in support of this issue: https://github.com/BCDevOps/developer-experience/issues/797

## Notable Changes 
- Just adding the sysdig teams developer user guide
