### PR TITLE
Remove old Common Services pages

### DIFF
--- a/web/topicRegistry/community-contributed.json
+++ b/web/topicRegistry/community-contributed.json
@@ -21,9 +21,7 @@
             "web/src/assets/migrated-pages/Community-Contributed-Content/integratingAlgolia.md",
             "web/src/assets/migrated-pages/Community-Contributed-Content/registry.md",
             "web/src/assets/migrated-pages/Community-Contributed-Content/docker-weasyprint.md",
-            "web/src/assets/migrated-pages/Community-Contributed-Content/go-crond.md",
-            "web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-developer-guide.md",
-            "web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-overview.md"
+            "web/src/assets/migrated-pages/Community-Contributed-Content/go-crond.md"
           ]
         }
       }, 

--- a/web/topicRegistry/community-contributed.json
+++ b/web/topicRegistry/community-contributed.json
@@ -20,7 +20,6 @@
           "files": [
             "web/src/assets/migrated-pages/Community-Contributed-Content/integratingAlgolia.md",
             "web/src/assets/migrated-pages/Community-Contributed-Content/registry.md",
-            "web/src/assets/migrated-pages/Community-Contributed-Content/document-generation-showcase-overview.md",
             "web/src/assets/migrated-pages/Community-Contributed-Content/docker-weasyprint.md",
             "web/src/assets/migrated-pages/Community-Contributed-Content/go-crond.md",
             "web/src/assets/migrated-pages/Community-Contributed-Content/nr-messaging-service-showcase-developer-guide.md",
@@ -88,23 +87,6 @@
             "title":"APIStore Document Management Services",
             "description":"The Document Management REST API and Swagger",
             "image":"https://upload.wikimedia.org/wikipedia/commons/a/ab/Swagger-logo.png"
-        }
-    },
-    {
-        "sourceType":"github",
-        "resourceType":"Repository",
-        "labels":[
-            "document",
-            "pdf",
-            "generation"
-        ],
-        "sourceProperties":{
-            "url":"https://github.com/bcgov/document-generation-showcase",
-            "repo":"document-generation-showcase",
-            "owner":"bcgov",
-            "files":[
-                "docs/developer-guide.md"
-            ]
         }
     },
     {


### PR DESCRIPTION
Following user feedback, this PR removes DevHub pages relating to common services that have been retired.

- The DGEN API is now the [CDOGS](https://digital.gov.bc.ca/common-components/common-document-generation-service)
- The Messaging Service functionality is now a part of [CHES](https://digital.gov.bc.ca/common-components/common-hosted-email-service)

This pull request removes three "retired" landing pages and one page that still has content:

- https://developer.gov.bc.ca/Community-Contributed-Content/Messaging-Service-Developer-Guide
- https://developer.gov.bc.ca/Community-Contributed-Content/About-the-Messaging-Common-Service
- https://developer.gov.bc.ca/Community-Contributed-Content/NR-Document-Generation-Showcase
- https://developer.gov.bc.ca/Community-Contributed-Content/DGEN-Developer's-Guide

The [Reusable services list on the Private Cloud Tech Docs site](https://beta-docs.developer.gov.bc.ca/reusable-services-list/) has been updated with correct information about these products.
