### PR TITLE
DEVEX-256 - Add link to BC Gov GitHub page from aboutDevHub page

### DIFF
--- a/web/src/assets/blog/devhub.md
+++ b/web/src/assets/blog/devhub.md
@@ -78,7 +78,7 @@ Documentation may be sourced from GitHub, other government websites, or external
 
 ### Github Repositories
 
-Github Repositories correspond directly to the B.C. Government repository on [GitHub](https://github.com). Resources that
+Github Repositories correspond directly to the [B.C. Government repository on GitHub](https://github.com/bcgov). Resources that
 are of type 'Github Repository' will allow you to directly access/reference/contribute to the repoositories
 codebase.  
 


### PR DESCRIPTION
## Summary
[DEVEX-256](https://bcdevex.atlassian.net/browse/DEVEX-256) - update the link in the [github-repositories section on the Welcome to the DevHub page](https://developer.gov.bc.ca/aboutDevhub#github-repositories) to point to [https://github.com/bcgov](https://github.com/bcgov) vs [https://github.com/](https://github.com/).

This change was requested to make our GitHub organization easier to fine.

