### PR TITLE
update "Steps to Join Rocketchat" location to non-archived version

### DIFF
--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -134,11 +134,11 @@
         "sourceType": "github",
         "resourceType": "Documentation",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/reggie/",
+          "url": "https://github.com/bcgov/rocketchat/",
           "owner": "bcgov",
-          "repo": "reggie",
+          "repo": "rocketchat",
           "files": [
-            "UserInstructions.md"
+            "reggie/UserInstructions.md"
           ]
         }
       },

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -130,6 +130,18 @@
           "files": [
             "README.md"
           ]
+        },
+        "attributes": {
+          "tags": [
+            "network",
+            "network policy",
+            "networkpolicy",
+            "nsp",
+            "migration",
+            "workshop",
+            "policy",
+            "aporeto"
+          ]
         }
       }
     ]

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -119,6 +119,17 @@
             "docs/OnboardingOutcomes.md"
           ]
         }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "https://github.com/bcgov/networkpolicy-migration-workshop",
+          "owner": "bcgov",
+          "repo": "networkpolicy-migration-workshop",
+          "files": [
+            "README.md"
+          ]
+        }
       }
     ]
   }

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -126,6 +126,7 @@
           "url": "https://github.com/bcgov/networkpolicy-migration-workshop",
           "owner": "bcgov",
           "repo": "networkpolicy-migration-workshop",
+          "ref": "main",
           "files": [
             "README.md"
           ]

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -130,18 +130,6 @@
           "files": [
             "README.md"
           ]
-        },
-        "attributes": {
-          "tags": [
-            "network",
-            "network policy",
-            "networkpolicy",
-            "nsp",
-            "migration",
-            "workshop",
-            "policy",
-            "aporeto"
-          ]
         }
       }
     ]


### PR DESCRIPTION
The devhub was pointing to an archived repo instead of the one where reggie is actively being developed!