### PR TITLE
Retiring Platform Services team content from DevHub

### DIFF
--- a/web/src/assets/migrated-pages/Agile-Delivery-Process/01_Alignment.md
+++ b/web/src/assets/migrated-pages/Agile-Delivery-Process/01_Alignment.md
@@ -5,3 +5,5 @@ title: Alignment
 # Alignment
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Agile-Delivery-Process/02_Discovery.md
+++ b/web/src/assets/migrated-pages/Agile-Delivery-Process/02_Discovery.md
@@ -5,3 +5,5 @@ title: Discovery
 # Discovery
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Agile-Delivery-Process/03_Alpha.md
+++ b/web/src/assets/migrated-pages/Agile-Delivery-Process/03_Alpha.md
@@ -5,3 +5,5 @@ title: Alpha
 # Alpha
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Agile-Delivery-Process/04_Beta.md
+++ b/web/src/assets/migrated-pages/Agile-Delivery-Process/04_Beta.md
@@ -5,3 +5,5 @@ title: Beta
 # Beta
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Agile-Delivery-Process/05_Live.md
+++ b/web/src/assets/migrated-pages/Agile-Delivery-Process/05_Live.md
@@ -5,3 +5,5 @@ title: Live
 # Live
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Agile-Delivery-Process/agile-delivery-process.md
+++ b/web/src/assets/migrated-pages/Agile-Delivery-Process/agile-delivery-process.md
@@ -5,3 +5,5 @@ title: Agile Delivery Process
 # Agile Delivery Process
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Cloud-Migration/exploring-available-images.md
+++ b/web/src/assets/migrated-pages/Cloud-Migration/exploring-available-images.md
@@ -5,3 +5,5 @@ title: Check \#1--:-- Exploring the images you leverage and its availability
 # Check \#1: Exploring the images you leverage and its availability
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Cloud-Migration/finding-app-migration-painpoints.md
+++ b/web/src/assets/migrated-pages/Cloud-Migration/finding-app-migration-painpoints.md
@@ -5,3 +5,5 @@ title: App Migration Painpoints
 # App Migration Painpoints
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Cloud-Migration/migrating-jenkins.md
+++ b/web/src/assets/migrated-pages/Cloud-Migration/migrating-jenkins.md
@@ -5,3 +5,5 @@ title: Migrating Your BC Gov Jenkins to the Cloud
 # Migrating Your BC Gov Jenkins to the Cloud
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Cloud-Migration/migrating-rhel-images.md
+++ b/web/src/assets/migrated-pages/Cloud-Migration/migrating-rhel-images.md
@@ -5,3 +5,5 @@ title: Migrating Rhel Images
 # Migrating Rhel Images
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Cloud-Migration/working-in-multiple-clusters.md
+++ b/web/src/assets/migrated-pages/Cloud-Migration/working-in-multiple-clusters.md
@@ -5,3 +5,5 @@ title: Working in Multiple Clusters
 # Working in Multiple Clusters
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Cloud-Pathfinder/aws-services.md
+++ b/web/src/assets/migrated-pages/Cloud-Pathfinder/aws-services.md
@@ -5,3 +5,5 @@ title: AWS Services
 # AWS Services
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/Collaborating-Contributing.md
+++ b/web/src/assets/migrated-pages/Code-Management/Collaborating-Contributing.md
@@ -5,3 +5,5 @@ title: Approaches to Collaborating/Contributing
 # Approaches to Collaborating/Contributing
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/Introduction-To-Github-in-BC-Gov.md
+++ b/web/src/assets/migrated-pages/Code-Management/Introduction-To-Github-in-BC-Gov.md
@@ -5,3 +5,5 @@ title: Introduction To Github and Gov
 # Introduction To Github and Gov
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/Licenses.md
+++ b/web/src/assets/migrated-pages/Code-Management/Licenses.md
@@ -5,3 +5,5 @@ title: Licensing Your Project
 # Licensing Your Project
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/SAMPLE-CODE_OF_CONDUCT.md
+++ b/web/src/assets/migrated-pages/Code-Management/SAMPLE-CODE_OF_CONDUCT.md
@@ -5,3 +5,5 @@ title: Sample Code of Conduct
 # Sample Code of Conduct
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/SAMPLE-CONTRIBUTING.md
+++ b/web/src/assets/migrated-pages/Code-Management/SAMPLE-CONTRIBUTING.md
@@ -5,3 +5,5 @@ title: Sample Contributing File
 # Sample Contributing File
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/SAMPLE-README.md
+++ b/web/src/assets/migrated-pages/Code-Management/SAMPLE-README.md
@@ -5,3 +5,5 @@ title: Sample Readme File
 # Sample Readme File
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/appropriate-use.md
+++ b/web/src/assets/migrated-pages/Code-Management/appropriate-use.md
@@ -5,3 +5,5 @@ title: Github Practices in Gov
 # Github Practices in Gov
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Code-Management/flow.md
+++ b/web/src/assets/migrated-pages/Code-Management/flow.md
@@ -5,3 +5,5 @@ title: Git Workflows For Your Team or Project
 # Git Workflows For Your Team or Project
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-Contributed-Content/docker-weasyprint.md
+++ b/web/src/assets/migrated-pages/Community-Contributed-Content/docker-weasyprint.md
@@ -5,3 +5,5 @@ title: WeasyPrint HTML to PDF/PNG Microservice
 # WeasyPrint HTML to PDF/PNG Microservice
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-Contributed-Content/document-generation-showcase-overview.md
+++ b/web/src/assets/migrated-pages/Community-Contributed-Content/document-generation-showcase-overview.md
@@ -5,3 +5,5 @@ title: NR Document Generation Showcase
 # NR Document Generation Showcase
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-Contributed-Content/go-crond.md
+++ b/web/src/assets/migrated-pages/Community-Contributed-Content/go-crond.md
@@ -5,3 +5,5 @@ title: Go-Crond
 # Go-Crond
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-Contributed-Content/integratingAlgolia.md
+++ b/web/src/assets/migrated-pages/Community-Contributed-Content/integratingAlgolia.md
@@ -5,3 +5,5 @@ title: Integrating Algolia Search Engine Into the Devhub
 # Integrating Algolia Search Engine Into the Devhub
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-developer-guide.md
+++ b/web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-developer-guide.md
@@ -5,3 +5,5 @@ title: Messaging Service Developer Guide
 # Messaging Service Developer Guide
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-overview.md
+++ b/web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-overview.md
@@ -5,3 +5,5 @@ title: About the Messaging Common Service
 # About the Messaging Common Service
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-Contributed-Content/registry.md
+++ b/web/src/assets/migrated-pages/Community-Contributed-Content/registry.md
@@ -5,3 +5,5 @@ title: Contributing To The Devhub
 # Contributing To The Devhub
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-and-Events/PlatformServicesDemoCollection.md
+++ b/web/src/assets/migrated-pages/Community-and-Events/PlatformServicesDemoCollection.md
@@ -5,3 +5,5 @@ title: Platform Services Sprint Review Demo Collection
 # Platform Services Sprint Review Demos
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-and-Events/UserInstructions.md
+++ b/web/src/assets/migrated-pages/Community-and-Events/UserInstructions.md
@@ -5,3 +5,5 @@ title: Steps to join Rocket.Chat
 # Steps to join Rocket.Chat
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-and-Events/chat_conventions.md
+++ b/web/src/assets/migrated-pages/Community-and-Events/chat_conventions.md
@@ -5,3 +5,5 @@ title: Chat Channel Conventions
 # Chat Channel Conventions
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-and-Events/community-meetup.md
+++ b/web/src/assets/migrated-pages/Community-and-Events/community-meetup.md
@@ -5,3 +5,5 @@ title: Platform Community Meetup
 # Platform Community Meetup
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Community-and-Events/events.md
+++ b/web/src/assets/migrated-pages/Community-and-Events/events.md
@@ -5,3 +5,5 @@ title: BC Gov Development Community Events
 # BC Gov Development Community Events
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/BC-Policy-Framework-For-GitHub-readme.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/BC-Policy-Framework-For-GitHub-readme.md
@@ -5,3 +5,5 @@ title: Introduction To Github and Gov
 # Introduction To Github and Gov
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/ImageStreams.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/ImageStreams.md
@@ -5,3 +5,5 @@ title: Best practices for managing image streams
 # Best practices for managing image streams
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/PipelineAutomation.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/PipelineAutomation.md
@@ -5,3 +5,5 @@ title: CI/CD with Pipeline Automation
 # CI/CD with Pipeline Automation
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/cloud-pathfinder-readme.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/cloud-pathfinder-readme.md
@@ -5,3 +5,5 @@ title: Cloud Pathfinder
 # Cloud Pathfinder
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/patroni-readme.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/patroni-readme.md
@@ -5,3 +5,5 @@ title: Patroni Cluster Setup in Openshift 4
 # Patroni Cluster Setup in Openshift 4
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/post-outage-checklist.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/post-outage-checklist.md
@@ -5,3 +5,5 @@ title: Post-Outage Application Health Checklist
 # Post-Outage Application Health Checklist
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/project-resource-quotas.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/project-resource-quotas.md
@@ -5,3 +5,5 @@ title: Project Resource Quotas in BC Gov's PaaS (Openshift 4 Platform)
 # Project Resource Quotas in BC Gov's PaaS (Openshift 4 Platform)
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/request-for-quota-increase.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/request-for-quota-increase.md
@@ -5,3 +5,5 @@ title: Need more quota for OpenShift project set?
 # Need more quota for OpenShift project set?
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/resiliency-checklist.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/resiliency-checklist.md
@@ -5,3 +5,5 @@ title: Resiliency Guidelines
 # Resiliency Guidelines
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/resource-tuning-recommendations.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/resource-tuning-recommendations.md
@@ -5,3 +5,5 @@ title: Resource Tuning Recommendations
 # Resource Tuning Recommendations
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/sizzy.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/sizzy.md
@@ -5,3 +5,5 @@ title: Sizzy - Responsive Design Testing
 # Sizzy - Responsive Design Testing
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-create-alert-channels.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-create-alert-channels.md
@@ -5,3 +5,5 @@ title: Create alerts and notifications in Sysdig Monitor
 # Create alerts and notifications in Sysdig Monitor
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-onboarding.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-onboarding.md
@@ -5,3 +5,5 @@ title: Onboarding to application monitoring with Sysdig
 # Onboarding to application monitoring with Sysdig
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-set-up-advanced-functions.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-set-up-advanced-functions.md
@@ -5,3 +5,5 @@ title: Set up advanced metrics in Sysdig Monitor
 # Set up advanced metrics in Sysdig Monitor
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-setup-team.md
+++ b/web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-setup-team.md
@@ -5,3 +5,5 @@ title: Set up a team in Sysdig Monitor
 # Set up a team in Sysdig Monitor
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Toy-Box/openshift-components-readme.md
+++ b/web/src/assets/migrated-pages/Developer-Toy-Box/openshift-components-readme.md
@@ -5,3 +5,5 @@ title: OpenShift Components
 # OpenShift Components
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Developer-Toy-Box/postgis-readme.md
+++ b/web/src/assets/migrated-pages/Developer-Toy-Box/postgis-readme.md
@@ -5,3 +5,5 @@ title: PostGIS
 # PostGIS
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/12-factor-apps.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/12-factor-apps.md
@@ -5,3 +5,5 @@ title: 12 Factor Apps
 # 12 Factor Apps
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/GrantUsersAccessToProject.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/GrantUsersAccessToProject.md
@@ -5,3 +5,5 @@ title: Granting a user access to a project
 # Granting a user access to a project
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/HumanHelp.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/HumanHelp.md
@@ -5,3 +5,5 @@ title: Getting human support for issues not covered by devops-requests
 # Getting human support for issues not covered by devops-requests
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/LoadTestingGuidelines.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/LoadTestingGuidelines.md
@@ -5,3 +5,5 @@ title: Load Testing Guidelines
 # Load Testing Guidelines
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/Networking.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/Networking.md
@@ -5,3 +5,5 @@ title: BC Gov OpenShift networking overview
 # BC Gov OpenShift networking overview
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCP4-Storage-backup.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCP4-Storage-backup.md
@@ -5,3 +5,5 @@ title: OCP4 Backup and Restore
 # OCP4 Backup and Restore
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCP4ServiceOverview.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCP4ServiceOverview.md
@@ -5,3 +5,5 @@ title: Service Overview for BC Government Private Cloud as a Service/Openshift 4
 # Service Overview for BC Government Private Cloud as a Service/Openshift 4 Platform
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCPServiceDefinition.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCPServiceDefinition.md
@@ -5,3 +5,5 @@ title: BC Gov PaaS OpenShift Platform Service Definition
 # BC Gov PaaS OpenShift Platform Service Definition
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCPStorageServices.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCPStorageServices.md
@@ -5,3 +5,5 @@ title: Persistent Storage Services
 # Persistent Storage Services
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OnboardingOutcomes.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OnboardingOutcomes.md
@@ -5,3 +5,5 @@ title: Welcome to our Platform Community!
 # Welcome to our Platform Community!
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestGitHubEnterpriseUserLicense.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestGitHubEnterpriseUserLicense.md
@@ -5,3 +5,5 @@ title: Use of GitHub Enterprise User Licenses in BC Gov
 # Use of GitHub Enterprise User Licenses in BC Gov
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestGitHubUserAccess.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestGitHubUserAccess.md
@@ -5,3 +5,5 @@ title: How to request new GitHub user access or repository creation
 # How to request new GitHub user access or repository creation
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestUserAccess.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestUserAccess.md
@@ -5,3 +5,5 @@ title: How to Request New User Access to OpenShift
 # How to Request New User Access to OpenShift
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/StartingANewProject.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/StartingANewProject.md
@@ -5,3 +5,5 @@ title: How to Request a New OpenShift Project
 # How to Request a New OpenShift Project
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/UsefulProTips.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/UsefulProTips.md
@@ -5,3 +5,5 @@ title: Openshift Useful Pro Tips
 # Openshift Useful Pro Tips
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/UserAccessToOrg.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/UserAccessToOrg.md
@@ -5,3 +5,5 @@ title: User access into Github or Openshift
 # User access into Github or Openshift
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/architecture_and_tech_stacks.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/architecture_and_tech_stacks.md
@@ -5,3 +5,5 @@ title: Application Architecture and Technology Stacks
 # Application Architecture and Technology Stacks
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/communication_community_and_support.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/communication_community_and_support.md
@@ -5,3 +5,5 @@ title: Communication, Community and Support
 # Communication, Community and Support
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/documize.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/documize.md
@@ -5,3 +5,5 @@ title: Documize
 # Documize
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/networkpolicy-migration-workshop-readme.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/networkpolicy-migration-workshop-readme.md
@@ -5,3 +5,5 @@ title: TL;DR
 # TL;DR
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/opensource.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/opensource.md
@@ -5,3 +5,5 @@ title: Open Source Code
 # Open Source Code
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/progressive-web-apps.md
+++ b/web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/progressive-web-apps.md
@@ -5,3 +5,5 @@ title: Progressive Web Apps
 # Progressive Web Apps
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Information-and-Application-Security/BC-Policy-Framework-For-GitHub-readme.md
+++ b/web/src/assets/migrated-pages/Information-and-Application-Security/BC-Policy-Framework-For-GitHub-readme.md
@@ -5,3 +5,5 @@ title: BC Gov Policy Framework For using GitHub
 # BC Gov Policy Framework For using GitHub
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Information-and-Application-Security/PCIDSSPatternforOCP.md
+++ b/web/src/assets/migrated-pages/Information-and-Application-Security/PCIDSSPatternforOCP.md
@@ -5,3 +5,5 @@ title: Payment Card Processing for OpenShift Applications
 # Payment Card Processing for OpenShift Applications
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Information-and-Application-Security/app_security_self_assessment.md
+++ b/web/src/assets/migrated-pages/Information-and-Application-Security/app_security_self_assessment.md
@@ -5,3 +5,5 @@ title: Application Security Self-Assessment
 # Application Security Self-Assessment
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Mobile-Starter-Kit/ServiceDefinition.md
+++ b/web/src/assets/migrated-pages/Mobile-Starter-Kit/ServiceDefinition.md
@@ -5,3 +5,5 @@ title: BC Government Team Mobile Services Definition
 # BC Government Team Mobile Services Definition
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Mobile-Starter-Kit/mobile-starter-kit-readme.md
+++ b/web/src/assets/migrated-pages/Mobile-Starter-Kit/mobile-starter-kit-readme.md
@@ -5,3 +5,5 @@ title: Mobile Starter Kit Overview
 # Mobile Starter Kit Overview
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Platform-Services-Security/AQUAServiceDefinition.md
+++ b/web/src/assets/migrated-pages/Platform-Services-Security/AQUAServiceDefinition.md
@@ -5,3 +5,5 @@ title: BC Government Aqua Cloud Service Definition
 # BC Government Aqua Cloud Service Definition
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Platform-Services-Security/IDIR_OpenShift_Login.md
+++ b/web/src/assets/migrated-pages/Platform-Services-Security/IDIR_OpenShift_Login.md
@@ -5,3 +5,5 @@ title: IDIR Login (via Azure AD) for OpenShift Console
 # IDIR Login (via Azure AD) for OpenShift Console
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Platform-Services-Security/SecurityConsiderationsForDevOps.md
+++ b/web/src/assets/migrated-pages/Platform-Services-Security/SecurityConsiderationsForDevOps.md
@@ -5,3 +5,5 @@ title: BC Government OpenShift DevOps Security Considerations
 # BC Government OpenShift DevOps Security Considerations
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Platform-Services-Security/ServiceDefinition.md
+++ b/web/src/assets/migrated-pages/Platform-Services-Security/ServiceDefinition.md
@@ -5,3 +5,5 @@ title: BC Government Artifact Repository Service Definition
 # BC Government Artifact Repository Service Definition
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Platform-Services-Security/ServiceDefiniton.md
+++ b/web/src/assets/migrated-pages/Platform-Services-Security/ServiceDefiniton.md
@@ -5,3 +5,5 @@ title: BC Government Sysdig Monitoring Service Definition
 # BC Government Sysdig Monitoring Service Definition
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Platform-Services-Security/SonarQubeBestPractices.md
+++ b/web/src/assets/migrated-pages/Platform-Services-Security/SonarQubeBestPractices.md
@@ -5,3 +5,5 @@ title: SonarQube Best Practices
 # SonarQube Best Practices
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/Platform-Services-Security/VaultServiceDefinition.md
+++ b/web/src/assets/migrated-pages/Platform-Services-Security/VaultServiceDefinition.md
@@ -5,3 +5,5 @@ title: BC Government Vault Secrets Management
 # BC Government Vault Secrets Management
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/src/assets/migrated-pages/community-and-events.md
+++ b/web/src/assets/migrated-pages/community-and-events.md
@@ -5,3 +5,5 @@ title: Community And Events
 # Community And Events
 
 The content you are trying to access has moved. If it is technical content, look for it on [BC Gov Private Cloud Platform's Technical Documentation website](https://beta-docs.developer.gov.bc.ca/). For non-technical content, check out our [new BC Gov Private Cloud Platform website](https://cloud.gov.bc.ca/private-cloud).
+
+If you can't find the information you are looking for on either of these sites, please email the Platform Services team (<a href="mailto:PlatformServicesTeam@gov.bc.ca">PlatformServicesTeam@gov.bc.ca</a>).

--- a/web/topicRegistry/agile-delivery-process.json
+++ b/web/topicRegistry/agile-delivery-process.json
@@ -7,16 +7,16 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/Agile-Delivery-Process",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "Agile-Delivery-Process",
+          "repo": "devhub-app-web",
           "files": [
-            "README.md",
-            "01_Alignment.md",
-            "02_Discovery.md",
-            "03_Alpha.md",
-            "04_Beta.md",
-            "05_Live.md"
+            "web/src/assets/migrated-pages/Agile-Delivery-Process/agile-delivery-process.md",
+            "web/src/assets/migrated-pages/Agile-Delivery-Process/01_Alignment.md",
+            "web/src/assets/migrated-pages/Agile-Delivery-Process/02_Discovery.md",
+            "web/src/assets/migrated-pages/Agile-Delivery-Process/03_Alpha.md",
+            "web/src/assets/migrated-pages/Agile-Delivery-Process/04_Beta.md",
+            "web/src/assets/migrated-pages/Agile-Delivery-Process/05_Live.md"
           ]
         }
       }

--- a/web/topicRegistry/agile-delivery-process.json
+++ b/web/topicRegistry/agile-delivery-process.json
@@ -7,7 +7,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/cloud-migration.json
+++ b/web/topicRegistry/cloud-migration.json
@@ -6,15 +6,15 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-resources/",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "devhub-resources",
+          "repo": "devhub-app-web",
           "files": [
-            "resources/aro/working-in-multiple-clusters.md",
-            "resources/aro/migrating-rhel-images.md",
-            "resources/aro/migrating-jenkins.md",
-            "resources/aro/exploring-available-images.md",
-            "resources/aro/finding-app-migration-painpoints.md"
+            "web/src/assets/migrated-pages/Cloud-Migration/working-in-multiple-clusters.md",
+            "web/src/assets/migrated-pages/Cloud-Migration/migrating-rhel-images.md",
+            "web/src/assets/migrated-pages/Cloud-Migration/migrating-jenkins.md",
+            "web/src/assets/migrated-pages/Cloud-Migration/exploring-available-images.md",
+            "web/src/assets/migrated-pages/Cloud-Migration/finding-app-migration-painpoints.md"
           ]
         }
       }

--- a/web/topicRegistry/cloud-migration.json
+++ b/web/topicRegistry/cloud-migration.json
@@ -6,7 +6,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/cloud-pathfinder.json
+++ b/web/topicRegistry/cloud-pathfinder.json
@@ -6,11 +6,11 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/cloud-pathfinder",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "cloud-pathfinder",
+          "repo": "devhub-app-web",
           "files": [
-            "devhub-content/cloud-pathfinder-services/aws-services.md"
+            "web/src/assets/migrated-pages/Cloud-Pathfinder/aws-services.md"
           ]
         },
         "resourceType": "Documentation",
@@ -32,3 +32,4 @@
   },
   "resourceType": "Documentation"
 }
+

--- a/web/topicRegistry/cloud-pathfinder.json
+++ b/web/topicRegistry/cloud-pathfinder.json
@@ -6,7 +6,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/code-management.json
+++ b/web/topicRegistry/code-management.json
@@ -21,7 +21,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/code-management.json
+++ b/web/topicRegistry/code-management.json
@@ -21,13 +21,18 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/BC-Policy-Framework-For-GitHub",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "BC-Policy-Framework-For-GitHub",
+          "repo": "devhub-app-web",
           "files": [
-            "github/README.md",
-            "BC-Open-Source-Development-Employee-Guide/appropriate-use.md",
-            "github/flow.md"
+            "web/src/assets/migrated-pages/Code-Management/Collaborating-Contributing.md",
+            "web/src/assets/migrated-pages/Code-Management/appropriate-use.md",
+            "web/src/assets/migrated-pages/Code-Management/flow.md",
+            "web/src/assets/migrated-pages/Code-Management/Licenses.md",
+            "web/src/assets/migrated-pages/Code-Management/SAMPLE-CODE_OF_CONDUCT.md",
+            "web/src/assets/migrated-pages/Code-Management/SAMPLE-CONTRIBUTING.md",
+            "web/src/assets/migrated-pages/Code-Management/SAMPLE-README.md",
+            "web/src/assets/migrated-pages/Code-Management/Introduction-To-Github-in-BC-Gov.md"
           ]
         }
       },
@@ -35,21 +40,6 @@
         "sourceType": "web",
         "sourceProperties": {
           "url": "https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow"
-        }
-      },
-      {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/BC-Policy-Framework-For-GitHub",
-          "owner": "bcgov",
-          "repo": "BC-Policy-Framework-For-GitHub",
-          "files": [
-            "BC-Open-Source-Development-Employee-Guide/Licenses.md",
-            "BC-Open-Source-Development-Employee-Guide/Collaborating-Contributing.md",
-            "BC-Gov-Org-HowTo/SAMPLE-CODE_OF_CONDUCT.md",
-            "BC-Gov-Org-HowTo/SAMPLE-CONTRIBUTING.md",
-            "BC-Gov-Org-HowTo/SAMPLE-README.md"
-          ]
         }
       }
     ]

--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -68,7 +68,7 @@
         "sourceType": "github",
         "resourceType": "Events",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -80,7 +80,7 @@
         "sourceType": "github",
         "resourceType": "Documentation",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/community-and-events.json
+++ b/web/topicRegistry/community-and-events.json
@@ -68,11 +68,11 @@
         "sourceType": "github",
         "resourceType": "Events",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-resources/",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "devhub-resources",
+          "repo": "devhub-app-web",
           "files": [
-            "resources/community/events.md"
+            "web/src/assets/migrated-pages/Community-and-Events/events.md"
           ]
         }
       },
@@ -80,56 +80,14 @@
         "sourceType": "github",
         "resourceType": "Documentation",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-resources/",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "devhub-resources",
+          "repo": "devhub-app-web",
           "files": [
-            "resources/community/chat_conventions.md"
-          ]
-        }
-      },
-      {
-        "sourceType": "github",
-        "resourceType": "Documentation",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-resources/",
-          "owner": "bcgov",
-          "repo": "devhub-resources",
-          "files": [
-            "resources/community/community-meetup.md"
-          ]
-        }
-      },
-      {
-        "sourceType": "github",
-        "resourceType": "Documentation",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/rocketchat/",
-          "owner": "bcgov",
-          "repo": "rocketchat",
-          "files": [
-            "reggie/UserInstructions.md"
-          ]
-        }
-      },
-      {
-        "sourceType": "web",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/reggie/",
-          "title": "Reggie - Rocket Chat Invitation App",
-          "image": ""
-        },
-        "resourceType": "Repositories"
-      },
-      {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/bcdevops/openshift-wiki",
-          "owner": "BCDevOps",
-          "repo": "openshift-wiki",
-          "ref": "master",
-          "files": [
-            "docs/HowTo/PlatformServicesDemoCollection.md"
+            "web/src/assets/migrated-pages/Community-and-Events/community-meetup.md",
+            "web/src/assets/migrated-pages/Community-and-Events/chat_conventions.md",
+            "web/src/assets/migrated-pages/Community-and-Events/UserInstructions.md",
+            "web/src/assets/migrated-pages/Community-and-Events/PlatformServicesDemoCollection.md"
           ]
         }
       }

--- a/web/topicRegistry/community-contributed.json
+++ b/web/topicRegistry/community-contributed.json
@@ -14,45 +14,20 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-app-web",
-          "owner": "bcgov",
-          "repo": "devhub-app-web",
-          "file": "web/src/assets/blog/integratingAlgolia.md"
-        }
-      },
-      {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-app-web",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
-            "docs/registry.md"
+            "web/src/assets/migrated-pages/Community-Contributed-Content/integratingAlgolia.md",
+            "web/src/assets/migrated-pages/Community-Contributed-Content/registry.md",
+            "web/src/assets/migrated-pages/Community-Contributed-Content/document-generation-showcase-overview.md",
+            "web/src/assets/migrated-pages/Community-Contributed-Content/docker-weasyprint.md",
+            "web/src/assets/migrated-pages/Community-Contributed-Content/go-crond.md",
+            "web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-developer-guide.md",
+            "web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-overview.md"
           ]
         }
-      },
-      {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/api-specs",
-          "owner": "bcgov",
-          "repo": "api-specs",
-          "files": [
-            "geocoder/geocoder-developer-guide.md"
-          ]
-        }
-      },
-      {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/BCDevOps/docker-weasyprint/",
-          "owner": "BCDevOps",
-          "repo": "docker-weasyprint",
-          "files": [
-            "README.md"
-          ]
-        }
-      },
+      }, 
       {
         "sourceType": "github",
         "sourceProperties": {
@@ -97,35 +72,6 @@
           ]
         }
       },
-      {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/BCDevOps/go-crond/",
-          "owner": "BCDevOps",
-          "repo": "go-crond",
-          "files": [
-            "README.md"
-          ]
-        }
-      },
-      {
-        "sourceType":"github",
-        "resourceType":"Repository",
-        "labels":[
-            "email",
-            "sms",
-            "messaging"
-        ],
-        "sourceProperties":{
-            "url":"https://github.com/bcgov/nr-messaging-service-showcase",
-            "repo":"nr-messaging-service-showcase",
-            "owner":"bcgov",
-            "files":[
-                "docs/overview.md",
-                "docs/developer-guide.md"
-            ]
-        }
-    },
     {
         "sourceType":"web",
         "sourceProperties":{
@@ -135,29 +81,7 @@
             "image":"https://upload.wikimedia.org/wikipedia/commons/a/ab/Swagger-logo.png"
         }
     },
-    {
-        "sourceType":"github",
-        "resourceType":"Repository",
-        "labels":[
-            "index",
-            "upload",
-            "store",
-            "update",
-            "retrieve",
-            "attachments",
-            "documents"
-        ],
-        "sourceProperties":{
-            "url":"https://github.com/bcgov/nr-document-management-showcase",
-            "repo":"nr-document-management-showcase",
-            "owner":"bcgov",
-            "files":[
-                "docs/overview.md",
-                "docs/developer-guide.md"
-            ]
-        }
-    },
-    {
+     {
         "sourceType":"web",
         "sourceProperties":{
             "url":"https://apistore.nrs.gov.bc.ca/store/apis/info?version=v1&name=dms-api&provider=admin",
@@ -179,7 +103,6 @@
             "repo":"document-generation-showcase",
             "owner":"bcgov",
             "files":[
-                "docs/overview.md",
                 "docs/developer-guide.md"
             ]
         }

--- a/web/topicRegistry/community-contributed.json
+++ b/web/topicRegistry/community-contributed.json
@@ -14,7 +14,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/developer-tools.json
+++ b/web/topicRegistry/developer-tools.json
@@ -190,18 +190,6 @@
         }
       },
       {
-        "sourceType": "github",
-        "sourceProperties": {
-          "title": "Patroni",
-          "url": "https://github.com/bcgov/devhub-app-web",
-          "owner": "bcgov",
-          "repo": "devhub-app-web",
-          "files": [
-            "web/src/assets/migrated-pages/Developer-Tools/patroni-readme.md"
-          ]
-        }
-      },
-      {
         "sourceType": "web",
         "sourceProperties": {
           "url": "https://github.com/bcgov/nr-get-token/wiki/Patroni-Troubleshooting",

--- a/web/topicRegistry/developer-tools.json
+++ b/web/topicRegistry/developer-tools.json
@@ -11,7 +11,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -46,7 +46,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -60,7 +60,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -71,7 +71,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -93,7 +93,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -104,7 +104,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -162,7 +162,7 @@
         "sourceType": "github",
         "sourceProperties": {
           "title": "Developer Experience",
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/developer-tools.json
+++ b/web/topicRegistry/developer-tools.json
@@ -1,6 +1,8 @@
 {
   "name": "Developer Tools",
+  "version": "1.0.0",
   "description": "Tools to assist software developers in building, deploying, and running applications for BC Gov.",
+  "resourceType": "Self-Service Tools",
   "attributes": {
     "personas": [
       "Developer"

--- a/web/topicRegistry/developer-tools.json
+++ b/web/topicRegistry/developer-tools.json
@@ -85,6 +85,7 @@
         "sourceType": "github",
         "sourceProperties": {
           "title": "Patroni",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -192,6 +193,7 @@
         "sourceType": "github",
         "sourceProperties": {
           "title": "Patroni",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/developer-tools.json
+++ b/web/topicRegistry/developer-tools.json
@@ -1,8 +1,6 @@
 {
   "name": "Developer Tools",
-  "version": "1.0.0",
   "description": "Tools to assist software developers in building, deploying, and running applications for BC Gov.",
-  "resourceType": "Self-Service Tools",
   "attributes": {
     "personas": [
       "Developer"
@@ -13,11 +11,11 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/cloud-pathfinder",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "cloud-pathfinder",
+          "repo": "devhub-app-web",
           "files": [
-            "devhub-content/README.md"
+            "web/src/assets/migrated-pages/Developer-Tools/cloud-pathfinder-readme.md"
           ]
         }
       },
@@ -48,36 +46,36 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/platform-developer-docs",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "platform-developer-docs",
+          "repo": "devhub-app-web",
           "files": [
-            "src/docs/app-monitoring/sysdig-monitor-onboarding.md",
-            "src/docs/app-monitoring/sysdig-monitor-setup-team.md",
-            "src/docs/app-monitoring/sysdig-monitor-create-alert-channels.md",
-            "src/docs/app-monitoring/sysdig-monitor-set-up-advanced-functions.md"
+            "web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-create-alert-channels.md",
+            "web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-onboarding.md",
+            "web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-set-up-advanced-functions.md",
+            "web/src/assets/migrated-pages/Developer-Tools/sysdig-monitor-setup-team.md"
           ]
         }
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/BCDevOps/openshift-wiki",
-          "owner": "BCDevOps",
-          "repo": "openshift-wiki",
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
           "files": [
-            "docs/HowTo/PipelineAutomation.md"
+            "web/src/assets/migrated-pages/Developer-Tools/PipelineAutomation.md"
           ]
         }
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/BCDevOps/openshift-wiki",
-          "owner": "BCDevOps",
-          "repo": "openshift-wiki",
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
           "files": [
-            "docs/HowTo/ImageStreams.md"
+            "web/src/assets/migrated-pages/Developer-Tools/ImageStreams.md"
           ]
         }
       },
@@ -85,34 +83,32 @@
         "sourceType": "github",
         "sourceProperties": {
           "title": "Patroni",
-          "url": "https://github.com/BCDevOps/platform-services",
-          "author": "cvarjao",
-          "owner": "bcdevops",
-          "repo": "platform-services",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
           "files": [
-            "apps/pgsql/patroni/README.md"
+            "web/src/assets/migrated-pages/Developer-Tools/patroni-readme.md"
           ]
         }
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/BC-Policy-Framework-For-GitHub",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "BC-Policy-Framework-For-GitHub",
+          "repo": "devhub-app-web",
           "files": [
-            "github/README.md"
+            "web/src/assets/migrated-pages/Developer-Tools/BC-Policy-Framework-For-GitHub-readme.md"
           ]
         }
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-resources",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "devhub-resources",
+          "repo": "devhub-app-web",
           "files": [
-            "resources/tools/sizzy.md"
+            "web/src/assets/migrated-pages/Developer-Tools/sizzy.md"
           ]
         }
       },
@@ -158,12 +154,22 @@
           "owner": "bcdevops",
           "repo": "developer-experience",
           "files": [
-            "apps/artifactory/DEVHUB-README.md",
-            "docs/resiliency-checklist.md",
-            "docs/post-outage-checklist.md", 
-            "docs/resource-tuning-recommendations.md",
-            "docs/resourceTuning/request-for-quota-increase.md",
-            "docs/resourceTuning/project-resource-quotas.md"
+            "apps/artifactory/DEVHUB-README.md"
+          ]
+        }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "title": "Developer Experience",
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
+          "files": [
+            "web/src/assets/migrated-pages/Developer-Tools/resiliency-checklist.md",
+            "web/src/assets/migrated-pages/Developer-Tools/post-outage-checklist.md",
+            "web/src/assets/migrated-pages/Developer-Tools/resource-tuning-recommendations.md",
+            "web/src/assets/migrated-pages/Developer-Tools/request-for-quota-increase.md"
           ]
         }
       },
@@ -184,12 +190,10 @@
         "sourceType": "github",
         "sourceProperties": {
           "title": "Patroni",
-          "url": "https://github.com/BCDevOps/platform-services",
-          "author": "cvarjao",
-          "owner": "bcdevops",
-          "repo": "platform-services",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
           "files": [
-            "apps/pgsql/patroni/README.md"
+            "web/src/assets/migrated-pages/Developer-Tools/patroni-readme.md"
           ]
         }
       },
@@ -203,4 +207,5 @@
       }
     ]
   }
-}
+ }
+  

--- a/web/topicRegistry/developer-toy-box.json
+++ b/web/topicRegistry/developer-toy-box.json
@@ -7,17 +7,20 @@
         "sourceType": "web",
         "sourceProperties": {
           "url": "https://github.com/BCDevOps/openshift-components/",
-          "description":"A trove of apps/components/stuff/things that are usable by anyone running OpenShift - in particular BC Gov teams \"doing\" Agile/DevOps."
+          "description": "A trove of apps/components/stuff/things that are usable by anyone running OpenShift - in particular BC Gov teams \"doing\" Agile/DevOps."
         },
         "resourceType": "Repositories"
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/BCDevOps/openshift-components/",
-          "owner": "BCDevOps",
-          "repo": "openshift-components",
-          "file": "README.md"
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
+          "files": [
+            "web/src/assets/migrated-pages/Developer-Toy-Box/openshift-components-readme.md",
+            "web/src/assets/migrated-pages/Developer-Toy-Box/postgis-readme.md"
+          ]
         },
         "resourceType": "Repositories"
       },
@@ -29,7 +32,6 @@
           "repo": "openshift-components",
           "files": [
             "db/oracle-rpm-store/README.md",
-            "db/postgis/README.md",
             "cicd/jenkins-slave-zap/README.md"
           ]
         }

--- a/web/topicRegistry/developer-toy-box.json
+++ b/web/topicRegistry/developer-toy-box.json
@@ -14,7 +14,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -1,7 +1,6 @@
 {
   "name": "Getting Started on the DevOps Platform",
   "description": "Resources to help product team become productive as quickly and effectively as possible when using the BC Gov DevOps OpenShift platform.",
-  "resourceType": "Documentation",
   "attributes": {
     "personas": [
       "Developer"
@@ -12,16 +11,16 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-resources/",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "devhub-resources",
+          "repo": "devhub-app-web",
           "files": [
-            "resources/alignment/opensource.md",
-            "resources/alignment/architecture_and_tech_stacks.md",
-            "resources/alignment/communication_community_and_support.md",
-            "resources/tools/documize.md",
-            "resources/community/12-factor-apps.md",
-            "resources/community/progressive-web-apps.md"
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/12-factor-apps.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/architecture_and_tech_stacks.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/communication_community_and_support.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/documize.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/opensource.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/progressive-web-apps.md"
           ]
         }
       },
@@ -91,21 +90,21 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcDevOps/openshift-wiki",
-          "owner": "bcDevOps",
-          "repo": "openshift-wiki",
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
           "files": [
-            "docs/OCP/OCPServiceDefinition.md",
-            "docs/OCP/StartingANewProject.md",
-            "docs/OCP/RequestUserAccess.md",
-            "docs/OCP/RequestGitHubUserAccess.md",
-            "docs/HowTo/GrantUsersAccessToProject.md",
-            "docs/OCP/Networking.md",
-            "docs/OCP/OCPStorageServices.md",
-            "docs/OCP/OCP4-Storage-backup.md",
-            "docs/OCP/OCP4ServiceOverview.md",
-            "docs/HowTo/UsefulProTips.md",
-            "docs/HowTo/RequestGitHubEnterpriseUserLicense.md"
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/GrantUsersAccessToProject.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/Networking.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCP4-Storage-backup.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCP4ServiceOverview.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCPStorageServices.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OCPServiceDefinition.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestGitHubEnterpriseUserLicense.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestGitHubUserAccess.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/RequestUserAccess.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/StartingANewProject.md",
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/UsefulProTips.md"
           ]
         }
       },
@@ -120,37 +119,55 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcDevOps/developer-experience",
-          "owner": "bcDevOps",
-          "repo": "developer-experience",
-          "files": [
-            "docs/HumanHelp.md",
-            "docs/OnboardingOutcomes.md",
-            "docs/UserAccessToOrg.md"
-          ]
-        }
-      },
-      {
-        "sourceType": "github",
-        "sourceProperties": {
-          "url": "https://github.com/bcgov/networkpolicy-migration-workshop",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "networkpolicy-migration-workshop",
-          "ref": "main",
+          "repo": "devhub-app-web",
           "files": [
-            "README.md"
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/HumanHelp.md"
           ]
         }
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/BCDevOps/openshift-wiki",
-          "owner": "BCDevOps",
-          "repo": "openshift-wiki",
-          "ref": "master",
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
           "files": [
-            "docs/LoadTest/LoadTestingGuidelines.md"
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/UserAccessToOrg.md"
+          ]
+        }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
+          "files": [
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/OnboardingOutcomes.md"
+          ]
+        }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
+          "files": [
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/networkpolicy-migration-workshop-readme.md"
+          ]
+        }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
+          "files": [
+            "web/src/assets/migrated-pages/Getting-Started-on-the-DevOps-Platform/LoadTestingGuidelines.md"
           ]
         }
       }

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -1,6 +1,7 @@
 {
   "name": "Getting Started on the DevOps Platform",
   "description": "Resources to help product team become productive as quickly and effectively as possible when using the BC Gov DevOps OpenShift platform.",
+  "resourceType": "Documentation",
   "attributes": {
     "personas": [
       "Developer"

--- a/web/topicRegistry/getting-started-on-the-devops-platform.json
+++ b/web/topicRegistry/getting-started-on-the-devops-platform.json
@@ -11,7 +11,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -90,7 +90,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -119,7 +119,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -130,7 +130,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -141,7 +141,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -152,7 +152,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -163,7 +163,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/information-and-application-security.json
+++ b/web/topicRegistry/information-and-application-security.json
@@ -12,33 +12,33 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-resources/",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "devhub-resources",
+          "repo": "devhub-app-web",
           "files": [
-            "resources/security/app_security_self_assessment.md"
+            "web/src/assets/migrated-pages/Information-and-Application-Security/app_security_self_assessment.md"
           ]
         }
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/BC-Policy-Framework-For-GitHub",
+          "url": "http://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
-          "repo": "BC-Policy-Framework-For-GitHub",
+          "repo": "devhub-app-web",
           "files": [
-            "README.md"
+            "web/src/assets/migrated-pages/Information-and-Application-Security/BC-Policy-Framework-For-GitHub-readme.md"
           ]
         }
       },
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/BCDevOps/developer-experience/",
-          "owner": "BCDevOps",
-          "repo": "developer-experience",
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
           "files": [
-            "docs/PCIDSSPatternforOCP.md"
+            "web/src/assets/migrated-pages/Information-and-Application-Security/PCIDSSPatternforOCP.md"
           ]
         }
       }

--- a/web/topicRegistry/information-and-application-security.json
+++ b/web/topicRegistry/information-and-application-security.json
@@ -12,7 +12,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -23,7 +23,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -34,7 +34,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/mobile-starter-kit.json
+++ b/web/topicRegistry/mobile-starter-kit.json
@@ -19,7 +19,10 @@
           "url": "https://github.com/bcgov/mobile-starter-kit",
           "repo": "mobile-starter-kit",
           "owner": "bcgov",
-          "files": ["README.md", "ServiceDefinition.md"]
+          "files": [
+            "README.md", 
+            "ServiceDefinition.md"
+          ]
         }
       }
     ]

--- a/web/topicRegistry/platform-security.json
+++ b/web/topicRegistry/platform-security.json
@@ -20,7 +20,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [
@@ -36,7 +36,7 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "http://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/devhub-app-web",
           "owner": "bcgov",
           "repo": "devhub-app-web",
           "files": [

--- a/web/topicRegistry/platform-security.json
+++ b/web/topicRegistry/platform-security.json
@@ -1,48 +1,49 @@
 {
-    "name": "Platform Services Security",
-    "description": "Modern day resources for securing your applications and services.",
-    "resourceType": "Documentation",
-    "attributes": {
-      "personas": ["Developer"]
-    },
-    "sourceProperties": {
-      "sources": [
-          {
-            "sourceType": "web",
-            "sourceProperties": {
-              "title": "Cloud Native Application Security",
-              "description": "Application Security in a Cloud Native World.",
-              "url": "https://raw.githubusercontent.com/bcgov/devhub-resources/master/resources/security/BCGov-DevSecOps-Project.pdf"
-            }
-          },
-          {
-            "sourceType": "github",
-            "sourceProperties": {
-              "url": "https://github.com/BCDevOps/openshift-wiki",
-              "owner": "BCDevOps",
-              "repo": "openshift-wiki",
-              "files": [
-                "docs/Vault/VaultServiceDefinition.md",
-                "docs/Sysdig/ServiceDefiniton.md",
-                "docs/Artifactory/ServiceDefinition.md",
-                "docs/AQUA/AQUAServiceDefinition.md",
-                 "docs/HowTo/SecurityConsiderationsForDevOps.md",
-                "docs/HowTo/IDIR_OpenShift_Login.md"
-               ]
-              }
-           },
-           {
-            "sourceType": "github",
-            "sourceProperties": {
-              "url": "https://github.com/BCDevOps/developer-experience/docs/",
-              "owner": "BCDevOps",
-              "repo": "developer-experience",
-              "files": [
-                "docs/SonarQubeBestPractices.md"          
-               ]
-             }
-          }
-      ]
-    }
+  "name": "Platform Services Security",
+  "description": "Modern day resources for securing your applications and services.",
+  "resourceType": "Documentation",
+  "attributes": {
+    "personas": [
+      "Developer"
+    ]
+  },
+  "sourceProperties": {
+    "sources": [
+      {
+        "sourceType": "web",
+        "sourceProperties": {
+          "title": "Cloud Native Application Security",
+          "description": "Application Security in a Cloud Native World.",
+          "url": "https://raw.githubusercontent.com/bcgov/devhub-resources/master/resources/security/BCGov-DevSecOps-Project.pdf"
+        }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
+          "files": [
+            "web/src/assets/migrated-pages/Platform-Services-Security/AQUAServiceDefinition.md",
+            "web/src/assets/migrated-pages/Platform-Services-Security/IDIR_OpenShift_Login.md",
+            "web/src/assets/migrated-pages/Platform-Services-Security/SecurityConsiderationsForDevOps.md",
+            "web/src/assets/migrated-pages/Platform-Services-Security/ServiceDefiniton.md",
+            "web/src/assets/migrated-pages/Platform-Services-Security/ServiceDefinition.md",
+            "web/src/assets/migrated-pages/Platform-Services-Security/VaultServiceDefinition.md"
+          ]
+        }
+      },
+      {
+        "sourceType": "github",
+        "sourceProperties": {
+          "url": "http://github.com/bcgov/devhub-app-web",
+          "owner": "bcgov",
+          "repo": "devhub-app-web",
+          "files": [
+            "web/src/assets/migrated-pages/Platform-Services-Security/SonarQubeBestPractices.md"
+          ]
+        }
+      }
+    ]
   }
-  
+}


### PR DESCRIPTION
This pull request relates to the issue [#2757 Remove PS Team's migrated content from DevHub](https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/bcdevops/developer-experience/2757), following up on the changes made in #1766, which added placeholder content for pages that are being retired from DevHub.

The changes in this PR remove references to Platform Services team documents in DevHub, replacing them with the new placeholder content pages from #1766. This is done in a way that preserves the use of each page's current URL, so that URLs indexed by search engines or bookmarked by users will still work, but will point to boilerplate text telling them to look in the [Private Cloud site](https://cloud.gov.bc.ca/private-cloud) or the [Private Cloud Technical Documentation site](https://beta-docs.developer.gov.bc.ca).

Example: Current production page for "Agile Delivery Process"
<img width="1840" alt="Agile Delivery Process page in production" src="https://user-images.githubusercontent.com/25143706/188997273-b11830c8-9c08-4368-b4cd-735bdd1e330b.png">

Updated "Agile Delivery Process" page
<img width="1840" alt="Agile Delivery Process page in local development" src="https://user-images.githubusercontent.com/25143706/188997299-85008987-2f18-4898-973b-d0a5b538fbd4.png">
