### PR TITLE
add networkpolicy migration guide to registry file

### DIFF
--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -119,6 +119,17 @@
             "docs/OnboardingOutcomes.md"
           ]
         }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "https://github.com/bcgov/networkpolicy-migration-workshop",
+          "owner": "bcgov",
+          "repo": "networkpolicy-migration-workshop",
+          "files": [
+            "README.md"
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
## Summary
Allow the [networkpolicy migration guide](https://github.com/bcgov/networkpolicy-migration-workshop) to be searchable on the devhub
