### PR TITLE
Content/mobile starter kit

### DIFF
--- a/web/gatsby/onCreateNode.js
+++ b/web/gatsby/onCreateNode.js
@@ -130,7 +130,12 @@ module.exports = async ({ node, actions, getNode, getNodes, store, cache, create
       value: node.unfurl.description,
     });
 
-    if (node.unfurl.image && /^https/.test(node.unfurl.image) && !/svg$/.test(node.unfurl.image)) {
+    if (
+      node.unfurl.image &&
+      /^https/.test(node.unfurl.image) &&
+      !/svg$/.test(node.unfurl.image) &&
+      !/(githubassets.com)/.test(node.unfurl.image) // Exclude images from GitHub CDN due to its API rate limiting breaking builds
+    ) {
       let fileNode = await createRemoteFileNode({
         url: node.unfurl.image, // string that points to the URL of the image
         parentNodeId: node.id, // id of the parent node of the fileNode you are going to create

--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -48,16 +48,6 @@
         "sourceType": "web",
         "resourceType": "Events",
         "sourceProperties": {
-          "url": "https://www.meetup.com/DevOps-Commons/",
-          "title": "DevOps Commons MeetUp",
-          "description": "The DevOps Commons MeetUp is the in-person forum focused on growing and evolving the BCGov DevOps community.",
-          "image": "https://secure.meetupstatic.com/photos/event/3/9/f/f/600_471194847.jpeg"
-        }
-      },
-      {
-        "sourceType": "web",
-        "resourceType": "Events",
-        "sourceProperties": {
           "url": "https://www.meetup.com/Cloud-Native-Victoria/",
           "title": "Cloud Native Victoria MeetUp",
           "description": "Cloud Native Victoria is the official Cloud Native Computing Foundation (CNCF) Meetup group dedicated to building a strong, open, diverse developer community around the Cloud Native platform and technologies in Victoria.",

--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -12,19 +12,6 @@
     "sources": [
       {
         "sourceType": "web",
-        "resourceType": "Events",
-        "sourceProperties": {
-          "url": "https://bcgov.github.io/ExchangeLabOps/Lab-Learning-Programs/README.html",
-          "title": "Exchange Lab Ops Learning Programs",
-          "description": "Find out about the different Lab Training programs and how you may sign up!"
-        },
-        "attributes": {
-          "personas": ["Product Owner", "Facilitators", "Developer"],
-          "tags": ["Openshift 101", "Openshift Training", "CSI Lab Training", "Agile Fundamentals", "Digital Leadership", "Training"]
-        }
-      },
-      {
-        "sourceType": "web",
         "resourceType": "Repositories",
         "sourceProperties": {
           "url": "https://github.com/bcdevops/devops-platform-workshops",

--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -27,10 +27,10 @@
         "sourceType": "web",
         "resourceType": "Self-Service Tools",
         "sourceProperties": {
-          "url": "https://www.bcdevexchange.org",
+          "url": "https://bcdevexchange.org",
           "title": "BC Developers Exchange",
           "description": "Finding better ways for government and developers to work together.",
-          "image": "https://www.bcdevexchange.org/modules/core/client/img/logo/new-logo.svg"
+          "image": "https://bcdevexchange.org/img/logo.svg"
         }
       },
       {

--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -48,15 +48,6 @@
         "sourceType": "web",
         "resourceType": "Events",
         "sourceProperties": {
-          "url": "https://www.meetup.com/bcgov-uxguild/",
-          "title": "BC Gov UX Guild",
-          "description": "We help build better digital products and services for government. The UX Guild is a group of user experience designers and researchers working within and supporting the B.C. government. We share ideas, support each other and push forward to make our collective work better."
-        }
-      },
-      {
-        "sourceType": "web",
-        "resourceType": "Events",
-        "sourceProperties": {
           "url": "https://www.meetup.com/Social-Club-for-Innovative-Public-Servants-SCIPS/",
           "title": "OneTeamGov Victoria, BC",
           "description": "This meetup group hosts the Victoria Chapter of the global #OneTeamGov movement.",

--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -48,16 +48,6 @@
         "sourceType": "web",
         "resourceType": "Events",
         "sourceProperties": {
-          "url": "https://www.meetup.com/Cloud-Native-Victoria/",
-          "title": "Cloud Native Victoria MeetUp",
-          "description": "Cloud Native Victoria is the official Cloud Native Computing Foundation (CNCF) Meetup group dedicated to building a strong, open, diverse developer community around the Cloud Native platform and technologies in Victoria.",
-          "image": "https://secure.meetupstatic.com/photos/event/4/f/e/6/highres_453200454.jpeg"
-        }
-      },
-      {
-        "sourceType": "web",
-        "resourceType": "Events",
-        "sourceProperties": {
           "url": "https://www.meetup.com/bcgov-uxguild/",
           "title": "BC Gov UX Guild",
           "description": "We help build better digital products and services for government. The UX Guild is a group of user experience designers and researchers working within and supporting the B.C. government. We share ideas, support each other and push forward to make our collective work better."

--- a/web/topicRegistry/developer-tools.json
+++ b/web/topicRegistry/developer-tools.json
@@ -22,15 +22,6 @@
         }
       },
       {
-        "sourceType": "web",
-        "sourceProperties": {
-          "resourceType": "Self-Service Tools",
-          "title": "OpenShift Developer Console",
-          "description": "This guide is intended for application developers, and provides instructions for setting up and configuring a workstation to develop and deploy applications in an OpenShift Container Platform.",
-          "url": "https://console.pathfinder.gov.bc.ca:8443/console/projects"
-        }
-      },
-      {
         "sourceType": "github",
         "sourceProperties": {
           "url": "https://github.com/BCDevOps/openshift-wiki",

--- a/web/topicRegistry/developer-tools.json
+++ b/web/topicRegistry/developer-tools.json
@@ -128,13 +128,6 @@
       {
         "sourceType": "web",
         "sourceProperties": {
-          "title": "Mobile Signing",
-          "url": "https://mss.developer.gov.bc.ca"
-        }
-      },
-      {
-        "sourceType": "web",
-        "sourceProperties": {
           "url": "https://github.com/bcgov",
           "author": "kelpisland",
           "title": "BC Gov on GitHub",

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -61,7 +61,7 @@
         "sourceProperties": {
           "title": "OpenShift Interactive Learning Portal",
           "description": "These Interactive Learning Scenarios provide you with a pre-configured OpenShift® instance, accessible from your browser without any downloads or configuration. Use it to experiment, learn OpenShift and see how we can help solve real-world problems.",
-          "url": "http://learn.openshift.com/"
+          "url": "https://developers.redhat.com/learn"
         }
       },
       {
@@ -69,7 +69,7 @@
         "sourceProperties": {
           "title": "OpenShift for Developers eBook",
           "description": "Get a quick hands-on introduction to OpenShift, the open source Platform as a Service (PaaS) offering from Red Hat®. With this practical guide, you’ll learn the steps necessary to build, deploy, and host a complete real-world application on OpenShift without having to slog through long, detailed explanations of the technologies involved.",
-          "url": "https://www.openshift.com/for-developers/"
+          "url": "https://www.redhat.com/en/openshift-developers-free-ebook-red-hat-openshift"
         }
       },
       {
@@ -77,7 +77,7 @@
         "sourceProperties": {
           "title": "Deploying to OpenShift eBook",
           "description": "Get an in-depth tour of OpenShift®, the container-based software deployment and management platform from Red Hat® that provides a secure multitenant environment for the enterprise. This practical guide describes in detail how OpenShift, building on Kubernetes, enables you to automate the way you create, ship, and run applications in a containerized environment.",
-          "url": "https://www.openshift.com/deploying-to-openshift/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC"
+          "url": "https://www.redhat.com/en/deploying-openshift-free-ebook-red-hat-openshift"
         }
       },
       {
@@ -85,7 +85,7 @@
         "sourceProperties": {
           "title": "DevOps with OpenShift eBook",
           "description": "For many organizations, a big part of DevOps’ appeal is software automation using infrastructure-as-code techniques. This book presents developers, architects, and infra-ops engineers with a more practical option. You’ll learn how a container-centric approach from OpenShift® can help your team deliver quality software through a self-service view of IT infrastructure.",
-          "url": "https://www.openshift.com/devops-with-openshift/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC"
+          "url": "https://developers.redhat.com/topics/devops"
         }
       },
       {

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -118,15 +118,6 @@
         }
       },
       {
-        "sourceType": "web",
-        "sourceProperties": {
-          "title": "OpenShift Developer Console",
-          "description": "This guide is intended for application developers, and provides instructions for setting up and configuring a workstation to develop and deploy applications in an OpenShift Container Platform.",
-          "url": "https://console.pathfinder.gov.bc.ca:8443/console/projects"
-        },
-        "resourceType": "Self-Service Tools"
-      },
-      {
         "sourceType": "github",
         "sourceProperties": {
           "url": "https://github.com/bcDevOps/developer-experience",

--- a/web/topicRegistry/mobile-starter-kit.json
+++ b/web/topicRegistry/mobile-starter-kit.json
@@ -10,7 +10,7 @@
       {
         "sourceType": "web",
         "sourceProperties": {
-          "url": "https://mss.developer.gov.bc.ca"
+          "url": "https://github.com/bcgov/mobile-signing-service/wiki/!-Signing-Changes"
         }
       },
       {

--- a/web/topicRegistry/mobile-starter-kit.json
+++ b/web/topicRegistry/mobile-starter-kit.json
@@ -1,6 +1,6 @@
 {
   "name": "Mobile Starter Kit",
-  "description": "Blarb",
+  "description": "Native mobile application development in the BC government ecosystem",
   "resourceType": "Self-Service Tools",
   "attributes": {
     "personas": ["Developer"]


### PR DESCRIPTION
This PR removes the Mobile Signing Service URL from the Mobile Starter Kit topic and replaced it with a link to the ![! Signing Changes wiki page](https://github.com/bcgov/mobile-signing-service/wiki/!-Signing-Changes). The current link to `https://mss.developer.gov.bc.ca` is not being rendered into a link by DevHub because that site's certificate is expired. (2f6b020382fd1130eed5a9b2dc13be1f8d22dacb)

I've also added a meaningful description to the Mobile Starter Kit topic (e81124928c995765409a2a21a6912bfe0b49054d).

Before (current production):
<img width="1840" alt="DevHub production screenshot" src="https://user-images.githubusercontent.com/25143706/185269851-4e742aa4-41fc-4015-a99d-ca544a8a5b47.png">

After (with the changes in this PR):
<img width="1840" alt="DevHub after the changes in this PR" src="https://user-images.githubusercontent.com/25143706/185269886-e5d0cc53-78d2-4eff-a00f-b6d7df78829c.png">

