### PR TITLE
Revert retirement of AWS Services page

### DIFF
--- a/web/topicRegistry/cloud-pathfinder.json
+++ b/web/topicRegistry/cloud-pathfinder.json
@@ -6,30 +6,19 @@
       {
         "sourceType": "github",
         "sourceProperties": {
-          "url": "https://github.com/bcgov/devhub-app-web",
+          "url": "https://github.com/bcgov/cloud-pathfinder",
           "owner": "bcgov",
-          "repo": "devhub-app-web",
-          "files": [
-            "web/src/assets/migrated-pages/Cloud-Pathfinder/aws-services.md"
-          ]
+          "repo": "cloud-pathfinder",
+          "files": ["devhub-content/cloud-pathfinder-services/aws-services.md"]
         },
         "resourceType": "Documentation",
-        "labels": [
-          "aws",
-          "cloud"
-        ]
+        "labels": ["aws", "cloud"]
       }
     ]
   },
   "attributes": {
-    "labels": [
-      "cloud"
-    ],
-    "personas": [
-      "Developer",
-      "Product Owner"
-    ]
+    "labels": ["cloud"],
+    "personas": ["Developer", "Product Owner"]
   },
   "resourceType": "Documentation"
 }
-


### PR DESCRIPTION
This PR re-adds the AWS Services page to DevHub. This page was retired in [Remove PS Team's migrated content from DevHub #2757](https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/bcdevops/developer-experience/2757) but it is not content that is available elsewhere yet. This page is referenced from the new `cloud.gov.bc.ca` landing page, which prompted me to check this out.