### PR TITLE
Add Monica and Shea to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # The default owner of all the files in the repository (Global Owner) will be requested for review.
-*      @ShellyXueHan @ty2k @w8896699
+*      @ShellyXueHan @ty2k @w8896699 @MonicaG @sheaphillips
 
 # If a pull request is made the following owners will be requested to review.
-*.     @ShellyXueHan @ty2k @w8896699
+*.     @ShellyXueHan @ty2k @w8896699 @MonicaG @sheaphillips
 


### PR DESCRIPTION
This PR updates the [GitHub code owners file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) to add Monica and Shea from the Developer Experience team (who now own DevHub).

@w8896699 or @ShellyXueHan , could you please approve?