### PR TITLE
Update apiVersion in web/bc.yaml OpenShift template

### DIFF
--- a/openshift/templates/web/bc.yaml
+++ b/openshift/templates/web/bc.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
 kind: Template
+apiVersion: template.openshift.io/v1
 metadata:
   creationTimestamp: null
   name: devhub-app-web-bc-template

--- a/openshift/templates/web/dc.yaml
+++ b/openshift/templates/web/dc.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
 kind: Template
+apiVersion: template.openshift.io/v1
 metadata:
   creationTimestamp: null
   name: devhub-app-web


### PR DESCRIPTION
This pull request is an attempt to fix [this broken build](https://github.com/bcgov/devhub-app-web/runs/7868142345?check_suite_focus=true) which is failing with this error:

`error: failed to read input object (not a Template?): resource mapping not found for name: "devhub-app-web-bc-template" namespace: "" from "openshift/templates/web/bc.yaml": no matches for kind "Template" in version "v1"`