### PR TITLE
Use main branch for Design System topicRegistry target

### DIFF
--- a/web/topicRegistry/design-system.json
+++ b/web/topicRegistry/design-system.json
@@ -9,6 +9,7 @@
           "url": "https://github.com/bcgov/design-system/",
           "owner": "bcgov",
           "repo": "design-system",
+          "branch": "main",
           "files": [
             "components/about/about.md",
             "components/about/accessibility.md",


### PR DESCRIPTION
## Summary
I've renamed the default branch of the `bcgov/design-system` repository to `main` from `master`, and this PR explicitly updates the design system's `topicRegistry` JSON data to point to that branch.

I think based on [this function](https://github.com/bcgov/devhub-app-web/blob/master/.github/actions/devhub-markdown-frontmatter-verify/src/run.js#L107) in the `devhub-markdown-frontmatter-verify` GitHub Action that this change isn't actually necessary to get the design system content to be picked up by the DevHub build. However, I wanted to make the change proactively in case the build fails, so it's not a bad surprise while you're updating some other part of the application.
