### PR TITLE
Remove Community and Event topicRegistry reference to BCDevExchange.org

### DIFF
--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -27,16 +27,6 @@
         "sourceType": "web",
         "resourceType": "Self-Service Tools",
         "sourceProperties": {
-          "url": "https://bcdevexchange.org",
-          "title": "BC Developers Exchange",
-          "description": "Finding better ways for government and developers to work together.",
-          "image": "https://bcdevexchange.org/img/logo.svg"
-        }
-      },
-      {
-        "sourceType": "web",
-        "resourceType": "Self-Service Tools",
-        "sourceProperties": {
           "url": "https://www.yammer.com/gov.bc.ca/#/threads/inGroup?type=in_group&feedId=11241672&view=all",
           "author": "kelpisland",
           "title": "DevOps Commons Yammer Group",


### PR DESCRIPTION
Because BCDevExchange.org is being decommissioned, its product team has allowed their SSL certificate to expire this afternoon. Since we have a link to this site in our Community and Events topic registry, this causes an error when Gatsby tries to access that site to build a link card for it.

```
 ERROR 

{ HTTPError: certificate has expired
    at request.then (/Users/tykrys/code/devhub-app-web/web/node_modules/preq/index.js:246:19)
    at tryCatcher (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/promise.js:725:18)
    at _drainQueueStep (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/tykrys/code/devhub-app-web/web/node_modules/bluebird/js/release/async.js:15:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
    at process.topLevelDomainCallback (domain.js:126:23)
  name: 'HTTPError',
  message: 'certificate has expired',
  status: 504,
  headers: { 'content-type': 'application/problem+json' },
  body:
   { type: 'internal_http_error',
     detail: 'certificate has expired',
     internalStack:
      'Error: certificate has expired\n    at TLSSocket.onConnectSecure (_tls_wrap.js:1088:34)\n    at TLSSocket.emit (events.js:198:13)\n    at TLSSocket.EventEmitter.emit
(domain.js:448:20)\n    at TLSSocket._finishInit (_tls_wrap.js:666:8)',
     internalURI: 'https://bcdevexchange.org',
     internalQuery: undefined,
     internalErr: 'certificate has expired',
     internalMethod: 'get' } }
```

I'm leaving the BCDevExchange link in the footer in there for now, since that one doesn't have potential to break future builds. We should still change that link at some point if that product team doesn't forward their URL to digital.gov.bc.ca or another site.

<img width="1840" alt="DevHub screenshot illustrating the link being removed and the footer link that remains" src="https://user-images.githubusercontent.com/25143706/187002219-2444321e-f77a-4458-91f5-447e968d1df2.png">
