### PR TITLE
Fix typo in web/README.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # The default owner of all the files in the repository (Global Owner) will be requested for review.
-*      @patricksimonian
+*      @ShellyXueHan @ty2k @w8896699
 
 # If a pull request is made the following owners will be requested to review.
-*.     @patricksimonian
+*.     @ShellyXueHan @ty2k @w8896699
 

--- a/web/README.md
+++ b/web/README.md
@@ -10,7 +10,7 @@ It will provide an inventory of ongoing open product development products, compo
 
 The resources will be collected into curated various focused kits/topics of resources needed to build particular types of systems, assist teams at a point in their lifecycle, support persona specific-workflows, etc. 
 
-It will also provide a aeans to seed “prosumer”/community behaviours. For example, it will be possible to view source/fork/comment/PR on many of the elements in the DevHub.
+It will also provide a means to seed “prosumer”/community behaviours. For example, it will be possible to view source/fork/comment/PR on many of the elements in the DevHub.
 
 ## Technical Details
 


### PR DESCRIPTION
## Summary
This PR fixes a typo, but it is mainly here for me to learn the process of deploying a new build of DevHub to OpenShift.

## Notable Changes <!-- if any -->
- Fix typo in `./web/README.md`
