### PR TITLE
add community-meetup to events tile

### DIFF
--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -134,6 +134,18 @@
         "sourceType": "github",
         "resourceType": "Documentation",
         "sourceProperties": {
+          "url": "https://github.com/bcgov/devhub-resources/",
+          "owner": "bcgov",
+          "repo": "devhub-resources",
+          "files": [
+            "resources/community/community-meetup.md"
+          ]
+        }
+      },
+      {
+        "sourceType": "github",
+        "resourceType": "Documentation",
+        "sourceProperties": {
           "url": "https://github.com/bcgov/rocketchat/",
           "owner": "bcgov",
           "repo": "rocketchat",


### PR DESCRIPTION
Add community meetup doc to add to the events tile.
Address issue: https://github.com/bcgov/devhub-app-web/issues/1598